### PR TITLE
Headers missing in Pika

### DIFF
--- a/kombu/transport/pypika.py
+++ b/kombu/transport/pypika.py
@@ -25,12 +25,13 @@ DEFAULT_PORT = 5672
 class Message(base.Message):
 
     def __init__(self, channel, amqp_message, **kwargs):
-        channel_id, method, header, body = amqp_message
+        channel_id, method, props, body = amqp_message
 
         kwargs.update({"body": body,
                        "delivery_tag": method.delivery_tag,
-                       "content_type": header.content_type,
-                       "content_encoding": header.content_encoding,
+                       "content_type": props.content_type,
+                       "content_encoding": props.content_encoding,
+                       "headers": props.headers,
                        "delivery_info": dict(
                             consumer_tag=getattr(method, "consumer_tag", None),
                             routing_key=method.routing_key,


### PR DESCRIPTION
When a message came through, it was missing headers. I added them in the pypika.Message#**init** now everything is ok! Maybe just check this out and add the line yourself? Dunno why I changed header to props, thought that was a better name, "headers": header.headers made me head spin :) Thanks for the hard work on this lib!
