### PR TITLE
Fix amqplib channel to not drop properties

### DIFF
--- a/kombu/transport/pyamqplib.py
+++ b/kombu/transport/pyamqplib.py
@@ -171,8 +171,8 @@ class Channel(_Channel):
         return amqp.Message(message_data, priority=priority,
                             content_type=content_type,
                             content_encoding=content_encoding,
-                            properties=properties,
-                            application_headers=headers)
+                            application_headers=headers,
+                            **properties)
 
     def message_to_python(self, raw_message):
         """Convert encoded message body back to a Python value."""


### PR DESCRIPTION
For example, as the 'delivery_mode' property is dropped, all messages will be transient even if the documented default is persistent and even if 'delivery_mode' is explicitely set
to persistent.
