### PR TITLE
Adding support for passing "extra connection arguments" to alternative brokers

### DIFF
--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -47,7 +47,7 @@ class BrokerConnection(object):
          ``amqplib``, ``pika``, ``redis``, ``memory``.
     :keyword connect_timeout: Timeout in seconds for connecting to the
       server. May not be suported by the specified transport.
-    :keyword backend_extra_args: A dict of additional connection arguments to pass to
+    :keyword transport_options: A dict of additional connection arguments to pass to
     alternate kombu channel implementations (useful for things like SQLAlchemy
     engine arguments)
 
@@ -80,7 +80,7 @@ class BrokerConnection(object):
 
     def __init__(self, hostname="localhost", userid="guest",
             password="guest", virtual_host="/", port=None, insist=False,
-            ssl=False, transport=None, connect_timeout=5, backend_cls=None, backend_extra_args={}):
+            ssl=False, transport=None, connect_timeout=5, backend_cls=None, transport_options={}):
         self.hostname = hostname
         self.userid = userid
         self.password = password
@@ -91,7 +91,7 @@ class BrokerConnection(object):
         self.ssl = ssl
         # backend_cls argument will be removed shortly.
         self.transport_cls = transport or backend_cls
-        self.backend_extra_args = backend_extra_args
+        self.transport_options = transport_options
 
     def connect(self):
         """Establish connection to server immediately."""

--- a/kombu/tests/test_connection.py
+++ b/kombu/tests/test_connection.py
@@ -105,11 +105,11 @@ class test_Connection_With_Broker_Args(unittest.TestCase):
     }
 
     def setUp(self):
-        self.conn = BrokerConnection(port=5672, transport=Transport, backend_extra_args=self._extra_args)
+        self.conn = BrokerConnection(port=5672, transport=Transport, transport_options=self._extra_args)
 
     def test_establish_connection(self):
         conn = self.conn
-        self.assertEqual(conn.backend_extra_args, self._extra_args)
+        self.assertEqual(conn.transport_options, self._extra_args)
 
 
 class ResourceCase(unittest.TestCase):


### PR DESCRIPTION
Ask,

We're using kombu-sqlalchemy on a few internal projects and needed the ability to pass connection arguments to SQLAlchemy's create_engine (like `pool_recycle`).  This (and a few associated pulls for `kombu` and `celery`) add support for a new celery config argument, `BROKER_BACKEND_EXTRA_ARGS` to pass args downwards from `celery`, through `kombu`, and into `sqlakombu`.
