### PR TITLE
Remove InvalidData from redis.exceptions

### DIFF
--- a/kombu/transport/pyredis.py
+++ b/kombu/transport/pyredis.py
@@ -342,6 +342,6 @@ class Transport(virtual.Transport):
         return ((exceptions.ConnectionError,
                  exceptions.AuthenticationError),
                 (exceptions.ConnectionError,
-                 exceptions.InvalidData,
+                 exceptions.DataError,
                  exceptions.InvalidResponse,
                  exceptions.ResponseError))


### PR DESCRIPTION
Hi there! I'm using kombu inside celery/django/redis, and in this recent commit to redis-py, the InvalidData exception was removed:

https://github.com/andymccurdy/redis-py/commit/d67fe6bb40f417f738f3fdd8e42e4d1873104ad8

This causes an import exception whenever kombu is used with the latest redis-py library.

Fix attached, hope you can use it!

Cheers!
-Gabe
