### PR TITLE
Fix broken Consumer.__exit__ semantics

### DIFF
--- a/kombu/messaging.py
+++ b/kombu/messaging.py
@@ -256,8 +256,9 @@ class Consumer(object):
         self.consume()
         return self
 
-    def __exit__(self):
+    def __exit__(self, exc_type, exc_val, traceback):
         self.cancel()
+        return False
 
     def consume(self, no_ack=None):
         """Register consumer on server.

--- a/kombu/tests/test_messaging.py
+++ b/kombu/tests/test_messaging.py
@@ -217,7 +217,9 @@ class test_Consumer(unittest.TestCase):
         context = consumer.__enter__()
         self.assertIs(context, consumer)
         self.assertTrue(consumer._active_tags)
-        consumer.__exit__()
+        self.assertRaises(TypeError, consumer.__exit__)
+        res = consumer.__exit__(None, None, None)
+        self.assertFalse(res)
         self.assertIn("basic_cancel", channel)
         self.assertFalse(consumer._active_tags)
 


### PR DESCRIPTION
Fix `kombu.messaging.Consumer.__exit__`, which didn’t conform to PEP 0343’s calling convention, and thus rendered `Consumer` unusable in a `with` statement.

PEP 0343 states:

```
The calling convention for mgr.__exit__() is as follows.  If the
finally-suite was reached through normal completion of BLOCK or
through a non-local goto (a break, continue or return statement in
BLOCK), mgr.__exit__() is called with three None arguments.  If
the finally-suite was reached through an exception raised in
BLOCK, mgr.__exit__() is called with three arguments representing
the exception type, value, and traceback.
```

The `__exit__` method took no arguments, which raised a `TypeError` when it was called.
