### PR TITLE
fixes for docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -119,7 +119,7 @@ Quick overview
     from kombu.messaging import Exchange, Queue, Consumer, Producer
 
     media_exchange = Exchange("media", "direct", durable=True)
-    video_queue = Queue("video", exchange=media_exchange, key="video")
+    video_queue = Queue("video", exchange=media_exchange, routing_key="video")
 
     # connections/channels
     connection = BrokerConnection("localhost", "guest", "guest", "/")


### PR DESCRIPTION
Per issue in django-kombu actually: https://github.com/ask/django-kombu/issues/7

"key" should be "routing_key" in docs 
