### PR TITLE
Fix MemoryError importing ctypes with kombu+mod_wsgi+SELinux 

### DIFF
--- a/kombu/utils/__init__.py
+++ b/kombu/utils/__init__.py
@@ -5,7 +5,7 @@ from uuid import UUID, uuid4 as _uuid4, _uuid_generate_random
 
 try:
     import ctypes
-except ImportError:
+except:
     ctypes = None  # noqa
 
 


### PR DESCRIPTION
This commit goes with the following issue: https://github.com/ask/kombu/issues/52

Silence all exceptions from 'import ctypes' to match behaviour
of standard python uuid module, and avoid passing on MemoryError
exceptions on SELinux-enabled systems.
