### PR TITLE
bugfix: BrokerConnection.as_uri() fails if hostname is None

### DIFF
--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -374,12 +374,14 @@ class BrokerConnection(object):
 
     def as_uri(self):
         fields = self.info()
+        hostname = fields["hostname"]
         port = fields["port"]
         userid = fields["userid"]
         url = "%s://" % fields["transport"]
         if userid:
             url += userid + '@'
-        url += fields["hostname"]
+        if hostname:
+            url += hostname
         if port:
             url += ':' + str(port)
         url += '/' + fields["virtual_host"]


### PR DESCRIPTION
A recent change in kombu broke support for transports where hostname is `None` (i.e. django-kombu), but only when building a pretty url in `BrokerConnection.as_uri()`, so far as I've seen. This patch adds a check for `hostname` just like existing checks for `port` and `userid`.
