### PR TITLE
update check for empty payload to work in MongoDB >= 2.0

### DIFF
--- a/kombu/transport/mongodb.py
+++ b/kombu/transport/mongodb.py
@@ -1,4 +1,3 @@
-
 """
 kombu.transport.mongodb
 =======================
@@ -39,6 +38,9 @@ class Channel(virtual.Channel):
             if "No matching object found" in exc.args[0]:
                 raise Empty()
             raise
+        # as of mongo 2.0 empty results won't raise an error
+        if msg['value'] is None:
+            raise Empty()
         return deserialize(msg["value"]["payload"])
 
     def _size(self, queue):


### PR DESCRIPTION
currently the mongodb transport doesn't work for MongoDB >= 2.0 due to a change in how they report errors in findandmodify

see https://gist.github.com/1227731 for a stacktrace of what happens when you try and run it without this fix, this fix simply checks if it returned a None value and if so raises the Empty exception.
