### PR TITLE
fixes to get the simple_task_queue example running.

### DIFF
--- a/examples/simple_task_queue/client.py
+++ b/examples/simple_task_queue/client.py
@@ -3,7 +3,7 @@ from __future__ import with_statement
 from kombu.common import maybe_declare
 from kombu.pools import producers
 
-from .queues import task_exchange
+from queues import task_exchange
 
 priority_to_routing_key = {"high": "hipri",
                            "mid": "midpri",
@@ -22,8 +22,8 @@ def send_as_task(connection, fun, args, kwargs, priority="mid"):
 
 if __name__ == "__main__":
     from kombu import BrokerConnection
-    from .tasks import hello_task
+    from tasks import hello_task
 
     connection = BrokerConnection("amqp://guest:guest@localhost:5672//")
-    send_as_task(connection, fun=hello_task, args=("Kombu", ),
+    send_as_task(connection, fun=hello_task, args=("Kombu", ), kwargs={},
                  priority="high")

--- a/examples/simple_task_queue/worker.py
+++ b/examples/simple_task_queue/worker.py
@@ -8,11 +8,14 @@ from queues import task_queues
 
 class Worker(ConsumerMixin):
 
-    def get_consumers(self, Consumer, channel):
-        return Consumer(queues=task_queues,
-                        callbacks=[self.process_task])
+    def __init__(self, connection):
+        self.connection = connection
 
-    def process_task(body, message):
+    def get_consumers(self, Consumer, channel):
+        return [Consumer(queues=task_queues,
+                        callbacks=[self.process_task])]
+
+    def process_task(self, body, message):
         fun = body["fun"]
         args = body["args"]
         kwargs = body["kwargs"]
@@ -21,7 +24,7 @@ class Worker(ConsumerMixin):
 
 if __name__ == "__main__":
     from kombu import BrokerConnection
-    from kombu.log import setup_logging
+    from kombu.utils.debug import setup_logging
     setup_logging(loglevel="INFO")
 
     with BrokerConnection("amqp://guest:guest@localhost:5672//") as conn:

--- a/kombu/serialization.py
+++ b/kombu/serialization.py
@@ -293,7 +293,9 @@ def register_yaml():
 def register_pickle():
     """The fastest serialization method, but restricts
     you to python clients."""
-    registry.register('pickle', pickle.dumps, pickle.loads,
+    def deserialize(data):
+        return pickle.loads(data.encode("ascii"))
+    registry.register('pickle', pickle.dumps, deserialize,
                       content_type='application/x-python-serialize',
                       content_encoding='binary')
 


### PR DESCRIPTION
I needed to make these changes against master to get the simple-task-queue example running.

The only real issue here is probably my change in _serialization.py_, where I got an error because the
pickle serializer tried to stick unicode to the pickle module.
