### PR TITLE
Fix issue #74 when deserialize an empty message

### DIFF
--- a/kombu/serialization.py
+++ b/kombu/serialization.py
@@ -146,10 +146,10 @@ class SerializerRegistry(object):
         except KeyError:
             return data
 
-        try:
-            return decoder(data)
-        except Exception:
+        if not len(data):
             return None
+
+        return decoder(data)
 
 
 """


### PR DESCRIPTION
I fix the issue #74 when an empty message is deserialize, it must be return None. (see bug report for explanation)
