### PR TITLE
Support for SQS queue prefixes

### DIFF
--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -158,6 +158,7 @@ class Channel(virtual.Channel):
 
     def _new_queue(self, queue, **kwargs):
         """Ensures a queue exists in SQS."""
+        queue = self.queue_name_prefix + queue
         try:
             return self._queue_cache[queue]
         except KeyError:
@@ -322,6 +323,10 @@ class Channel(virtual.Channel):
     @cached_property
     def visibility_timeout(self):
         return self.transport_options.get("visibility_timeout")
+    
+    @cached_property
+    def queue_name_prefix(self):
+        return self.transport_options.get("queue_name_prefix", '')    
 
     @cached_property
     def supports_fanout(self):


### PR DESCRIPTION
Kombu's support for SQS works great, but has one drawback: if I want to run multiple (independent) instances of Celery with Kombu, they'll try to use the same SQS queues and interfere with each other.  This happened to me, for example, with a dev server and production server running the same code at the same time.

I propose a super-simple option to allow prefixing the SQS queue name with some string (in Django's case, by adding queue_name_prefix option to the BROKER_TRANSPORT_OPTIONS setting).
