### PR TITLE
handle None connections when used in a pool

### DIFF
--- a/kombu/pools.py
+++ b/kombu/pools.py
@@ -59,7 +59,8 @@ class ProducerPool(Resource):
         return p
 
     def release(self, resource):
-        resource.connection.release()
+        if resource.connection:
+            resource.connection.release()
         resource.channel = None
         super(ProducerPool, self).release(resource)
 


### PR DESCRIPTION
if connection.ensure fails it closes the connection
and removes it before the pool has a chance to
release it
