### PR TITLE
Parse the mongodb connection string

### DIFF
--- a/kombu/transport/mongodb.py
+++ b/kombu/transport/mongodb.py
@@ -105,10 +105,9 @@ class Channel(virtual.Channel):
             (host, database) = host.split("/")
         if ":" in host:
             (host, port) = host.split(":")
+            port = int(port)
         if ":" in username:
             (username, password) = username.split(":")
-        # TODO: use port and username
-        port = int(port)
         mongoconn = Connection(host=host, port=port)
         dbname = conninfo.virtual_host
         version = mongoconn.server_info()["version"]


### PR DESCRIPTION
Parse the mongodb connection string in the transport since it's a slightly different format than the one in the BrokerConnection

Issue reported at https://github.com/ask/kombu/issues/87
