### PR TITLE
Redis transport should raise an error if no queues/the queues key is not available

### DIFF
--- a/kombu/tests/test_transport_redis.py
+++ b/kombu/tests/test_transport_redis.py
@@ -423,6 +423,20 @@ class test_Channel(TestCase):
             if InvalidData is not None:
                 exceptions.InvalidData = InvalidData
 
+    def test_empty_queues_key(self):
+        self.channel._in_poll = False
+        c = self.channel.client = Mock()
+
+        # Everything is fine, there is a list of queues.
+        c.smembers.return_value = ['celery\x06\x16\x06\x16celery']
+        self.assertEquals(self.channel.get_table('celery'),
+            [('celery', '', 'celery')])
+
+        # For some reason, the _kombu.binding.celery key gets lost
+        c.smembers.return_value = []
+
+        # We assert, that there should be at least one entry in the table.
+        self.assertRaises(AssertionError, self.channel.get_table, 'celery')
 
 class test_Redis(TestCase):
 

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -281,9 +281,12 @@ class Channel(virtual.Channel):
         return self._avail_client.exists(queue)
 
     def get_table(self, exchange):
-        return [tuple(val.split(self.sep))
+        tables = [tuple(val.split(self.sep))
                     for val in self._avail_client.smembers(
                             self.keyprefix_queue % exchange)]
+        assert len(tables) > 0, 'Queue list empty or key does not exist: %s' % (
+            self.keyprefix_queue % exchange)
+        return tables
 
     def _purge(self, queue):
         size, _ = self._avail_client.pipeline().llen(queue) \


### PR DESCRIPTION
I found this problem while debugging an weird behaviour of celeryd. The worker stopped to process tasks from time to time and I had to restart the worker to get tasks done again.

After a while I found out that there is a "_kombu.binding.celery" key which stores all available queues in my broker (redis). If the key gets deleted (e.g. by max-memory-policies of redis), kombu silently fails to submit the task to the broker.

This change will raise an assertion error, if the queues list/output of the get_table method of the redis transport has no entries. This list should have at least have one entry all the time.

If you have any questions write to the comments here or ping me on irc, I'm around in the #celery channel as "steph".

Cheers, Steph
