### PR TITLE
allow anonymous queues to create & bind exchanges

### DIFF
--- a/kombu/entity.py
+++ b/kombu/entity.py
@@ -382,11 +382,12 @@ class Queue(MaybeChannelBound):
         """Declares the queue, the exchange and binds the queue to
         the exchange."""
         name = self.name
-        if name:
-            if self.exchange:
-                self.exchange.declare(nowait)
+        if self.exchange:
+            self.exchange.declare(nowait)
         self.queue_declare(nowait, passive=False)
-        if name:
+        # self.name should be set by queue_declare in the case that
+        # we're working with anonymous queues
+        if self.name:
             self.queue_bind(nowait)
         return self.name
 


### PR DESCRIPTION
This should allow anonymous queues to create their exchanges & bind to them at declaration.  I don't believe this should cause problems anywhere else, though perhaps in non AMQP servers?
