### PR TITLE
Sending TTR to beanstalk

### DIFF
--- a/kombu/transport/beanstalk.py
+++ b/kombu/transport/beanstalk.py
@@ -45,7 +45,7 @@ class Channel(virtual.Channel):
     def _put(self, queue, message, **kwargs):
         priority = message["properties"]["delivery_info"]["priority"]
         client_kwargs = {}
-        if 'ttr' in message['properties']:
+        if message['properties'].get('ttr', None) is not None:
             client_kwargs["ttr"] = message["properties"]["ttr"]
         self.client.use(queue)
         self.client.put(dumps(message), priority=priority, **client_kwargs)


### PR DESCRIPTION
Currently it is not possible to send big task in beanstalk. Without ttr argument to `put` method `beanstalkc` creates task with ttr=120 (default value).

So I can not create big tasks, which can be processed 5 minutes and so on.

This patch allows to send a task with ttr argument 
