### PR TITLE
Problem with deserialization

### DIFF
--- a/kombu/serialization.py
+++ b/kombu/serialization.py
@@ -157,6 +157,11 @@ class SerializerRegistry(object):
         content_type = content_type or 'application/data'
         content_encoding = (content_encoding or 'utf-8').lower()
 
+        from types import BufferType
+
+        if type(data) == BufferType:
+          data = str(data)
+
         if data:
             decode = self._decoders.get(content_type)
             if decode:


### PR DESCRIPTION
When I tried to use the kombu lib to build a consumer for amqp messages, I discovered a problem with the deserialization from json objects.

The SerializerRegistry gets a buffer object instead of a string on my system (Python 2.6.6, CentOS 6), and subsequently the anyjson library chokes on the data, as it expects a string object, not a buffer.

This simple patch fixes the problem (at least for me ;) ), though I'm pretty sure it doesn't fix the issue at the root, but just fixes the effect. Please consider fixing this issue.

Regards,
Jens
