### PR TITLE
Removed use of deprecated msgpack functions

### DIFF
--- a/kombu/serialization.py
+++ b/kombu/serialization.py
@@ -336,7 +336,7 @@ def register_msgpack():
     """See http://msgpack.sourceforge.net/"""
     try:
         import msgpack
-        registry.register('msgpack', msgpack.packs, msgpack.unpacks,
+        registry.register('msgpack', msgpack.packb, msgpack.unpackb,
                 content_type='application/x-msgpack',
                 content_encoding='binary')
     except ImportError:


### PR DESCRIPTION
msgpack-python no longer has the deprecated functions msgpack.packs and msgpack.unpacks. 
They have been replaced by msgpack.packb and msgpack.unpackb.
See here:
https://github.com/msgpack/msgpack-python/commit/dd5b1e265a24a6ddc6ffe681d9d632a8240ce2ad
