### PR TITLE
[issue #149] transport/librabbitmq: KeyError prevents further handling

### DIFF
--- a/kombu/transport/librabbitmq.py
+++ b/kombu/transport/librabbitmq.py
@@ -39,9 +39,9 @@ class Message(base.Message):
                 body=body,
                 delivery_info=info,
                 properties=props,
-                delivery_tag=info['delivery_tag'],
-                content_type=props['content_type'],
-                content_encoding=props['content_encoding'],
+                delivery_tag=info.get('delivery_tag'),
+                content_type=props.get('content_type'),
+                content_encoding=props.get('content_encoding'),
                 headers=props.get('headers'))
 
 


### PR DESCRIPTION
Kombu ordinarily sets the `content_type` and `content_encoding` standard
AMQP properties; in the event a message enters circulation _without_ these
headers, Kombu triggers a KeyError, and enters an unrecoverable loop precluding
user handlers from ever reviewing, or even _recieving_ the message.
