### PR TITLE
Better index for MongoDB transport

### DIFF
--- a/kombu/transport/mongodb.py
+++ b/kombu/transport/mongodb.py
@@ -144,7 +144,7 @@ class Channel(virtual.Channel):
         #     database.authenticate(conninfo.userid, conninfo.password)
         self.db = database
         col = database.messages
-        col.ensure_index([('queue', 1)])
+        col.ensure_index([('queue', 1), ('_id', 1)])
 
         if 'messages.broadcast' not in database.collection_names():
             capsize = conninfo.transport_options.get(


### PR DESCRIPTION
Kombu uses the following query to fetch messages from the queue:

```
msg = self.client.command('findandmodify', 'messages',
                    query={'queue': queue},
                    sort={'_id': pymongo.ASCENDING}, remove=True)
```

This query combines `queue` and `_id` fields, but current Kombu index only include `queue`. By adding `_id` to the index on messages collection we got better performance in situations when messages queue becomes clogged for any reason.
