### PR TITLE
Fixes examples/simple_task_queue

### DIFF
--- a/examples/simple_task_queue/client.py
+++ b/examples/simple_task_queue/client.py
@@ -15,7 +15,9 @@ def send_as_task(connection, fun, args=(), kwargs={}, priority='mid'):
     routing_key = priority_to_routing_key[priority]
 
     with producers[connection].acquire(block=True) as producer:
+        producer.exchange = task_exchange
         maybe_declare(task_exchange, producer.channel)
+        task_exchange.maybe_bind(producer.channel)
         producer.publish(payload, serializer='pickle',
                                   compression='bzip2',
                                   routing_key=routing_key)


### PR DESCRIPTION
Hi

I'm starting learning AMQP, and try to use kombu as client library.
However  I'm confused in this example because it is not work when I change routing key.

In this example, client actually send message to **AMQP default exchange** that has no name.
So it works well only if a queue name and it's routing key is same.

It seems to send named exchange because client declare exchange before publishing, but actual behavior is not. this confuse me.
So I fixed producer send message to correct exchange (i.e named exchange).

If you intend to send to default exchange in this example, it doesn't need to declare named exchange.

In beginner's point of view, declared exchange is preferred than default exchange.
I don't know whether another transport has same concept as AMQP default exchange.
