### PR TITLE
Decode MsgPack strings as str not bytes

### DIFF
--- a/kombu/serialization.py
+++ b/kombu/serialization.py
@@ -349,7 +349,8 @@ def register_msgpack():
     """See http://msgpack.sourceforge.net/"""
     try:
         try:
-            from msgpack import packb as dumps, unpackb as loads
+            from msgpack import packb as dumps, unpackb
+            loads = lambda s: unpackb(s, encoding='utf-8')
         except ImportError:
             # msgpack < 0.2.0 and Python 2.5
             from msgpack import packs as dumps, unpacks as loads  # noqa


### PR DESCRIPTION
MsgPack defaults to utf-8 encoding on packing, but no decoding on unpacking.

On Python 3 this leads to unpacked messages having bytes instances where str instances are expected, which leads to (e.g.) Celery being unable to run any tasks as the names never compare as True.

This patch passes the encoding='utf-8' parameter to unpackb which leads to the expected behaviour.
