### PR TITLE
JSON Decoder can't decode bytes object in Python 3.x

### DIFF
--- a/kombu/serialization.py
+++ b/kombu/serialization.py
@@ -296,10 +296,16 @@ def register_json():
     """Register a encoder/decoder for JSON serialization."""
     from anyjson import loads, dumps
 
-    def _loads(obj):
-        if isinstance(obj, str):
-            obj = bytes_to_str(obj)
-        return loads(obj)
+    if sys.version_info[0] == 3:
+        def _loads(obj):
+            if isinstance(obj, bytes):
+                obj = bytes_to_str(obj)
+            return loads(obj)
+    else:
+        def _loads(obj):
+            if isinstance(obj, str):
+                obj = bytes_to_str(obj)
+            return loads(obj)
 
     registry.register('json', dumps, _loads,
                       content_type='application/json',


### PR DESCRIPTION
Error occured by tutorial sample using SQLAlchemy and SQLite in Python 3.2.3.

CRITICAL/MainProcess] Can't decode message body: TypeError('initial_value must be str or None, not bytes',) (type:'application/json' encoding:'utf-8' raw:'b\'{"retries": 0, "task": "mytask.add", "errbacks": null, "callbacks": null, "kwargs": {}, "eta": null, "args": [3, 2], "id": "cf0ba54b-ed2e-49b6-ba1b-8b2c6477fc11", "expires": null, "utc": true}\' (192b)'')
