### PR TITLE
Changing the _info method of the connection class to respect the alt att...

### DIFF
--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -517,9 +517,14 @@ class Connection(object):
         if resolve:
             transport_cls = RESOLVE_ALIASES.get(transport_cls, transport_cls)
         D = self.transport.default_connection_params
-        hostname = self.hostname or D.get('hostname')
-        if self.uri_prefix:
-            hostname = '%s+%s' % (self.uri_prefix, hostname)
+
+        if self.alt:
+            hostname = ";".join(self.alt)
+        else:
+            hostname = self.hostname or D.get('hostname')
+            if self.uri_prefix:
+                hostname = '%s+%s' % (self.uri_prefix, hostname)
+
         info = (('hostname', hostname),
                 ('userid', self.userid or D.get('userid')),
                 ('password', self.password or D.get('password')),


### PR DESCRIPTION
...ribute of the object. 

I was messing around with the feature added in 2fa467a that allows multiple URLs in the hostname.

After configuring 2 brokers in celery, I noticed that after killing the first broker while producing tasks, the tasks would not route to the second broker. After debugging into kombu, I noticed that the clone method in kombu/connections.py is not working correctly. It is ignoring the alt and cycle attributes that were added in the pull request mentioned above. Since the init method of the Connections class changes the hostname attribute to grab the first URL, we need to make sure the clone method restores that info in the new Connections instance.

I will add a pull request for what got things working for me as a suggestion.

I encountered this issue using celery 3.0.12, kombu 2.5.X

Just a suggestion.  Would be nice if fix was applied to the 2.5 branch.
