### PR TITLE
Support fanout for in-memory transport

### DIFF
--- a/kombu/transport/memory.py
+++ b/kombu/transport/memory.py
@@ -15,6 +15,7 @@ from . import virtual
 class Channel(virtual.Channel):
     queues = {}
     do_restore = False
+    supports_fanout = True
 
     def _has_queue(self, queue, **kwargs):
         return queue in self.queues
@@ -31,6 +32,13 @@ class Channel(virtual.Channel):
             self.queues[queue] = Queue()
         return self.queues[queue]
 
+    def _queue_bind(self, *args):
+        pass
+
+    def _put_fanout(self, exchange, message, **kwargs):
+        for queue in self.queues.values():
+            queue.put(message)
+
     def _put(self, queue, message, **kwargs):
         self._queue_for(queue).put(message)
 
@@ -45,6 +53,12 @@ class Channel(virtual.Channel):
         size = q.qsize()
         q.queue.clear()
         return size
+
+    def close(self):
+        super(Channel, self).close()
+        for queue in self.queues.values():
+            queue.empty()
+        self.queues = {}
 
     def after_reply_message_received(self, queue):
         pass


### PR DESCRIPTION
Since the memory transport's 'broker state' is global. Here's a
quick implementation of fanout for the memory transport. We at
Nova/Oslo project were using this support in the really old
versions of kombu and would love to re-enable those test cases
that use in-memory transport.

Fixes Bug 195
