### PR TITLE
socket.error doesn't have an 'errno' member under python 2.6

### DIFF
--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -293,10 +293,16 @@ class Connection(object):
             self.more_to_read = False
             return False
         except socket.error as exc:
-            if exc.errno in (errno.EAGAIN, errno.EINTR):
-                self.more_to_read = False
-                return False
-            raise
+            try:
+                if exc.errno in (errno.EAGAIN, errno.EINTR):
+                    self.more_to_read = False
+                    return False
+                raise
+            except AttributeError:				
+                if exc.args[0] in (errno.EAGAIN, errno.EINTR):
+                    self.more_to_read = False
+                    return False				
+                raise
         self.more_to_read = True
         return True
 


### PR DESCRIPTION
http://docs.python.org/2/library/socket.html#socket.error
