### PR TITLE
restrict queues to those with specified prefix

### DIFF
--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -136,7 +136,7 @@ class Channel(virtual.Channel):
         # exists with a different visibility_timeout, so this prepopulates
         # the queue_cache to protect us from recreating
         # queues that are known to already exist.
-        queues = self.sqs.get_all_queues()
+        queues = self.sqs.get_all_queues(prefix=self.queue_name_prefix)
         for queue in queues:
             self._queue_cache[queue.name] = queue
 


### PR DESCRIPTION
For SQS, broker transport option `queue_name_prefix` effectively namespaces the possible queues, kombu has no business getting queues that aren't part of that namespace (and may not be permissioned to use).
