### PR TITLE
Attempting to use SSL when librabbitmq is installed

### DIFF
--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -111,6 +111,8 @@ class Connection(object):
             >>> conn.release()
 
     """
+    SSLNotSupported = exceptions.SSLNotSupported
+
     port = None
     virtual_host = '/'
     connect_timeout = 5
@@ -235,7 +237,7 @@ class Connection(object):
         self.heartbeat = heartbeat and float(heartbeat)
 
         if ssl and transport == 'librabbitmq':
-            raise Exception('SSL not supported for "librabbitmq" transport')
+            raise self.SSLNotSupported(transport)
 
     def _debug(self, msg, *args, **kwargs):
         fmt = '[Kombu connection:0x{id:x}] {msg}'

--- a/kombu/exceptions.py
+++ b/kombu/exceptions.py
@@ -48,6 +48,8 @@ class ChannelLimitExceeded(LimitExceeded):
     """Maximum number of simultaneous channels exceeded."""
     pass
 
+class SSLNotSupported(KombuError):
+    pass
 
 class StdConnectionError(KombuError):
     pass


### PR DESCRIPTION
I was having issues connecting to another RabbitMQ instance where I must use SSL to connect.  AFAIK, librabbitmq does NOT support SSL.  However, since it's installed, it's being forced as the transport for a `amqp://` broker URL.  I tried specifying `?ssl=1` and still it does not work.   To work around the issue, I do:

```
conn = Connection(broker_url)
conn.transport_cls = 'amqp'
```

It would be much cleaner (and enable me to continue to use tools like `celery amqp -b ...`) if the `Connection` object would not force the use of `librabbitmq` in the case when SSL was in use.
