### PR TITLE
This change fixes issue #209

### DIFF
--- a/kombu/entity.py
+++ b/kombu/entity.py
@@ -492,7 +492,7 @@ class Queue(MaybeChannelBound):
             self.exchange.declare(nowait)
         self.queue_declare(nowait, passive=False)
 
-        if self.exchange is not None:
+        if self.exchange and self.exchange.name:
             self.queue_bind(nowait)
 
         # - declare extra/multi-bindings.


### PR DESCRIPTION
This checks for a named exchange before calling queue_bind - see my comment on #209 for more info.
