### PR TITLE
connection.info(): 'hostname' is misleading

### DIFF
--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -545,12 +545,9 @@ class Connection(object):
             transport_cls = RESOLVE_ALIASES.get(transport_cls, transport_cls)
         D = self.transport.default_connection_params
 
-        if self.alt:
-            hostname = ";".join(self.alt)
-        else:
-            hostname = self.hostname or D.get('hostname')
-            if self.uri_prefix:
-                hostname = '%s+%s' % (self.uri_prefix, hostname)
+        hostname = self.hostname or D.get('hostname')
+        if self.uri_prefix:
+            hostname = '%s+%s' % (self.uri_prefix, hostname)
 
         info = (('hostname', hostname),
                 ('userid', self.userid or D.get('userid')),
@@ -565,6 +562,10 @@ class Connection(object):
                 ('login_method', self.login_method or D.get('login_method')),
                 ('uri_prefix', self.uri_prefix),
                 ('heartbeat', self.heartbeat))
+
+        if self.alt:
+            info += (('alternates', self.alt),)
+
         return info
 
     def info(self):


### PR DESCRIPTION
When multiple brokers are specified, dont show the
the hostname as the entire python list.

This fixes: https://github.com/celery/celery/issues/1338

Tests still pass.

Spot-checked a few things that use kombu.  Other than celery, I didn't see anyone using the info() method.
