### PR TITLE
Close underlying connection in Producer on .close()

### DIFF
--- a/kombu/messaging.py
+++ b/kombu/messaging.py
@@ -224,7 +224,9 @@ class Producer(object):
         self.release()
 
     def release(self):
-        pass
+        if self.connection:
+            self.connection.close()
+
     close = release
 
     def _prepare(self, body, serializer=None, content_type=None,

--- a/kombu/tests/test_messaging.py
+++ b/kombu/tests/test_messaging.py
@@ -160,6 +160,11 @@ class test_Producer(TestCase):
         self.assertIs(p.channel, defchan)
         p.exchange.revive.assert_called_with(defchan)
 
+    def test_close_connection(self):
+        p = self.connection.Producer()
+        p.close()
+        self.assertIsNone(self.connection.connection)
+
     def test_enter_exit(self):
         p = self.connection.Producer()
         p.release = Mock()


### PR DESCRIPTION
I don't know if it was an oversight, but `close()` just does `pass` in the current code. This patch makes it actually close the underlying connection.
