### PR TITLE
Add the ability to specify __tablename__ for SQLALchemy tables.

### DIFF
--- a/kombu/transport/sqlalchemy/__init__.py
+++ b/kombu/transport/sqlalchemy/__init__.py
@@ -11,8 +11,10 @@ from sqlalchemy.orm import sessionmaker
 
 from kombu.transport import virtual
 from kombu.exceptions import StdConnectionError, StdChannelError
+from kombu.utils import cached_property
 
-from .models import Queue, Message, metadata
+from .models import (ModelBase, Queue as QueueBase, Message as MessageBase,
+                     class_registry, metadata)
 
 
 VERSION = (1, 1, 0)
@@ -23,11 +25,27 @@ class Channel(virtual.Channel):
     _session = None
     _engines = {}   # engine cache
 
+    def __init__(self, connection, **kwargs):
+        self._configure_entity_tablenames(connection.client.transport_options)
+        super(Channel, self).__init__(connection, **kwargs)
+
+    def _configure_entity_tablenames(self, opts):
+        self.queue_tablename = opts.get('queue_tablename', 'kombu_queue')
+        self.message_tablename = opts.get('message_tablename', 'kombu_message')
+
+        #
+        # Define the model definitions.  This registers the declarative
+        # classes with the active SQLAlchemy metadata object.  This *must* be
+        # done prior to the ``create_engine`` call.
+        #
+        self.queue_cls and self.message_cls
+
     def _engine_from_config(self):
         conninfo = self.connection.client
-        configuration = dict(conninfo.transport_options)
-        url = conninfo.hostname
-        return create_engine(url, **configuration)
+        transport_options = conninfo.transport_options.copy()
+        transport_options.pop('queue_tablename', None)
+        transport_options.pop('message_tablename', None)
+        return create_engine(conninfo.hostname, **transport_options)
 
     def _open(self):
         conninfo = self.connection.client
@@ -46,10 +64,10 @@ class Channel(virtual.Channel):
         return self._session
 
     def _get_or_create(self, queue):
-        obj = self.session.query(Queue) \
-            .filter(Queue.name == queue).first()
+        obj = self.session.query(self.queue_cls) \
+            .filter(self.queue_cls.name == queue).first()
         if not obj:
-            obj = Queue(queue)
+            obj = self.queue_cls(queue)
             self.session.add(obj)
             try:
                 self.session.commit()
@@ -62,7 +80,7 @@ class Channel(virtual.Channel):
 
     def _put(self, queue, payload, **kwargs):
         obj = self._get_or_create(queue)
-        message = Message(dumps(payload), obj)
+        message = self.message_cls(dumps(payload), obj)
         self.session.add(message)
         try:
             self.session.commit()
@@ -74,12 +92,12 @@ class Channel(virtual.Channel):
         if self.session.bind.name == 'sqlite':
             self.session.execute('BEGIN IMMEDIATE TRANSACTION')
         try:
-            msg = self.session.query(Message) \
+            msg = self.session.query(self.message_cls) \
                 .with_lockmode('update') \
-                .filter(Message.queue_id == obj.id) \
-                .filter(Message.visible != False) \
-                .order_by(Message.sent_at) \
-                .order_by(Message.id) \
+                .filter(self.message_cls.queue_id == obj.id) \
+                .filter(self.message_cls.visible != False) \
+                .order_by(self.message_cls.sent_at) \
+                .order_by(self.message_cls.id) \
                 .limit(1) \
                 .first()
             if msg:
@@ -91,8 +109,8 @@ class Channel(virtual.Channel):
 
     def _query_all(self, queue):
         obj = self._get_or_create(queue)
-        return self.session.query(Message) \
-            .filter(Message.queue_id == obj.id)
+        return self.session.query(self.message_cls) \
+            .filter(self.message_cls.queue_id == obj.id)
 
     def _purge(self, queue):
         count = self._query_all(queue).delete(synchronize_session=False)
@@ -104,6 +122,27 @@ class Channel(virtual.Channel):
 
     def _size(self, queue):
         return self._query_all(queue).count()
+
+    def _declarative_cls(self, name, base, ns):
+        if name in class_registry:
+            return class_registry[name]
+        return type(name, (base, ModelBase), ns)
+
+    @cached_property
+    def queue_cls(self):
+        return self._declarative_cls(
+            'Queue',
+            QueueBase,
+            {'__tablename__': self.queue_tablename}
+        )
+
+    @cached_property
+    def message_cls(self):
+        return self._declarative_cls(
+            'Message',
+            MessageBase,
+            {'__tablename__': self.message_tablename}
+        )
 
 
 class Transport(virtual.Transport):


### PR DESCRIPTION
This adds two new options to the SQLAlchemy broker's transport options:

    BROKER_URL = 'sqla+mysql://root@localhost/dbname?charset=utf8'
    BROKER_TRANSPORT_OPTIONS = {
        'queue_tablename': 'custom_named_celery_queue',
        'message_tablename': 'custom_named_celery_message'
    }