### PR TITLE
#243: Handle connection errors and channel errors for failover reconnect

### DIFF
--- a/kombu/mixins.py
+++ b/kombu/mixins.py
@@ -167,7 +167,7 @@ class ConsumerMixin(object):
                         pass
                 else:
                     sleep(self.restart_limit.expected_time(_tokens))
-            except self.connection.connection_errors:
+            except self.connection.connection_errors + self.connection.channel_errors:
                 warn('Connection to broker lost. '
                      'Trying to re-establish the connection...')
 


### PR DESCRIPTION
Adding channel_errors in except correctly handles rabbitmq server crash and reconnection to a new server is working properly.
