### PR TITLE
Return unicode from _safe_str in Python 2.x

### DIFF
--- a/kombu/utils/encoding.py
+++ b/kombu/utils/encoding.py
@@ -96,7 +96,7 @@ def _safe_str(s, errors='replace'):
     encoding = default_encoding()
     try:
         if isinstance(s, unicode):
-            return s.encode(encoding, errors)
+            return s
         return unicode(s, encoding, errors)
     except Exception as exc:
         return '<Unrepresentable {0!r}: {1!r} {2!r}>'.format(


### PR DESCRIPTION
Under _Python 2.x_, `_safe_str()` should return `unicode`, otherwise `logger.error(u"The quiæk fåx jømps øver the lazy dåg")` fails in celery's `ColorFormatter`. This is because celery's `ColorFormatter.format()` expects unicode or ascii from `_safe_str()`, not `utf-8`, otherwise `str_t(...)` (`unicode(...)`) fails.

These all should work, but the last `logger.error(...)` currently fails without this patch:

``` python
import logging
from celery.utils.log import ColorFormatter

handler = logging.StreamHandler()
handler.setFormatter(ColorFormatter("%(message)s", use_color=True))
logger = logging.getLogger('test')
logger.handlers = []
logger.addHandler(handler)
logger.error('The quiæk fåx jømps øver the lazy dåg')
logger.error('The qui\xc3\xa6k f\xc3\xa5x j\xc3\xb8mps \xc3\xb8ver the lazy d\xc3\xa5g')
logger.error(u'The quiæk fåx jømps øver the lazy dåg')
```
