### PR TITLE
 Drop distribute dependencies

### DIFF
--- a/requirements/test3.txt
+++ b/requirements/test3.txt
@@ -1,4 +1,4 @@
-distribute
+setuptools>=0.7
 nose
 nose-cover3
 mock>=0.7.0

--- a/tox.ini
+++ b/tox.ini
@@ -2,12 +2,10 @@
 envlist = py26,py27,py33,pypy
 
 [testenv]
-distribute = True
 sitepackages = False
 commands = nosetests
 
 [testenv:py33]
-distribute = True
 basepython = python3.3
 deps = -r{toxinidir}/requirements/default.txt
        -r{toxinidir}/requirements/test3.txt
@@ -19,7 +17,6 @@ commands = {toxinidir}/extra/release/removepyc.sh {toxinidir}
                 --xunit-file={toxinidir}/nosetests.xml
 
 [testenv:py32]
-distribute = True
 basepython = python3.2
 deps = -r{toxinidir}/requirements/default.txt
        -r{toxinidir}/requirements/test3.txt


### PR DESCRIPTION
distribute was merged back into setuptools-0.7 and deprecated therefore.
