### PR TITLE
remove positional exchange type, and use the exchange_opts dict instead,...

### DIFF
--- a/kombu/simple.py
+++ b/kombu/simple.py
@@ -101,7 +101,7 @@ class SimpleBase(object):
 class SimpleQueue(SimpleBase):
     no_ack = False
     queue_opts = {}
-    exchange_opts = {}
+    exchange_opts = { 'type': 'direct' }
 
     def __init__(self, channel, name, no_ack=None, queue_opts=None,
                  exchange_opts=None, serializer=None,
@@ -112,7 +112,7 @@ class SimpleQueue(SimpleBase):
         if no_ack is None:
             no_ack = self.no_ack
         if not isinstance(queue, entity.Queue):
-            exchange = entity.Exchange(name, 'direct', **exchange_opts)
+            exchange = entity.Exchange(name, **exchange_opts)
             queue = entity.Queue(name, exchange, name, **queue_opts)
         else:
             name = queue.name


### PR DESCRIPTION
... allowing the override of exchange_type from SimpleQueue constructor.

Before this change, the following script fails:

```
from kombu import Connection
from kombu.pools import connections
connection = Connection('amqp://guest:guest@localhost:5672')
with connections[connection].acquire() as conn:
    with conn.SimpleQueue('callhome_logging', exchange_opts={'type': 'fanout'}) as queue:
        while True:
            message = queue.get(block=True)
            message.ack()
            print message.payload
```

With this exception:

```
$ python test.py
Traceback (most recent call last):
  File "test.py", line 5, in <module>
    with conn.SimpleQueue('callhome_logging', exchange_opts={'type': 'fanout'}) as queue:
  File "/Library/Python/2.7/site-packages/kombu-3.0.0a1-py2.7.egg/kombu/connection.py", line 709, in SimpleQueue
    exchange_opts, **kwargs)
  File "/Library/Python/2.7/site-packages/kombu-3.0.0a1-py2.7.egg/kombu/simple.py", line 115, in __init__
    exchange = entity.Exchange(name, 'direct', **exchange_opts)
TypeError: __init__() got multiple values for keyword argument 'type'
```
