### PR TITLE
Make Redis Ack Emulation More Consistent with AMQP

### DIFF
--- a/kombu/tests/transport/test_redis.py
+++ b/kombu/tests/transport/test_redis.py
@@ -281,7 +281,7 @@ class test_Channel(Case):
         self.channel._do_restore_message(
             pl1, 'ex', 'rkey', client,
         )
-        client.lpush.assert_has_calls([
+        client.rpush.assert_has_calls([
             call('george', spl1), call('elaine', spl1),
         ])
 
@@ -291,11 +291,11 @@ class test_Channel(Case):
         self.channel._do_restore_message(
             pl2, 'ex', 'rkey', client,
         )
-        client.lpush.assert_has_calls([
+        client.rpush.assert_has_calls([
             call('george', spl2), call('elaine', spl2),
         ])
 
-        client.lpush.side_effect = KeyError()
+        client.rpush.side_effect = KeyError()
         with patch('kombu.transport.redis.logger') as logger:
             self.channel._do_restore_message(
                 pl2, 'ex', 'rkey', client,

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -387,7 +387,7 @@ class Channel(virtual.Channel):
                 except KeyError:
                     pass
                 for queue in self._lookup(exchange, routing_key):
-                    client.lpush(queue, dumps(payload))
+                    client.rpush(queue, dumps(payload))
             except Exception:
                 logger.critical('Could not restore message: %r', payload,
                                 exc_info=True)


### PR DESCRIPTION
Currently when the Redis transport restores unacknowledged messages they are put on the back of the queue `lpush` rather than the front `rpush`. This is inconsistent with how unacknowledged messages are restored when using RabbitMQ/AMQP. I created a gist example to demonstrate this difference: https://gist.github.com/mlavin/6671079
