### PR TITLE
Fix LaxBoundedSemaphore' object has no attribute 'waiting'

### DIFF
--- a/kombu/async/semaphore.py
+++ b/kombu/async/semaphore.py
@@ -94,7 +94,7 @@ class LaxBoundedSemaphore(object):
 
     def __repr__(self):
         return '<{0} at {1:#x} value:{2} waiting:{3}>'.format(
-            self.__class__.__name__, id(self), self.value, len(self.waiting),
+            self.__class__.__name__, id(self), self.value, len(self._waiting),
         )
 
 


### PR DESCRIPTION
Hi, 
I think there is a typo in the **repr** method

I'm having this stacktrace:
[2013-11-13 14:04:22,900: ERROR/MainProcess] 'LaxBoundedSemaphore' object has no attribute 'waiting'
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/raven/utils/serializer/manager.py", line 76, in transform
    return repr(value)
  File "/usr/local/lib/python2.7/dist-packages/kombu/async/semaphore.py", line 97, in **repr**
    self.**class**.**name**, id(self), self.value, len(self.waiting),
AttributeError: 'LaxBoundedSemaphore' object has no attribute 'waiting'
