### PR TITLE
fixing small bug in prepare_message method: type object argument after *...

### DIFF
--- a/kombu/transport/pyamqp.py
+++ b/kombu/transport/pyamqp.py
@@ -46,7 +46,7 @@ class Channel(amqp.Channel, base.StdChannel):
             content_type=content_type,
             content_encoding=content_encoding,
             application_headers=headers,
-            **properties
+            **properties or {}
         )
 
     def message_to_python(self, raw_message):


### PR DESCRIPTION
...\* must be a mapping, not NoneType

The "properties" params is passed with *\* so it can't be None, just using {} if None to avoid error:

type object argument after *\* must be a mapping, not NoneType
