### PR TITLE
Check against correct types

### DIFF
--- a/kombu/utils/eventio.py
+++ b/kombu/utils/eventio.py
@@ -11,6 +11,8 @@ import errno
 import select as __select__
 import socket
 
+from kombu.five import int_types
+
 _selectf = __select__.select
 _selecterr = __select__.error
 epoll = getattr(__select__, 'epoll', None)
@@ -219,15 +221,15 @@ class _select(Poller):
 
         events = {}
         for fd in read:
-            if not isinstance(fd, int):
+            if not isinstance(fd, int_types):
                 fd = fd.fileno()
             events[fd] = events.get(fd, 0) | READ
         for fd in write:
-            if not isinstance(fd, int):
+            if not isinstance(fd, int_types):
                 fd = fd.fileno()
             events[fd] = events.get(fd, 0) | WRITE
         for fd in error:
-            if not isinstance(fd, int):
+            if not isinstance(fd, int_types):
                 fd = fd.fileno()
             events[fd] = events.get(fd, 0) | ERR
         return list(events.items())


### PR DESCRIPTION
The "fd" can be a type of long, so isinstance has to be tested against int_types and not only "int".
Not sure if the bug can be reproduced on linux.
My config:

Window 8.1 x64
redis 2.6.12 x64
celery 3.1
python 2.7.5, x64
