### PR TITLE
Go back to the way the code was originally structured, but with a differ...

### DIFF
--- a/kombu/tests/transport/test_redis.py
+++ b/kombu/tests/transport/test_redis.py
@@ -499,8 +499,17 @@ class test_Channel(Case):
         c.parse_response.assert_called_with(c.connection, 'BRPOP')
 
         c.parse_response.side_effect = KeyError('foo')
-        with self.assertRaises(KeyError):
-            self.channel._poll_error('BRPOP')
+        self.assertIsNone(self.channel._poll_error('BRPOP'))
+
+    def test_poll_error_on_type_LISTEN(self):
+        c = self.channel.subclient = Mock()
+        c.parse_response = Mock()
+        self.channel._poll_error('LISTEN')
+
+        c.parse_response.assert_called_with()
+
+        c.parse_response.side_effect = KeyError('foo')
+        self.assertIsNone(self.channel._poll_error('LISTEN'))
 
     def test_put_fanout(self):
         self.channel._in_poll = False

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -528,14 +528,30 @@ class Channel(virtual.Channel):
             self._in_poll = False
 
     def _poll_error(self, type, **options):
-        client = self.subclient if type == 'LISTEN' else self.client
         try:
-            _sock = client.connection._sock
-        except AttributeError:
-            pass
-        else:
-            if _sock is not None:
-                client.parse_response(client.connection, type)
+            if type == 'LISTEN':
+                self.subclient.parse_response()
+            else:
+                self.client.parse_response(self.client.connection, type)
+        except self.connection_errors as ex:
+            #Again, upstream may want this to be removed for performance reasons, but proved useful in identifying
+            # a problem with our redis server configuration.
+            #
+            # e.g. :
+            # """Connection error: Error while reading from socket: (104, 'Connection reset by peer')
+            #    Traceback (most recent call last):
+            #      File "/opt/python2.7.1/lib/python2.7/site-packages/kombu/transport/redis.py", line 500, in _poll_error
+            #        self.subclient.parse_response()
+            #      File "/opt/python2.7.1/lib/python2.7/site-packages/redis/client.py", line 1498, in parse_response
+            #        response = self.connection.read_response()
+            #      File "/opt/python2.7.1/lib/python2.7/site-packages/redis/connection.py", line 304, in read_response
+            #        response = self._parser.read_response()
+            #      File "/opt/python2.7.1/lib/python2.7/site-packages/redis/connection.py", line 102, in read_response
+            #        response = self.read()
+            #      File "/opt/python2.7.1/lib/python2.7/site-packages/redis/connection.py", line 91, in read
+            #        (e.args,))
+            #    ConnectionError: Error while reading from socket: (104, 'Connection reset by peer')"""
+            logger.warning("Connection error: {}".format(ex), exc_info=True)
 
     def _get(self, queue):
         with self.conn_or_acquire() as client:


### PR DESCRIPTION
...ent parse_response signature for LISTEN operations.

After realizing that subclient and client are two different instances of two different pyredis classes, I realized that the fix might be simpler than I had originally suggested.  I think the real problem was that we were calling `client.parse_response` (wrong) with 1 arg (also wrong), when we should have been calling `subclient.parse_response` with 0 args (not two). (You can see the signature difference between the two at https://github.com/andymccurdy/redis-py/search?q=def+parse_response&ref=cmdform )

I believe the AttributeError/null socket was actually occurring after my original fix because it was calling client.parse_response instead of subclient.parse_response.  

With the current version of the fix, the issue that I used to see is now raised as a ConnectionError.  However, since the original version of master was catching connection errors, I put the catch for this back in, and updated the unit tests accordingly.  I also added a warning when such errors are caught, which upstream may want to remove if it's a performance risk, although it did prove useful for us to find the cause of the ConnectionError.
