### PR TITLE
Add restore_visible and restore_by_tag to virtual.QoS.  Fixes error when...

### DIFF
--- a/kombu/transport/virtual/__init__.py
+++ b/kombu/transport/virtual/__init__.py
@@ -210,6 +210,11 @@ class QoS(object):
         finally:
             state.restored = True
 
+    def restore_visible(self, **kwargs):
+        """ No-op for use by implementations with optional QoS support (e.g. ack_emulation in redis) """
+        pass
+
+
 
 class Message(base.Message):
 


### PR DESCRIPTION
... ack_emulation disabled in redis transport.

This fixes the following error when I set `BROKER_TRANSPORT_OPTIONS = {'visibility_timeout': 259200, 'ack_emulation':False}` (`'ack_emulation': False` being the parameter that breaks things)

```
ERROR/MainProcess] Unrecoverable error: AttributeError("'QoS' object has no attribute 'restore_visible'",)
Traceback (most recent call last):
  File "/home/mnelson/source/development/local/lib/python2.7/site-packages/celery/worker/__init__.py", line 212, in start
    self.blueprint.start(self)
  File "/home/mnelson/source/development/local/lib/python2.7/site-packages/celery/bootsteps.py", line 123, in start
    step.start(parent)
  File "/home/mnelson/source/development/local/lib/python2.7/site-packages/celery/bootsteps.py", line 373, in start
    return self.obj.start()
  File "/home/mnelson/source/development/local/lib/python2.7/site-packages/celery/worker/consumer.py", line 270, in start
    blueprint.start(self)
  File "/home/mnelson/source/development/local/lib/python2.7/site-packages/celery/bootsteps.py", line 123, in start
    step.start(parent)
  File "/home/mnelson/source/development/local/lib/python2.7/site-packages/celery/worker/consumer.py", line 467, in start
    c.connection = c.connect()
  File "/home/mnelson/source/development/local/lib/python2.7/site-packages/celery/worker/consumer.py", line 369, in connect
    conn.transport.register_with_event_loop(conn.connection, self.hub)
  File "/home/mnelson/source/myforks/kombu/kombu/transport/redis.py", line 803, in register_with_event_loop
    cycle.on_poll_init(loop.poller)
  File "/home/mnelson/source/myforks/kombu/kombu/transport/redis.py", line 264, in on_poll_init
    return channel.qos.restore_visible(
AttributeError: 'QoS' object has no attribute 'restore_visible'
```

Wasn't sure whether it was preferred to add this method to the virtual.QoS, or to add logic to check the QoS type/supported methods in maybe_restore_messages.  Went with the option that seemed cleaner to me.
