### PR TITLE
fixup! Redis: Propagate connection errors in _poll_error

### DIFF
--- a/kombu/tests/transport/test_redis.py
+++ b/kombu/tests/transport/test_redis.py
@@ -499,7 +499,8 @@ class test_Channel(Case):
         c.parse_response.assert_called_with(c.connection, 'BRPOP')
 
         c.parse_response.side_effect = KeyError('foo')
-        self.assertIsNone(self.channel._poll_error('BRPOP'))
+        with self.assertRaises(KeyError):
+            self.channel._poll_error('BRPOP')
 
     def test_poll_error_on_type_LISTEN(self):
         c = self.channel.subclient = Mock()
@@ -509,7 +510,8 @@ class test_Channel(Case):
         c.parse_response.assert_called_with()
 
         c.parse_response.side_effect = KeyError('foo')
-        self.assertIsNone(self.channel._poll_error('LISTEN'))
+        with self.assertRaises(KeyError):
+            self.channel._poll_error('LISTEN')
 
     def test_put_fanout(self):
         self.channel._in_poll = False


### PR DESCRIPTION
Updated unit tests following decision to propagate connection errors from _poll_error call to parse_response.
