### PR TITLE
Limit SQS message pulls to 10

### DIFF
--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -392,6 +392,9 @@ class Channel(virtual.Channel):
         # one message.
         maxcount = self.qos.can_consume_max_estimate()
         maxcount = max_if_unlimited if maxcount is None else max(maxcount, 1)
+
+        # SQS only supports pulling a maximum of 10 messages at a time
+        maxcount = min(maxcount, 10)
         messages = self._get_from_sqs(queue, count=maxcount)
 
         if not messages:


### PR DESCRIPTION
#### Fix for https://github.com/celery/celery/issues/1746
- Bug reproduced by having a prefetch_multiplier and process
  count that multiply together to become greater than 10. This bug
  is on a per worker basis, and not a per instance basis.
- **Fix**: Anything greater than 10 gets floored to 10.
- **Efficient work around for this hard cap:** Decrease process count per worker
  and add a new worker. Set process count and prefetch multiplier such that
  they multiply to 10.
### Question

It is clear that the original author of this SQS update had the max of 10 in mind when he set the `max_if_unlimited` kwarg. **Would it better to use that instead of the hard coded 10?** I stayed away from that since amazon imposes the strict 10 limit, and if someone somehow messes up and passes in the wrong value, this would fix it for them.
