### PR TITLE
Add suppport to custom routing_key if passing a kombu.entity.Queue to Simple* interface

### DIFF
--- a/kombu/simple.py
+++ b/kombu/simple.py
@@ -114,12 +114,14 @@ class SimpleQueue(SimpleBase):
         if not isinstance(queue, entity.Queue):
             exchange = entity.Exchange(name, **exchange_opts)
             queue = entity.Queue(name, exchange, name, **queue_opts)
+            routing_key = name
         else:
             name = queue.name
             exchange = queue.exchange
+            routing_key = queue.routing_key
         producer = messaging.Producer(channel, exchange,
                                       serializer=serializer,
-                                      routing_key=name,
+                                      routing_key=routing_key,
                                       compression=compression)
         consumer = messaging.Consumer(channel, queue)
         super(SimpleQueue, self).__init__(channel, producer,


### PR DESCRIPTION
I need to use routing keys in my application - to avoid using multiple queues -, but dont want to it be fully asynchronous (eg.: I dont want to use Consumer class directly), so, i made this little modification to the Simple interface: When passing a `kombu.entity.Queue` class, it get the routing key from the Queue and use in the producer, directly.

This avoids the possible issue of, for example, when passing a `kombu.entity.Queue` with a custom Routing Key, the producer starts sending the messages to the wrong routing key, too. =)
