### PR TITLE
retry forever if max_retries is set to 0

### DIFF
--- a/kombu/utils/__init__.py
+++ b/kombu/utils/__init__.py
@@ -228,7 +228,7 @@ def retry_over_time(fun, catch, args=[], kwargs={}, errback=None,
         try:
             return fun(*args, **kwargs)
         except catch as exc:
-            if max_retries is not None and retries >= max_retries:
+            if max_retries and retries >= max_retries:
                 raise
             if callback:
                 callback()


### PR DESCRIPTION
Hello, 

In celery documentation you have: 

> > > BROKER_CONNECTION_MAX_RETRIES
> > > Maximum number of retries before we give up re-establishing a connection to the AMQP broker.
> > > If this is set to 0 or None, we will retry forever.

But with setting 0 as MAX_RETRIES, it disables retry and instant raise the error. 
