### PR TITLE
retry_over_time never sleep interval_start

### DIFF
--- a/kombu/utils/__init__.py
+++ b/kombu/utils/__init__.py
@@ -235,6 +235,7 @@ def retry_over_time(fun, catch, args=[], kwargs={}, errback=None,
             tts = (errback(exc, interval_range, retries) if errback
                    else next(interval_range))
             if tts:
+                sleep(interval_start)
                 for i in range(int(tts / interval_step)):
                     if callback:
                         callback()


### PR DESCRIPTION
The interval_start is never use.

Currently retry_over_time sleep `retries_count*interval_step`
