### PR TITLE
Added await_data param to tailable cursor in mongodb transport layer.

### DIFF
--- a/kombu/transport/mongodb.py
+++ b/kombu/transport/mongodb.py
@@ -185,7 +185,8 @@ class Channel(virtual.Channel):
     def _queue_bind(self, exchange, routing_key, pattern, queue):
         if self.typeof(exchange).type == 'fanout':
             cursor = self.bcast.find(query={'queue': exchange},
-                                     sort=[('$natural', 1)], tailable=True)
+                                     sort=[('$natural', 1)], tailable=True,
+                                     await_data=True)
             # Fast forward the cursor past old events
             self._queue_cursors[queue] = cursor.skip(cursor.count())
             self._queue_readcounts[queue] = cursor.count()


### PR DESCRIPTION
If the cursor does not have any data, blocks for a while instead
of returning no data. Now we get more 'streaming' behaviour rather
than getting blocks of messages once per poll unit.