### PR TITLE
Allow None in 'accept' parameter to Connection()

### DIFF
--- a/kombu/serialization.py
+++ b/kombu/serialization.py
@@ -449,5 +449,5 @@ for ep, args in entrypoints('kombu.serializers'):  # pragma: no cover
 
 def prepare_accept_content(l, name_to_type=registry.name_to_type):
     if l is not None:
-        return set(n if '/' in n else name_to_type[n] for n in l)
+        return set(n if n is None or '/' in n else name_to_type[n] for n in l)
     return l


### PR DESCRIPTION
I'm consuming binary (Protocol Buffer) messages from the (@emile) RabbitMQ MQTT Adapter's `mqtt.topic` exchange. These come with a null (None) `content-type` for some reason (I've not looked into what's going on).

With my patch, I can cope with a null `content-type` by doing something like:

``` python
identity = lambda x: x
serialization.register('raw', identity, identity, None)
# ...
Consumer(..., accept=[None], ...)
```

If there's a better way that renders this patch unnecessary, let me know. Thanks!
