### PR TITLE
Broken GZIP + pickle on Python 3.3

### DIFF
--- a/kombu/utils/encoding.py
+++ b/kombu/utils/encoding.py
@@ -50,8 +50,8 @@ if is_py3k:  # pragma: no cover
         return s
 
     def bytes_to_str(s):
-        if isinstance(s, bytes):
-            return s.decode()
+        #if isinstance(s, bytes):
+        #    return s.decode()
         return s
 
     def from_utf8(s, *args, **kwargs):


### PR DESCRIPTION
When enabling pickle as the result serializer and enabling gzip as the message compression, I get a consistent UnicodeDecodeError on this line since it is trying to decode bytes into UTF-8, which cannot be done.  Removing this line makes everything work like a charm.  It also works fine with JSON and JSON+GZIP.

Why was it inserted?  What did it fix?  Was there a change in python 3.3 that maybe makes it no longer necessary?
