### PR TITLE
raise Empty() rather than returning null event message

### DIFF
--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -570,9 +570,9 @@ class Channel(virtual.Channel):
                     try:
                         message = loads(bytes_to_str(payload['data']))
                     except (TypeError, ValueError):
-                        message = None
                         warn('Cannot process event on channel %r: %r',
                              channel, payload, exc_info=1)
+                        raise Empty()
                     return message, self._fanout_to_queue[channel]
         raise Empty()
 


### PR DESCRIPTION
This PR is the solution we have had in our environments for about 2 months now. I see that in 3.0.11 the message has been set to None if an exception is caught, but it seems like the empty message shouldn't be returned. 
