### PR TITLE
Don't increase the semaphore is a callback is going to get called 

### DIFF
--- a/kombu/async/semaphore.py
+++ b/kombu/async/semaphore.py
@@ -71,11 +71,10 @@ class LaxBoundedSemaphore(object):
         that is waiting for the resource (FIFO order).
 
         """
-        self.value = min(self.value + 1, self.initial_value)
         try:
             waiter, args = self._pop_waiter()
         except IndexError:
-            pass
+            self.value = min(self.value + 1, self.initial_value)
         else:
             waiter(*args)
 


### PR DESCRIPTION
increasing the semaphore in all situations will make the callbacks waiting for the semaphore run for free, even there's no space to run them.
