### PR TITLE
don't convert decompressed data into utf-8 string

### DIFF
--- a/kombu/compression.py
+++ b/kombu/compression.py
@@ -67,7 +67,7 @@ def decompress(body, content_type):
     :param content_type: mime-type of compression method used.
 
     """
-    return bytes_to_str(get_decoder(content_type)(body))
+    return get_decoder(content_type)(body)
 
 
 register(zlib.compress,

--- a/kombu/tests/test_compression.py
+++ b/kombu/tests/test_compression.py
@@ -34,7 +34,7 @@ class test_compression(Case):
             self.assertIn('application/x-bz2', encoders)
 
     def test_compress__decompress__zlib(self):
-        text = 'The Quick Brown Fox Jumps Over The Lazy Dog'
+        text = b'The Quick Brown Fox Jumps Over The Lazy Dog'
         c, ctype = compression.compress(text, 'zlib')
         self.assertNotEqual(text, c)
         d = compression.decompress(c, ctype)
@@ -43,7 +43,7 @@ class test_compression(Case):
     def test_compress__decompress__bzip2(self):
         if not self.has_bzip2:
             raise SkipTest('bzip2 not available')
-        text = 'The Brown Quick Fox Over The Lazy Dog Jumps'
+        text = b'The Brown Quick Fox Over The Lazy Dog Jumps'
         c, ctype = compression.compress(text, 'bzip2')
         self.assertNotEqual(text, c)
         d = compression.decompress(c, ctype)


### PR DESCRIPTION
This patch fixes celery/celery#1931 and probably celery/kombu#307 too.

I hope it's done the right way, and forgive me if it's not, as this is my first _pull request_ ever :)
