### PR TITLE
Convert major and minor versions to integers for version matching

### DIFF
--- a/kombu/utils/text.py
+++ b/kombu/utils/text.py
@@ -34,7 +34,7 @@ def version_string_as_tuple(s):
 
 
 def _unpack_version(major, minor=0, micro=0, releaselevel='', serial=''):
-    return version_info_t(major, minor, micro, releaselevel, serial)
+    return version_info_t(int(major), int(minor), micro, releaselevel, serial)
 
 
 def _splitmicro(s):


### PR DESCRIPTION
The fix for #339 was great for RabbitMQ 3.3.0, but the version comparison is incorrect under RabbitMQ 3.2.X. The version string's major and minor components stay as unicode, which you compare to a tuple of integers. This little fix just converts the major and minor components to integers, so that RabbitMQ < 3.2 also works properly.
