### PR TITLE
Improve SQLAlchemy connection handling

### DIFF
--- a/kombu/transport/sqlalchemy/__init__.py
+++ b/kombu/transport/sqlalchemy/__init__.py
@@ -153,6 +153,7 @@ class Transport(virtual.Transport):
     default_port = 0
     driver_type = 'sql'
     driver_name = 'sqlalchemy'
+    connection_errors = (OperationalError, )
 
     def driver_version(self):
         import sqlalchemy


### PR DESCRIPTION
currently the SQLAlchemy Transport does not set the "connection_errors" attribute. This prevents downstream users like celery to handle connection errors appropriately.

For example celery (with a db broker) will immediately exit if the DB server was restarted (which usually drops all existing connections) because it uses kombu's Transport.connection_errors in its except clause.
