### PR TITLE
344 - added the skip decorator to three tests.

### DIFF
--- a/kombu/tests/transport/test_redis.py
+++ b/kombu/tests/transport/test_redis.py
@@ -616,10 +616,12 @@ class test_Channel(Case):
             self.channel.connection.client.virtual_host = 'dwqeq'
             self.channel._connparams()
 
+    @skip_if_not_module('redis')
     def test_connparams_allows_slash_in_db(self):
         self.channel.connection.client.virtual_host = '/123'
         self.assertEqual(self.channel._connparams()['db'], 123)
 
+    @skip_if_not_module('redis')
     def test_connparams_db_can_be_int(self):
         self.channel.connection.client.virtual_host = 124
         self.assertEqual(self.channel._connparams()['db'], 124)
@@ -630,6 +632,7 @@ class test_Channel(Case):
         redis.Channel._new_queue(self.channel, 'elaine', auto_delete=True)
         self.assertIn('elaine', self.channel.auto_delete_queues)
 
+    @skip_if_not_module('redis')
     def test_connparams_regular_hostname(self):
         self.channel.connection.client.hostname = 'george.vandelay.com'
         self.assertEqual(


### PR DESCRIPTION
Three tests were missing the @skip_if_not_module('redis') decorator.

https://github.com/celery/kombu/issues/344
