### PR TITLE
Fix reversed method references in custom seiralizer example

### DIFF
--- a/docs/userguide/serialization.rst
+++ b/docs/userguide/serialization.rst
@@ -179,6 +179,6 @@ supported by Kombu.
         def loads(s):
             return pickle.load(BytesIO(s))
 
-        register('my_pickle', loads, pickle.dumps,
+        register('my_pickle', pickle.dumps, loads,
                 content_type='application/x-pickle2',
                 content_encoding='binary')


### PR DESCRIPTION
According to docs on kombu.serialization.register the params order is (name, encoder, decoder, content_type, content_encoding). This caused us a bit of grief as I was too lazy to read the actual docs on register() :)
