### PR TITLE
Issue #355: Check if the userid is populated for couchdb credentials

### DIFF
--- a/kombu/transport/couchdb.py
+++ b/kombu/transport/couchdb.py
@@ -79,7 +79,9 @@ class Channel(virtual.Channel):
                                                  port))
         # Use username and password if avaliable
         try:
-            server.resource.credentials = (conninfo.userid, conninfo.password)
+            if conninfo.userid:
+                server.resource.credentials = (conninfo.userid,
+                                               conninfo.password)
         except AttributeError:
             pass
         try:


### PR DESCRIPTION
While the userid attribute may be present in the conninfo object, it isn't always populated. This checks for whether it is populated or not.
