### PR TITLE
MongoDB transport: Channel constructor doesn't evaluate the connection

### DIFF
--- a/kombu/transport/mongodb.py
+++ b/kombu/transport/mongodb.py
@@ -87,6 +87,9 @@ class Channel(virtual.Channel):
 
         self._broadcast_cursors = {}
 
+        # Evaluate connection
+        self.client
+
     def _new_queue(self, queue, **kwargs):
         pass
 


### PR DESCRIPTION
Using Celery 3.1.11, MongoDB 2.4.10

When the broker (mongo) is down, calling connect() on the kombu Connection doesn't raise

```
In [1]: from kombu import Connection
In [2]: conn = Connection('mongodb://localhost:27017')
In [3]: conn.connect()
Out[3]: <kombu.transport.mongodb.Transport at 0x28545d0>
In [4]: conn.channel()
```

However, MongoClient is raising a ConnectionFailure

```
In [6]: from pymongo import MongoClient
In [7]: c = MongoClient(host='localhost', port=27017)
---------------------------------------------------------------------------
ConnectionFailure                         Traceback (most recent call last)
<ipython-input-7-4fc95e25c398> in <module>()
----> 1 c = MongoClient(host='localhost', port=27017)

/opt/ampli/apps/marvinworker/venv/lib/python2.7/site-packages/pymongo-2.7-py2.7-linux-x86_64.egg/pymongo/mongo_client.pyc in __init__(self, host, port, max_pool_size, document_class, tz_aware, _connect, **kwargs)
    364             except AutoReconnect, e:
    365                 # ConnectionFailure makes more sense here than AutoReconnect
--> 366                 raise ConnectionFailure(str(e))
    367 
    368         if username:

ConnectionFailure: [Errno 111] Connection refused
```

Channel constructor should evaluate the connection

This caused https://github.com/celery/celery/issues/2063
