### PR TITLE
fixed race condition on closing when using gevent

### DIFF
--- a/kombu/tests/transport/test_redis.py
+++ b/kombu/tests/transport/test_redis.py
@@ -1051,7 +1051,7 @@ class test_MultiChannelPoller(Case):
         p._channels.clear.assert_called_with()
         p._fd_to_chan.clear.assert_called_with()
         p._chan_to_sock.clear.assert_called_with()
-        self.assertIsNone(p.poller)
+        self.assertTrue(p.closed)
 
     def test_register_when_registered_reregisters(self):
         p = self.Poller()

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -236,6 +236,7 @@ class MultiChannelPoller(object):
         self.poller = poll()
         # one-shot callbacks called after reading from socket.
         self.after_read = set()
+        self.closed = False
 
     def close(self):
         for fd in values(self._chan_to_sock):
@@ -246,6 +247,7 @@ class MultiChannelPoller(object):
         self._channels.clear()
         self._fd_to_chan.clear()
         self._chan_to_sock.clear()
+        self.closed = True
 
     def add(self, channel):
         self._channels.add(channel)


### PR DESCRIPTION
Hi! When using redis as broker and gevent as pool there's big and ugly traceback when terminating celery worker. I tracked it to race condition when MultiChannelPoller is closed. Calls to poller.unregister() are non-blocking when using gevent, so self.poller gets assigned to None before some of channels are unregistered. I removed that assignment, hope it will not break anything.
