### PR TITLE
Fix up issues with v3.0.19 release.

### DIFF
--- a/kombu/__init__.py
+++ b/kombu/__init__.py
@@ -7,7 +7,7 @@ version_info_t = namedtuple(
     'version_info_t', ('major', 'minor', 'micro', 'releaselevel', 'serial'),
 )
 
-VERSION = version_info_t(3, 0, 18, '', '')
+VERSION = version_info_t(3, 0, 19, '', '')
 __version__ = '{0.major}.{0.minor}.{0.micro}{0.releaselevel}'.format(VERSION)
 __author__ = 'Ask Solem'
 __contact__ = 'ask@celeryproject.org'

--- a/kombu/common.py
+++ b/kombu/common.py
@@ -22,7 +22,6 @@ from amqp import RecoverableConnectionError
 from .entity import Exchange, Queue
 from .five import range
 from .log import get_logger
-from .messaging import Consumer as _Consumer
 from .serialization import registry as serializers
 from .utils import uuid
 
@@ -89,35 +88,45 @@ class Broadcast(Queue):
 def declaration_cached(entity, channel):
     return entity in channel.connection.client.declared_entities
 
-
 def maybe_declare(entity, channel=None, retry=False, **retry_policy):
-    if not entity.is_bound:
+    is_bound = entity.is_bound
+
+    if not is_bound:
         assert channel
         entity = entity.bind(channel)
-    if retry:
-        return _imaybe_declare(entity, **retry_policy)
-    return _maybe_declare(entity)
 
+    if channel is None:
+        assert is_bound
+        channel = entity.channel
 
-def _maybe_declare(entity):
-    channel = entity.channel
-    if not channel.connection:
-        raise RecoverableConnectionError('channel disconnected')
-    if entity.can_cache_declaration:
+    declared = ident = None
+
+    if channel.connection and entity.can_cache_declaration:
         declared = channel.connection.client.declared_entities
         ident = hash(entity)
-        if ident not in declared:
-            entity.declare()
-            declared.add(ident)
-            return True
-        return False
+        if ident in declared:
+            return False
+
+    if retry:
+        return _imaybe_declare(entity, declared, ident,
+                               channel, **retry_policy)
+    return _maybe_declare(entity, declared, ident, channel)
+
+
+def _maybe_declare(entity, declared, ident, channel):
+    channel = channel or entity.channel
+    if not channel.connection:
+        raise RecoverableConnectionError('channel disconnected')
     entity.declare()
+    if declared is not None and ident:
+        declared.add(ident)
     return True
 
 
-def _imaybe_declare(entity, **retry_policy):
+def _imaybe_declare(entity, declared, ident, channel, **retry_policy):
     return entity.channel.connection.client.ensure(
-        entity, _maybe_declare, **retry_policy)(entity)
+        entity, _maybe_declare, **retry_policy)(
+            entity, declared, ident, channel)
 
 
 def drain_consumer(consumer, limit=1, timeout=None, callbacks=None):
@@ -138,8 +147,8 @@ def drain_consumer(consumer, limit=1, timeout=None, callbacks=None):
 
 
 def itermessages(conn, channel, queue, limit=1, timeout=None,
-                 Consumer=_Consumer, callbacks=None, **kwargs):
-    return drain_consumer(Consumer(channel, queues=[queue], **kwargs),
+                 callbacks=None, **kwargs):
+    return drain_consumer(conn.Consumer(channel, queues=[queue], **kwargs),
                           limit=limit, timeout=timeout, callbacks=callbacks)
 
 

--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -194,6 +194,7 @@ class Connection(object):
         """Switch connection parameters to use a new URL (does not
         reconnect)"""
         self.close()
+        self.declared_entities.clear()
         self._closed = False
         self._init_params(**dict(self._initial_params, **parse_url(url)))
 

--- a/kombu/messaging.py
+++ b/kombu/messaging.py
@@ -11,6 +11,7 @@ import numbers
 
 from itertools import count
 
+from .common import maybe_declare
 from .compression import compress
 from .connection import maybe_channel, is_connection
 from .entity import Exchange, Queue, DELIVERY_MODES
@@ -107,7 +108,6 @@ class Producer(object):
         """Declare the exchange if it hasn't already been declared
         during this session."""
         if entity:
-            from .common import maybe_declare
             return maybe_declare(entity, self.channel, retry, **retry_policy)
 
     def publish(self, body, routing_key=None, delivery_mode=None,

--- a/kombu/pidbox.py
+++ b/kombu/pidbox.py
@@ -324,6 +324,7 @@ class Mailbox(object):
             if expires and time() > expires:
                 return
             this_id = header('ticket', ticket)
+
             if this_id == ticket:
                 if callback:
                     callback(body)


### PR DESCRIPTION
Not sure why v3.0.19 is not on this repo.  I've taken the release and played the changes on top of it.

There are two issues with kombu/common.py that need to be fixed with this PR.  First, the code attempts to avoid declaring exchanges more than once.  The problem is that Celery control signals leverage the auto_delete flag, which will delete exchanges when there are no more messages.  The other issue appears that the exchanges are not being bound to any channels.

1) Avoid trying to cache entities that have auto_delete=True (i.e. Celery control signals)

2) Bind the entity if it currently is not bound.

Fixes issue https://github.com/celery/kombu/issues/366
