### PR TITLE
Fix issue with Celery control signals not being received after the 2nd time.

### DIFF
--- a/kombu/common.py
+++ b/kombu/common.py
@@ -92,6 +92,10 @@ def declaration_cached(entity, channel):
 def maybe_declare(entity, channel=None, retry=False, **retry_policy):
     is_bound = entity.is_bound
 
+    if not is_bound:
+        assert channel
+        entity = entity.bind(channel)
+
     if channel is None:
         assert is_bound
         channel = entity.channel
@@ -103,7 +107,6 @@ def maybe_declare(entity, channel=None, retry=False, **retry_policy):
         if ident in declared:
             return False
 
-    entity = entity if is_bound else entity.bind(channel)
     if retry:
         return _imaybe_declare(entity, declared, ident,
                                channel, **retry_policy)

--- a/kombu/entity.py
+++ b/kombu/entity.py
@@ -288,7 +288,7 @@ class Exchange(MaybeChannelBound):
 
     @property
     def can_cache_declaration(self):
-        return self.durable and not self.auto_delete
+        return not self.auto_delete
 
 
 class binding(object):

--- a/kombu/entity.py
+++ b/kombu/entity.py
@@ -288,7 +288,7 @@ class Exchange(MaybeChannelBound):
 
     @property
     def can_cache_declaration(self):
-        return True
+        return self.durable and not self.auto_delete
 
 
 class binding(object):


### PR DESCRIPTION
There are two issues with kombu/common.py that need to be fixed with this PR. First, the code attempts to avoid declaring exchanges more than once. The problem is that Celery control signals leverage the auto_delete flag, which will delete exchanges when there are no more messages. The other issue appears that the exchanges are not being bound to any channels.

1) Avoid trying to cache entities that have auto_delete=True (i.e. Celery control signals) -- reverts back to original behavior in v3.0.18.

2) Bind the entity if it currently is not bound.
