### PR TITLE
Add a requeue_log_error method

### DIFF
--- a/kombu/message.py
+++ b/kombu/message.py
@@ -102,6 +102,13 @@ class Message(object):
             logger.critical("Couldn't reject %r, reason: %r",
                             self.delivery_tag, exc, exc_info=True)
 
+    def requeue_log_error(self, logger, errors):
+        try:
+            self.requeue()
+        except errors as exc:
+            logger.critical("Couldn't requeue %r, reason: %r",
+                            self.delivery_tag, exc, exc_info=True)
+
     def reject(self, requeue=False):
         """Reject this message.
 


### PR DESCRIPTION
In order to match how there is a ack_log_error
and a reject_log_error it seems appropriate to
also provide a requeue_log_error method that
is provided in the message class.
