### PR TITLE
Add support for RabbitMQ extensions for librabbitmq.

### DIFF
--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -137,7 +137,7 @@ class Connection(object):
                  ssl=False, transport=None, connect_timeout=5,
                  transport_options=None, login_method=None, uri_prefix=None,
                  heartbeat=0, failover_strategy='round-robin',
-                 alternates=None, **kwargs):
+                 alternates=None, client_properties=None, **kwargs):
         alt = [] if alternates is None else alternates
         # have to spell the args out, just to get nice docstrings :(
         params = self._initial_params = {
@@ -145,7 +145,8 @@ class Connection(object):
             'password': password, 'virtual_host': virtual_host,
             'port': port, 'insist': insist, 'ssl': ssl,
             'transport': transport, 'connect_timeout': connect_timeout,
-            'login_method': login_method, 'heartbeat': heartbeat
+            'login_method': login_method, 'heartbeat': heartbeat,
+            'client_properties': client_properties
         }
 
         if hostname and not isinstance(hostname, string_t):
@@ -206,7 +207,7 @@ class Connection(object):
 
     def _init_params(self, hostname, userid, password, virtual_host, port,
                      insist, ssl, transport, connect_timeout,
-                     login_method, heartbeat):
+                     login_method, heartbeat, client_properties):
         transport = transport or 'amqp'
         if transport == 'amqp' and supports_librabbitmq():
             transport = 'librabbitmq'
@@ -221,6 +222,7 @@ class Connection(object):
         self.ssl = ssl
         self.transport_cls = transport
         self.heartbeat = heartbeat and float(heartbeat)
+        self.client_properties = client_properties
 
     def register_with_event_loop(self, loop):
         self.transport.register_with_event_loop(self.connection, loop)
@@ -553,6 +555,7 @@ class Connection(object):
             ('uri_prefix', self.uri_prefix),
             ('heartbeat', self.heartbeat),
             ('alternates', self.alt),
+            ('client_properties', self.client_properties)
         )
         return info
 

--- a/kombu/transport/librabbitmq.py
+++ b/kombu/transport/librabbitmq.py
@@ -121,6 +121,7 @@ class Transport(base.Transport):
             'insist': conninfo.insist,
             'ssl': conninfo.ssl,
             'connect_timeout': conninfo.connect_timeout,
+            'client_properties': conninfo.client_properties
         }, **conninfo.transport_options or {})
         conn = self.Connection(**opts)
         conn.client = self.client


### PR DESCRIPTION
Requires PR https://github.com/celery/librabbitmq/pull/49 to enable extension support.

It can be tested by the following:

```
from kombu import Connection

conn = Connection(host="host", userid="user",
                  password="password", virtual_host="vhost",
                  client_properties={'capabilities': {'authentication_failure_close': True}})

conn.connect()
```

Normally an error message of "_librabbitmq.ConnectionError: Couldn't log in: a socket error occurred" is given.  If this capability is enabled, an error message of "_librabbitmq.ConnectionError: Couldn't log in: unexpected method received" is received (this part should be improved).

Open to making pyamqp with the same support but that can be a separate PR.
