### PR TITLE
Forgot one more can_cache_declaration declaration.

### DIFF
--- a/kombu/entity.py
+++ b/kombu/entity.py
@@ -672,7 +672,7 @@ class Queue(MaybeChannelBound):
 
     @property
     def can_cache_declaration(self):
-        return True
+        return not self.auto_delete
 
     @classmethod
     def from_dict(self, queue, **options):


### PR DESCRIPTION
The queues are still being cached because of the auto_delete=True.
