### PR TITLE
Minor spelling/grammar in comments

### DIFF
--- a/kombu/utils/limits.py
+++ b/kombu/utils/limits.py
@@ -25,10 +25,10 @@ class TokenBucket(object):
 
     """
 
-    #: The rate in tokens/second that the bucket will be refilled
+    #: The rate in tokens/second that the bucket will be refilled.
     fill_rate = None
 
-    #: Maximum number of tokensin the bucket.
+    #: Maximum number of tokens in the bucket.
     capacity = 1
 
     #: Timestamp of the last time a token was taken out of the bucket.


### PR DESCRIPTION
This pull request corrects a minor typo `s/tokensin/tokens in/` and adds a period to the end of a comment for consistency with the rest of the file.
