### PR TITLE
Fix MongoDB Broadcast Cursor when empty

### DIFF
--- a/kombu/transport/mongodb.py
+++ b/kombu/transport/mongodb.py
@@ -262,6 +262,11 @@ class Channel(virtual.Channel):
         self._open()
         self._ensure_indexes()
 
+        # tailable cursors won't block if empty.
+        # ensure at least one row exists.
+        if self.get_broadcast().count() == 0:
+            self.get_broadcast().save({'pad':'pad'})
+
     @property
     def client(self):
         if self._client is None:


### PR DESCRIPTION
Tailable cursors do not remain alive (and block in next()) if they
are empty.

An example of this behavior:
http://stackoverflow.com/questions/10321140/using-pymongo-tailable-cursors-dies-on-empty-collections

Adding an outer find() loop appears to be non-trivial since the
cursor init/find() and poll/next() are decoupled, so the
BroadcastCursor has no way to restart itself.