### PR TITLE
Cache declared entities using a unique key instead of hash.

### DIFF
--- a/kombu/abstract.py
+++ b/kombu/abstract.py
@@ -101,6 +101,15 @@ class MaybeChannelBound(Object):
         return '<unbound {0}>'.format(item)
 
     @property
+    def declaration_key(self):
+        """Uniquely identifies a cacheable declaration.
+
+        This method must be overriden by subclasses if :attr:`can_cache_declaration` is True
+        """
+        if self.can_cache_declaration:
+            raise NotImplementedError('Cacheable declarations must implement declaration_key')
+
+    @property
     def is_bound(self):
         """Flag set if the channel is bound."""
         return self._is_bound and self._channel is not None

--- a/kombu/common.py
+++ b/kombu/common.py
@@ -88,7 +88,7 @@ class Broadcast(Queue):
 
 
 def declaration_cached(entity, channel):
-    return entity in channel.connection.client.declared_entities
+    return entity.can_cache_declaration and entity.declaration_key in channel.connection.client.declared_entities
 
 
 def maybe_declare(entity, channel=None, retry=False, **retry_policy):
@@ -106,7 +106,7 @@ def maybe_declare(entity, channel=None, retry=False, **retry_policy):
     declared = ident = None
     if channel.connection and entity.can_cache_declaration:
         declared = channel.connection.client.declared_entities
-        ident = hash(entity)
+        ident = entity.declaration_key
         if ident in declared:
             return False
 

--- a/kombu/entity.py
+++ b/kombu/entity.py
@@ -158,7 +158,11 @@ class Exchange(MaybeChannelBound):
         self.maybe_bind(channel)
 
     def __hash__(self):
-        return hash('E|%s' % (self.name,))
+        return hash(self.declaration_key)
+
+    @property
+    def declaration_key(self):
+        return 'E|%s' % (self.name, )
 
     def _can_declare(self):
         return not self.no_declare and (
@@ -362,6 +366,10 @@ class binding(Object):
             _reprstr(self.exchange.name), _reprstr(self.routing_key),
         )
 
+    @property
+    def declaration_key(self):
+        return str(self)
+
 
 @python_2_unicode_compatible
 class Queue(MaybeChannelBound):
@@ -515,7 +523,11 @@ class Queue(MaybeChannelBound):
         return bound
 
     def __hash__(self):
-        return hash('Q|%s' % (self.name,))
+        return hash(self.declaration_key)
+
+    @property
+    def declaration_key(self):
+        return 'Q|%s|%s|%s' % (self.name, self.routing_key, '|'.join(sorted(b.declaration_key for b in self.bindings)))
 
     def when_bound(self):
         if self.exchange:

--- a/kombu/tests/test_common.py
+++ b/kombu/tests/test_common.py
@@ -42,13 +42,26 @@ class test_declaration_cached(Case):
 
     def test_when_cached(self):
         chan = Mock()
+        entity = Mock()
+        entity.can_cache_declaration = True
+        entity.declaration_key = 'foo'
         chan.connection.client.declared_entities = ['foo']
-        self.assertTrue(declaration_cached('foo', chan))
+        self.assertTrue(declaration_cached(entity, chan))
 
     def test_when_not_cached(self):
         chan = Mock()
+        entity = Mock()
+        entity.can_cache_declaration = True
+        entity.declaration_key = 'foo'
         chan.connection.client.declared_entities = ['bar']
-        self.assertFalse(declaration_cached('foo', chan))
+        self.assertFalse(declaration_cached(entity, chan))
+
+    def test_when_not_cacheable(self):
+        chan = Mock()
+        entity = Mock()
+        entity.can_cache_declaration = False
+        chan.connection.client.declared_entities = ['bar']
+        self.assertFalse(declaration_cached(entity, chan))
 
 
 class test_Broadcast(Case):
@@ -77,6 +90,7 @@ class test_maybe_declare(Case):
         client.declared_entities = set()
         entity = Mock()
         entity.can_cache_declaration = True
+        entity.declaration_key = 'foo'
         entity.auto_delete = False
         entity.is_bound = True
         entity.channel = channel
@@ -84,7 +98,7 @@ class test_maybe_declare(Case):
         maybe_declare(entity, channel)
         self.assertEqual(entity.declare.call_count, 1)
         self.assertIn(
-            hash(entity), channel.connection.client.declared_entities,
+            entity.declaration_key, channel.connection.client.declared_entities,
         )
 
         maybe_declare(entity, channel)

--- a/kombu/tests/test_entity.py
+++ b/kombu/tests/test_entity.py
@@ -76,6 +76,10 @@ class test_Exchange(Case):
         self.assertEqual(hash(Exchange('a')), hash(Exchange('a')))
         self.assertNotEqual(hash(Exchange('a')), hash(Exchange('b')))
 
+    def test_declaration_key(self):
+        self.assertEqual(Exchange('a').declaration_key, Exchange('a').declaration_key)
+        self.assertNotEqual(Exchange('a').declaration_key, Exchange('b').declaration_key)
+
     def test_can_cache_declaration(self):
         self.assertTrue(Exchange('a', durable=True).can_cache_declaration)
         self.assertTrue(Exchange('a', durable=False).can_cache_declaration)
@@ -218,6 +222,23 @@ class test_Queue(Case):
     def test_hash(self):
         self.assertEqual(hash(Queue('a')), hash(Queue('a')))
         self.assertNotEqual(hash(Queue('a')), hash(Queue('b')))
+
+    def test_declaration_key(self):
+        self.assertEqual(Queue('a').declaration_key, Queue('a').declaration_key)
+        self.assertNotEqual(Queue('a').declaration_key, Queue('b').declaration_key)
+
+    def test_declaration_key_with_routing_key(self):
+        self.assertEqual(Queue('a', routing_key='foo').declaration_key,
+                         Queue('a', routing_key='foo').declaration_key)
+        self.assertNotEqual(Queue('a', routing_key='foo').declaration_key,
+                            Queue('a', routing_key='bar').declaration_key)
+
+    def test_declaration_key_with_bindings(self):
+        ex = Exchange('foo')
+        self.assertEqual(Queue('a', bindings=[ex.binding('A'), ex.binding('B')]).declaration_key,
+                         Queue('a', bindings=[ex.binding('B'), ex.binding('A')]).declaration_key)
+        self.assertNotEqual(Queue('a', bindings=[ex.binding('A'), ex.binding('B')]).declaration_key,
+                            Queue('a', bindings=[ex.binding('A')]).declaration_key)
 
     def test_repr_with_bindings(self):
         ex = Exchange('foo')


### PR DESCRIPTION
Also build the key for Queues using bindings so that bindings
are properly declared.

This is a fix for celery/kombu#396
