### PR TITLE
Rename AppConfig name to not conflict with Django

### DIFF
--- a/kombu/transport/django/__init__.py
+++ b/kombu/transport/django/__init__.py
@@ -18,7 +18,7 @@ except ImportError:  # pragma: no cover
     pass
 else:
     class KombuAppConfig(AppConfig):
-        name = 'kombu_django'
+        name = 'kombu.transport.django'
         label = name.replace('.', '_')
         verbose_name = 'Message queue'
     default_app_config = 'kombu.transport.django.KombuAppConfig'


### PR DESCRIPTION
Fixes #399
