### PR TITLE
Bugfix for commit_on_success.

### DIFF
--- a/kombu/transport/django/managers.py
+++ b/kombu/transport/django/managers.py
@@ -19,6 +19,7 @@ else:
         def _commit(*args, **kwargs):
             with transaction.atomic():
                 return fun(*args, **kwargs)
+        return _commit
 
 
 
@@ -75,7 +76,6 @@ class MessageManager(models.Manager):
             recv[0] += 1
             if not recv[0] % self.cleanup_every:
                 self.cleanup()
-            transaction.commit()
             return result.payload
         except self.model.DoesNotExist:
             pass


### PR DESCRIPTION
The `commit_on_success` decorator should return the decorated version.
Also, manual commits are forbidden inside `transaction.atomic`.
