### PR TITLE
Allow ANONYMOUS sasl_mechanism by default

### DIFF
--- a/kombu/tests/transport/test_qpid.py
+++ b/kombu/tests/transport/test_qpid.py
@@ -1595,7 +1595,7 @@ class TestTransportEstablishConnection(Case):
         self.client.userid = new_userid_string
         self.transport.establish_connection()
         self.mock_conn.assert_called_once_with(username=new_userid_string,
-                                               sasl_mechanisms='PLAIN',
+                                               sasl_mechanisms='PLAIN ANONYMOUS',
                                                host='127.0.0.1',
                                                timeout=4,
                                                password='guest',
@@ -1605,7 +1605,7 @@ class TestTransportEstablishConnection(Case):
     def test_transport_establish_conn_empty_client_is_default(self):
         self.transport.establish_connection()
         self.mock_conn.assert_called_once_with(username='guest',
-                                               sasl_mechanisms='PLAIN',
+                                               sasl_mechanisms='PLAIN ANONYMOUS',
                                                host='127.0.0.1',
                                                timeout=4,
                                                password='guest',
@@ -1617,7 +1617,7 @@ class TestTransportEstablishConnection(Case):
         self.client.transport_options['new_param'] = new_param_value
         self.transport.establish_connection()
         self.mock_conn.assert_called_once_with(username='guest',
-                                               sasl_mechanisms='PLAIN',
+                                               sasl_mechanisms='PLAIN ANONYMOUS',
                                                host='127.0.0.1',
                                                timeout=4,
                                                new_param=new_param_value,
@@ -1629,7 +1629,7 @@ class TestTransportEstablishConnection(Case):
         self.client.hostname = 'localhost'
         self.transport.establish_connection()
         self.mock_conn.assert_called_once_with(username='guest',
-                                               sasl_mechanisms='PLAIN',
+                                               sasl_mechanisms='PLAIN ANONYMOUS',
                                                host='127.0.0.1',
                                                timeout=4,
                                                password='guest',
@@ -1640,7 +1640,7 @@ class TestTransportEstablishConnection(Case):
         self.client.ssl = False
         self.transport.establish_connection()
         self.mock_conn.assert_called_once_with(username='guest',
-                                               sasl_mechanisms='PLAIN',
+                                               sasl_mechanisms='PLAIN ANONYMOUS',
                                                host='127.0.0.1',
                                                timeout=4,
                                                password='guest',
@@ -1658,7 +1658,7 @@ class TestTransportEstablishConnection(Case):
                                                ssl_trustfile='my_cacerts',
                                                timeout=4,
                                                ssl_skip_hostname_check=False,
-                                               sasl_mechanisms='PLAIN',
+                                               sasl_mechanisms='PLAIN ANONYMOUS',
                                                host='127.0.0.1',
                                                ssl_keyfile='my_keyfile',
                                                password='guest',
@@ -1675,7 +1675,7 @@ class TestTransportEstablishConnection(Case):
                                                ssl_trustfile='my_cacerts',
                                                timeout=4,
                                                ssl_skip_hostname_check=True,
-                                               sasl_mechanisms='PLAIN',
+                                               sasl_mechanisms='PLAIN ANONYMOUS',
                                                host='127.0.0.1',
                                                ssl_keyfile='my_keyfile',
                                                password='guest',
@@ -1713,7 +1713,7 @@ class TestTransportEstablishConnection(Case):
         self.client.hostname = 'some_other_hostname'
         self.transport.establish_connection()
         self.mock_conn.assert_called_once_with(username='guest',
-                                               sasl_mechanisms='PLAIN',
+                                               sasl_mechanisms='PLAIN ANONYMOUS',
                                                host='some_other_hostname',
                                                timeout=4, password='guest',
                                                port=5672, transport='tcp')
@@ -1863,7 +1863,7 @@ class TestTransport(ExtraAssertionsMixin, Case):
         correct_params = {'userid': 'guest', 'password': 'guest',
                           'port': 5672, 'virtual_host': '',
                           'hostname': 'localhost',
-                          'sasl_mechanisms': 'PLAIN'}
+                          'sasl_mechanisms': 'PLAIN ANONYMOUS'}
         my_transport = Transport(self.mock_client)
         result_params = my_transport.default_connection_params
         self.assertDictEqual(correct_params, result_params)

--- a/kombu/transport/qpid.py
+++ b/kombu/transport/qpid.py
@@ -1638,4 +1638,4 @@ class Transport(base.Transport):
         """
         return {'userid': 'guest', 'password': 'guest',
                 'port': self.default_port, 'virtual_host': '',
-                'hostname': 'localhost', 'sasl_mechanisms': 'PLAIN'}
+                'hostname': 'localhost', 'sasl_mechanisms': 'PLAIN ANONYMOUS'}


### PR DESCRIPTION
Kombu currently only uses "PLAIN" authentication by default. However, Qpid does
not set up a SASL database on a default install. This means users have to
either set up their own SASL db, or set `auth=no` in qpidd.conf.

For a better out-of-the-box experience, both PLAIN and ANONYMOUS mechanisms
should be supported by kombu. See
https://issues.apache.org/jira/browse/QPID-6091 from @bmbouter  for more detail.

We believe that this does not impact security since the default
login is already set to "guest/guest". Allowing anonymous auth is nearly the
same from a security standpoint.
