### PR TITLE
Fix broken timeout for SSL transport

### DIFF
--- a/kombu/transport/amqplib.py
+++ b/kombu/transport/amqplib.py
@@ -198,7 +198,7 @@ class Connection(amqp.Connection):  # pragma: no cover
     def read_timeout(self, timeout=None):
         if timeout is None:
             return self.method_reader.read_method()
-        sock = self.transport.sock
+        sock = self.transport.sslobj or self.transport.sock
         prev = sock.gettimeout()
         if prev != timeout:
             sock.settimeout(timeout)


### PR DESCRIPTION
read_timeout() sets timeout on original TCP socket even if it has been wrapped into SSLSocket. Changing timeout such way does not influence wrapped socket. We need to use other interface - thru transport.sslobj instead of transport.sock . This fix also handles OpenStack issue when Rabbit SSL is used and Nova Compute starts a bit faster then Nova Conductor - the former hangs forever with incorrectly set 10s timeout
