### PR TITLE
Backport of Qpid transport from master to 3.0 release stream

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,8 +18,10 @@ Ask Solem <ask@celeryproject.org>
 Basil Mironenko <bmironenko@ddn.com>
 Bobby Beever <bobby.beever@yahoo.com>
 Brian Bernstein
+Brian Bouterse <bmbouter@redhat.com>
 C Anthony Risinger <anthony+corvisa.com@xtfx.me>
 Christophe Chauvet <christophe.chauvet@gmail.com>
+Christopher Duryee <cduryee@redhat.com>
 Christopher Grebs <cg@webshox.org>
 Clay Gerrard <clay.gerrard@gmail.com>
 Corentin Ardeois <cardeois@iweb.com>

--- a/Changelog
+++ b/Changelog
@@ -4,6 +4,19 @@
  Change history
 ================
 
+.. _version-3.0.24:
+
+3.0.24
+======
+:release-date:
+:release-by:
+
+- The `Qpid <http://qpid.apache.org/>`_ broker is supported for Python 2.x
+  environments. The Qpid transport includes full SSL support within Kombu. See
+  the :mod:`kombu.transport.qpid` docs for more info.
+
+    Contributed by Brian Bouterse and Chris Duryee through support from Red Hat.
+
 .. _version-3.0.23:
 
 3.0.23

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Features
 * Allows application authors to support several message server
   solutions by using pluggable transports.
 
-    * AMQP transport using the `py-amqp`_ or `librabbitmq`_ client libraries.
+    * AMQP transport using the `py-amqp`_, `librabbitmq`_, or `qpid-python`_ client libraries.
 
     * High performance AMQP transport written in C - when using `librabbitmq`_
 
@@ -60,6 +60,7 @@ and the `Wikipedia article about AMQP`_.
 .. _`RabbitMQ`: http://www.rabbitmq.com/
 .. _`AMQP`: http://amqp.org
 .. _`py-amqp`: http://pypi.python.org/pypi/amqp/
+.. _`qpid-python`: http://pypi.python.org/pypi/qpid-python/
 .. _`Redis`: http://code.google.com/p/redis/
 .. _`Amazon SQS`: http://aws.amazon.com/sqs/
 .. _`MongoDB`: http://www.mongodb.org/
@@ -85,6 +86,8 @@ Transport Comparison
 | **Client**    | **Type** | **Direct** | **Topic**  | **Fanout**    |
 +---------------+----------+------------+------------+---------------+
 | *amqp*        | Native   | Yes        | Yes        | Yes           |
++---------------+----------+------------+------------+---------------+
+| *qpid*        | Native   | Yes        | Yes        | Yes           |
 +---------------+----------+------------+------------+---------------+
 | *redis*       | Virtual  | Yes        | Yes        | Yes (PUB/SUB) |
 +---------------+----------+------------+------------+---------------+

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -31,6 +31,7 @@
     kombu.transport
     kombu.transport.pyamqp
     kombu.transport.librabbitmq
+    kombu.transport.qpid
     kombu.transport.memory
     kombu.transport.redis
     kombu.transport.zmq

--- a/docs/reference/kombu.transport.qpid.rst
+++ b/docs/reference/kombu.transport.qpid.rst
@@ -1,0 +1,35 @@
+.. currentmodule:: kombu.transport.qpid
+
+.. automodule:: kombu.transport.qpid
+
+    .. contents::
+        :local:
+
+    Transport
+    ---------
+
+    .. autoclass:: Transport
+        :members:
+        :undoc-members:
+
+    Connection
+    ----------
+
+    .. autoclass:: Connection
+        :members:
+        :undoc-members:
+
+    Channel
+    -------
+
+    .. autoclass:: Channel
+        :members:
+        :undoc-members:
+
+    Message
+    -------
+
+    .. autoclass:: Message
+        :members:
+        :undoc-members:
+

--- a/docs/userguide/connections.rst
+++ b/docs/userguide/connections.rst
@@ -10,7 +10,7 @@ Basics
 ======
 
 To send and receive messages you need a transport and a connection.
-There are several transports to choose from (amqp, librabbitmq, redis, in-memory, etc.),
+There are several transports to choose from (amqp, librabbitmq, redis, qpid, in-memory, etc.),
 and you can even create your own. The default transport is amqp.
 
 Create a connection using the default transport::
@@ -73,6 +73,9 @@ All of these are valid URLs::
     # Using Redis over a Unix socket
     redis+socket:///tmp/redis.sock
 
+    # Using Qpid
+    qpid://localhost/
+
     # Using virtual host '/foo'
     amqp://localhost//foo
 
@@ -114,10 +117,10 @@ keyword arguments, these are:
 :transport: Default transport if not provided in the URL.
   Can be a string specifying the path to the class. (e.g.
   ``kombu.transport.pyamqp:Transport``), or one of the aliases:
-  ``pyamqp``, ``librabbitmq``, ``redis``, ``memory``, and so on.
+  ``pyamqp``, ``librabbitmq``, ``redis``, ``qpid``, ``memory``, and so on.
 
 :ssl: Use SSL to connect to the server. Default is ``False``.
-  Only supported by the amqp transport.
+  Only supported by the amqp and qpid transports.
 :insist: Insist on connecting to a server.
   *No longer supported, relic from AMQP 0.8*
 :connect_timeout: Timeout in seconds for connecting to the
@@ -129,7 +132,7 @@ keyword arguments, these are:
 AMQP Transports
 ===============
 
-There are 3 transports available for AMQP use.
+There are 4 transports available for AMQP use.
 
 1. ``pyamqp`` uses the pure Python library ``amqp``, automatically
    installed with Kombu.
@@ -137,6 +140,9 @@ There are 3 transports available for AMQP use.
    This requires the ``librabbitmq`` Python package to be installed, which
    automatically compiles the C library.
 3. ``amqp`` tries to use ``librabbitmq`` but falls back to ``pyamqp``.
+4. ``qpid`` uses the pure Python library ``qpid.messaging``, automatically
+   installed with Kombu.  The Qpid library uses AMQP, but uses custom
+   extensions specifically supported by the Apache Qpid Broker.
 
 For the highest performance, you should install the ``librabbitmq`` package.
 To ensure librabbitmq is used, you can explicitly specify it in the
@@ -149,6 +155,8 @@ Transport Comparison
 | **Client**    | **Type** | **Direct** | **Topic**  | **Fanout**    |
 +---------------+----------+------------+------------+---------------+
 | *amqp*        | Native   | Yes        | Yes        | Yes           |
++---------------+----------+------------+------------+---------------+
+| *qpid*        | Native   | Yes        | Yes        | Yes           |
 +---------------+----------+------------+------------+---------------+
 | *redis*       | Virtual  | Yes        | Yes        | Yes (PUB/SUB) |
 +---------------+----------+------------+------------+---------------+

--- a/funtests/tests/test_qpid.py
+++ b/funtests/tests/test_qpid.py
@@ -1,0 +1,13 @@
+from nose import SkipTest
+
+from funtests import transport
+
+class test_qpid(transport.TransportCase):
+    transport = 'qpid'
+    prefix = 'qpid'
+
+    def before_connect(self):
+        try:
+            import qpid.messaging  # noqa
+        except ImportError:
+            raise SkipTest('qpid.messaging not installed')

--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -65,8 +65,8 @@ class Connection(object):
 
     .. admonition:: SSL compatibility
 
-        SSL currently only works with the py-amqp & amqplib transports.
-        For other transports you can use stunnel.
+        SSL currently only works with the py-amqp, amqplib, and qpid
+        transports.  For other transports you can use stunnel.
 
     :keyword hostname: Default host name/address if not provided in the URL.
     :keyword userid: Default user name if not provided in the URL.

--- a/kombu/tests/case.py
+++ b/kombu/tests/case.py
@@ -192,3 +192,28 @@ def skip_if_not_module(module, import_errors=(ImportError, )):
 
 def skip_if_quick(fun):
     return skip_if_environ('QUICKTEST')(fun)
+
+
+def case_no_pypy(cls):
+    setup = cls.setUp
+
+    @wraps(setup)
+    def around_setup(self):
+        if getattr(sys, 'pypy_version_info', None):
+            raise SkipTest('pypy incompatible')
+        setup(self)
+    cls.setUp = around_setup
+    return cls
+
+
+def case_no_python3(cls):
+    setup = cls.setUp
+
+    @wraps(setup)
+    def around_setup(self):
+        if PY3:
+            raise SkipTest('Python3 incompatible')
+        setup(self)
+    cls.setUp = around_setup
+    return cls
+

--- a/kombu/tests/transport/test_qpid.py
+++ b/kombu/tests/transport/test_qpid.py
@@ -1,0 +1,1914 @@
+from __future__ import absolute_import
+
+import datetime
+import select
+import ssl
+import socket
+import sys
+import threading
+import time
+
+from itertools import count
+
+from mock import call
+
+import kombu.five
+from kombu.transport.qpid import AuthenticationFailure, QoS, Message
+from kombu.transport.qpid import QpidMessagingExceptionHandler, Channel
+from kombu.transport.qpid import Connection, ReceiversMonitor, Transport
+from kombu.transport.qpid import ConnectionError
+from kombu.transport.virtual import Base64
+from kombu.tests.case import Case, Mock, case_no_pypy, case_no_python3
+from kombu.tests.case import patch
+from kombu.utils.compat import OrderedDict
+
+
+QPID_MODULE = 'kombu.transport.qpid'
+
+
+class ExtraAssertionsMixin(object):
+    """A mixin class adding assertDictEqual and assertDictContainsSubset"""
+
+    def assertDictEqual(self, a, b):
+        """
+        Test that two dictionaries are equal.
+
+        Implemented here because this method was not available until Python
+        2.6. This asserts that the unique set of keys are the same in a and b.
+        Also asserts that the value of each key is the same in a and b using
+        the is operator.
+        """
+        self.assertEqual(set(a.keys()), set(b.keys()))
+        for key in a.keys():
+            self.assertEqual(a[key], b[key])
+
+    def assertDictContainsSubset(self, a, b):
+        """
+        Assert that all the key/value pairs in a exist in b.
+        """
+        for key in a.keys():
+            self.assertTrue(key in b)
+            self.assertTrue(a[key] == b[key])
+
+
+class MockException(Exception):
+    pass
+
+
+class BreakOutException(Exception):
+    pass
+
+
+@case_no_python3
+@case_no_pypy
+class TestQpidMessagingExceptionHandler(Case):
+
+    allowed_string = 'object in use'
+    not_allowed_string = 'a different string'
+
+    def setUp(self):
+        """Create a mock ExceptionHandler for testing by this object."""
+        self.handler = QpidMessagingExceptionHandler(self.allowed_string)
+
+    def test_string_stored(self):
+        """Assert that the allowed_exception_string is stored correctly"""
+        handler_string = self.handler.allowed_exception_string
+        self.assertEqual(self.allowed_string, handler_string)
+
+    def test_exception_positive(self):
+        """Assert that an exception is silenced if it contains the
+        allowed_string text
+        """
+        exception_to_raise = Exception(self.allowed_string)
+
+        def exception_raise_func():
+            raise exception_to_raise
+        decorated_func = self.handler(exception_raise_func)
+        try:
+            decorated_func()
+        except:
+            self.fail("QpidMessagingExceptionHandler allowed an exception "
+                      "to be raised that should have been silenced!")
+
+    def test_exception_negative(self):
+        """Assert that an exception that does not contain the
+        allowed_string text is properly raised
+        """
+        exception_to_raise = Exception(self.not_allowed_string)
+
+        def exception_raise_func():
+            raise exception_to_raise
+        decorated_func = self.handler(exception_raise_func)
+        self.assertRaises(Exception, decorated_func)
+
+
+@case_no_python3
+@case_no_pypy
+class TestQoS__init__(Case):
+
+    def setUp(self):
+        self.mock_session = Mock()
+        self.qos = QoS(self.mock_session)
+
+    def test__init__prefetch_default_set_correct_without_prefetch_value(self):
+        self.assertEqual(self.qos.prefetch_count, 1)
+
+    def test__init__prefetch_is_hard_set_to_one(self):
+        qos_limit_two = QoS(self.mock_session)
+        self.assertEqual(qos_limit_two.prefetch_count, 1)
+
+    def test__init___not_yet_acked_is_initialized(self):
+        self.assertTrue(isinstance(self.qos._not_yet_acked, OrderedDict))
+
+
+@case_no_python3
+@case_no_pypy
+class TestQoSCanConsume(Case):
+
+    def setUp(self):
+        session = Mock()
+        self.qos = QoS(session)
+
+    def test_True_when_prefetch_limit_is_zero(self):
+        self.qos.prefetch_count = 0
+        self.qos._not_yet_acked = []
+        self.assertTrue(self.qos.can_consume())
+
+    def test_True_when_len_of__not_yet_acked_is_lt_prefetch_count(self):
+        self.qos.prefetch_count = 3
+        self.qos._not_yet_acked = ['a', 'b']
+        self.assertTrue(self.qos.can_consume())
+
+    def test_False_when_len_of__not_yet_acked_is_eq_prefetch_count(self):
+        self.qos.prefetch_count = 3
+        self.qos._not_yet_acked = ['a', 'b', 'c']
+        self.assertFalse(self.qos.can_consume())
+
+
+@case_no_python3
+@case_no_pypy
+class TestQoSCanConsumeMaxEstimate(Case):
+
+    def setUp(self):
+        self.mock_session = Mock()
+        self.qos = QoS(self.mock_session)
+
+    def test_return_one_when_prefetch_count_eq_zero(self):
+        self.qos.prefetch_count = 0
+        self.assertEqual(self.qos.can_consume_max_estimate(), 1)
+
+    def test_return_prefetch_count_sub_len__not_yet_acked(self):
+        self.qos._not_yet_acked = ['a', 'b']
+        self.qos.prefetch_count = 4
+        self.assertEqual(self.qos.can_consume_max_estimate(), 2)
+
+
+@case_no_python3
+@case_no_pypy
+class TestQoSAck(Case):
+
+    def setUp(self):
+        self.mock_session = Mock()
+        self.qos = QoS(self.mock_session)
+
+    def test_ack_pops__not_yet_acked(self):
+        message = Mock()
+        self.qos.append(message, 1)
+        self.assertTrue(1 in self.qos._not_yet_acked)
+        self.qos.ack(1)
+        self.assertTrue(1 not in self.qos._not_yet_acked)
+
+    def test_ack_calls_session_acknowledge_with_message(self):
+        message = Mock()
+        self.qos.append(message, 1)
+        self.qos.ack(1)
+        self.qos.session.acknowledge.assert_called_with(message=message)
+
+
+@case_no_python3
+@case_no_pypy
+class TestQoSReject(Case):
+
+    def setUp(self):
+        self.mock_session = Mock()
+        self.mock_message = Mock()
+        self.qos = QoS(self.mock_session)
+        self.patch_qpid = patch(QPID_MODULE + '.qpid')
+        self.mock_qpid = self.patch_qpid.start()
+        self.mock_Disposition = self.mock_qpid.messaging.Disposition
+        self.mock_RELEASED = self.mock_qpid.messaging.RELEASED
+        self.mock_REJECTED = self.mock_qpid.messaging.REJECTED
+
+    def tearDown(self):
+        self.patch_qpid.stop()
+
+    def test_reject_pops__not_yet_acked(self):
+        self.qos.append(self.mock_message, 1)
+        self.assertTrue(1 in self.qos._not_yet_acked)
+        self.qos.reject(1)
+        self.assertTrue(1 not in self.qos._not_yet_acked)
+
+    def test_reject_requeue_true(self):
+        self.qos.append(self.mock_message, 1)
+        self.qos.reject(1, requeue=True)
+        self.mock_Disposition.assert_called_with(self.mock_RELEASED)
+        self.qos.session.acknowledge.assert_called_with(
+            message=self.mock_message,
+            disposition=self.mock_Disposition.return_value)
+
+    def test_reject_requeue_false(self):
+        message = Mock()
+        self.qos.append(message, 1)
+        self.qos.reject(1, requeue=False)
+        self.mock_Disposition.assert_called_with(self.mock_REJECTED)
+        self.qos.session.acknowledge.assert_called_with(
+            message=message, disposition=self.mock_Disposition.return_value)
+
+
+@case_no_python3
+@case_no_pypy
+class TestQoS(Case):
+
+    def mock_message_factory(self):
+        """Create and return a mock message tag and delivery_tag."""
+        m_delivery_tag = self.delivery_tag_generator.next()
+        m = 'message %s' % m_delivery_tag
+        return (m, m_delivery_tag)
+
+    def add_n_messages_to_qos(self, n, qos):
+        """Add N mock messages into the passed in qos object"""
+        for i in range(n):
+            self.add_message_to_qos(qos)
+
+    def add_message_to_qos(self, qos):
+        """Add a single mock message into the passed in qos object.
+
+        Uses the mock_message_factory() to create the message and
+        delivery_tag.
+        """
+        m, m_delivery_tag = self.mock_message_factory()
+        qos.append(m, m_delivery_tag)
+
+    def setUp(self):
+        self.mock_session = Mock()
+        self.qos_no_limit = QoS(self.mock_session)
+        self.qos_limit_2 = QoS(self.mock_session, prefetch_count=2)
+        self.delivery_tag_generator = count(1)
+
+    def test_append(self):
+        """Append two messages and check inside the QoS object that they
+        were put into the internal data structures correctly
+        """
+        qos = self.qos_no_limit
+        m1, m1_tag = self.mock_message_factory()
+        m2, m2_tag = self.mock_message_factory()
+        qos.append(m1, m1_tag)
+        length_not_yet_acked = len(qos._not_yet_acked)
+        self.assertEqual(length_not_yet_acked, 1)
+        checked_message1 = qos._not_yet_acked[m1_tag]
+        self.assertTrue(m1 is checked_message1)
+        qos.append(m2, m2_tag)
+        length_not_yet_acked = len(qos._not_yet_acked)
+        self.assertEqual(length_not_yet_acked, 2)
+        checked_message2 = qos._not_yet_acked[m2_tag]
+        self.assertTrue(m2 is checked_message2)
+
+    def test_get(self):
+        """Append two messages, and use get to receive them"""
+        qos = self.qos_no_limit
+        m1, m1_tag = self.mock_message_factory()
+        m2, m2_tag = self.mock_message_factory()
+        qos.append(m1, m1_tag)
+        qos.append(m2, m2_tag)
+        message1 = qos.get(m1_tag)
+        message2 = qos.get(m2_tag)
+        self.assertTrue(m1 is message1)
+        self.assertTrue(m2 is message2)
+
+
+@case_no_python3
+@case_no_pypy
+class ConnectionTestBase(Case):
+
+    @patch(QPID_MODULE + '.qpid')
+    def setUp(self, mock_qpid):
+        self.connection_options = {'host': 'localhost',
+                                   'port': 5672,
+                                   'username': 'guest',
+                                   'password': '',
+                                   'transport': 'tcp',
+                                   'timeout': 10,
+                                   'sasl_mechanisms': 'ANONYMOUS PLAIN'}
+        self.mock_qpid_connection = mock_qpid.messaging.Connection
+        self.conn = Connection(**self.connection_options)
+
+
+@case_no_python3
+@case_no_pypy
+class TestConnectionInit(ExtraAssertionsMixin, ConnectionTestBase):
+
+    def test_connection__init__stores_connection_options(self):
+        # ensure that only one mech was passed into connection. The other
+        # options should all be passed through as-is
+        modified_conn_opts = self.connection_options
+        modified_conn_opts['sasl_mechanisms'] = 'PLAIN'
+        self.assertDictEqual(modified_conn_opts,
+                             self.conn.connection_options)
+
+    def test_connection__init__variables(self):
+        self.assertTrue(isinstance(self.conn.channels, list))
+        self.assertTrue(isinstance(self.conn._callbacks, dict))
+
+    def test_connection__init__establishes_connection(self):
+        modified_conn_opts = self.connection_options
+        modified_conn_opts['sasl_mechanisms'] = 'PLAIN'
+        self.mock_qpid_connection.establish.assert_called_with(**modified_conn_opts)
+
+    def test_connection__init__saves_established_connection(self):
+        created_conn = self.mock_qpid_connection.establish.return_value
+        self.assertTrue(self.conn._qpid_conn is created_conn)
+
+    @patch(QPID_MODULE + '.ConnectionError', new=(MockException, ))
+    @patch(QPID_MODULE + '.sys.exc_info')
+    @patch(QPID_MODULE + '.qpid')
+    def test_connection__init__mutates_ConnError_by_message(self, mock_qpid,
+                                                            mock_exc_info):
+        my_conn_error = MockException()
+        my_conn_error.text = 'connection-forced: Authentication failed(320)'
+        mock_qpid.messaging.Connection.establish.side_effect = my_conn_error
+        mock_exc_info.return_value = ('a', 'b', None)
+        try:
+            self.conn = Connection(**self.connection_options)
+        except AuthenticationFailure as error:
+            exc_info = sys.exc_info()
+            self.assertTrue(not isinstance(error, MockException))
+            self.assertTrue(exc_info[1] is 'b')
+            self.assertTrue(exc_info[2] is None)
+        else:
+            self.fail('ConnectionError type was not mutated correctly')
+
+    @patch(QPID_MODULE + '.ConnectionError', new=(MockException, ))
+    @patch(QPID_MODULE + '.sys.exc_info')
+    @patch(QPID_MODULE + '.qpid')
+    def test_connection__init__mutates_ConnError_by_code(self, mock_qpid,
+                                                         mock_exc_info):
+        my_conn_error = MockException()
+        my_conn_error.code = 320
+        my_conn_error.text = 'someothertext'
+        mock_qpid.messaging.Connection.establish.side_effect = my_conn_error
+        mock_exc_info.return_value = ('a', 'b', None)
+        try:
+            self.conn = Connection(**self.connection_options)
+        except AuthenticationFailure as error:
+            exc_info = sys.exc_info()
+            self.assertTrue(not isinstance(error, MockException))
+            self.assertTrue(exc_info[1] is 'b')
+            self.assertTrue(exc_info[2] is None)
+        else:
+            self.fail('ConnectionError type was not mutated correctly')
+
+    @patch(QPID_MODULE + '.ConnectionError', new=(MockException, ))
+    @patch(QPID_MODULE + '.sys.exc_info')
+    @patch(QPID_MODULE + '.qpid')
+    def test_connection__init__unknown_connection_error(self, mock_qpid, mock_exc_info):
+        # If we get a connection error that we don't understand, bubble it up as-is
+        my_conn_error = MockException()
+        my_conn_error.code = 999
+        my_conn_error.text = 'someothertext'
+        mock_qpid.messaging.Connection.establish.side_effect = my_conn_error
+        mock_exc_info.return_value = ('a', 'b', None)
+        try:
+            self.conn = Connection(**self.connection_options)
+        except Exception as error:
+            self.assertTrue(error.code == 999)
+        else:
+            self.fail("Connection should have thrown an exception")
+
+    @patch.object(Transport, 'channel_errors', new=(MockException, ))
+    @patch(QPID_MODULE + '.qpid')
+    @patch(QPID_MODULE + '.ConnectionError', new=IOError)
+    def test_connection__init__non_qpid_error_raises(self, mock_qpid):
+        mock_Qpid_Connection = mock_qpid.messaging.Connection
+        my_conn_error = SyntaxError()
+        my_conn_error.text = 'some non auth related error message'
+        mock_Qpid_Connection.establish.side_effect = my_conn_error
+        self.assertRaises(SyntaxError, Connection, **self.connection_options)
+
+    @patch(QPID_MODULE + '.qpid')
+    @patch(QPID_MODULE + '.ConnectionError', new=IOError)
+    def test_connection__init__non_auth_conn_error_raises(self, mock_qpid):
+        mock_Qpid_Connection = mock_qpid.messaging.Connection
+        my_conn_error = IOError()
+        my_conn_error.text = 'some non auth related error message'
+        mock_Qpid_Connection.establish.side_effect = my_conn_error
+        self.assertRaises(IOError, Connection, **self.connection_options)
+
+
+@case_no_python3
+@case_no_pypy
+class TestConnectionClassAttributes(ConnectionTestBase):
+
+    def test_connection_verify_class_attributes(self):
+        self.assertEqual(Channel, Connection.Channel)
+
+
+@case_no_python3
+@case_no_pypy
+class TestConnectionGetQpidConnection(ConnectionTestBase):
+
+    def test_connection_get_qpid_connection(self):
+        self.conn._qpid_conn = Mock()
+        returned_connection = self.conn.get_qpid_connection()
+        self.assertTrue(self.conn._qpid_conn is returned_connection)
+
+
+@case_no_python3
+@case_no_pypy
+class TestConnectionCloseChannel(ConnectionTestBase):
+
+    def setUp(self):
+        super(TestConnectionCloseChannel, self).setUp()
+        self.conn.channels = Mock()
+
+    def test_connection_close_channel_removes_channel_from_channel_list(self):
+        mock_channel = Mock()
+        self.conn.close_channel(mock_channel)
+        self.conn.channels.remove.assert_called_once_with(mock_channel)
+
+    def test_connection_close_channel_handles_ValueError_being_raised(self):
+        self.conn.channels.remove = Mock(side_effect=ValueError())
+        try:
+            self.conn.close_channel(Mock())
+        except ValueError:
+            self.fail('ValueError should not have been raised')
+
+    def test_connection_close_channel_set_channel_connection_to_None(self):
+        mock_channel = Mock()
+        mock_channel.connection = False
+        self.conn.channels.remove = Mock(side_effect=ValueError())
+        self.conn.close_channel(mock_channel)
+        self.assertTrue(mock_channel.connection is None)
+
+
+@case_no_python3
+@case_no_pypy
+class ChannelTestBase(Case):
+
+    def setUp(self):
+        self.patch_qpidtoollibs = patch(QPID_MODULE + '.qpidtoollibs')
+        self.mock_qpidtoollibs = self.patch_qpidtoollibs.start()
+        self.mock_broker_agent = self.mock_qpidtoollibs.BrokerAgent
+        self.conn = Mock()
+        self.transport = Mock()
+        self.channel = Channel(self.conn, self.transport)
+
+    def tearDown(self):
+        self.patch_qpidtoollibs.stop()
+
+
+@case_no_python3
+@case_no_pypy
+class TestChannelPurge(ChannelTestBase):
+
+    def setUp(self):
+        super(TestChannelPurge, self).setUp()
+        self.mock_queue = Mock()
+
+    def test_channel__purge_gets_queue(self):
+        self.channel._purge(self.mock_queue)
+        getQueue = self.mock_broker_agent.return_value.getQueue
+        getQueue.assert_called_once_with(self.mock_queue)
+
+    def test_channel__purge_does_not_call_purge_if_message_count_is_zero(self):
+        values = {'msgDepth': 0}
+        queue_obj = self.mock_broker_agent.return_value.getQueue.return_value
+        queue_obj.values = values
+        self.channel._purge(self.mock_queue)
+        self.assertTrue(not queue_obj.purge.called)
+
+    def test_channel__purge_purges_all_messages_from_queue(self):
+        values = {'msgDepth': 5}
+        queue_obj = self.mock_broker_agent.return_value.getQueue.return_value
+        queue_obj.values = values
+        self.channel._purge(self.mock_queue)
+        queue_obj.purge.assert_called_with(5)
+
+    def test_channel__purge_returns_message_count(self):
+        values = {'msgDepth': 5}
+        queue_obj = self.mock_broker_agent.return_value.getQueue.return_value
+        queue_obj.values = values
+        result = self.channel._purge(self.mock_queue)
+        self.assertTrue(result is 5)
+
+
+@case_no_python3
+@case_no_pypy
+class TestChannelPut(ChannelTestBase):
+
+    @patch(QPID_MODULE + '.qpid')
+    def test_channel__put_onto_queue(self, mock_qpid):
+        routing_key = 'routingkey'
+        mock_message = Mock()
+        mock_Message_cls = mock_qpid.messaging.Message
+
+        self.channel._put(routing_key, mock_message)
+
+        address_string = '%s; {assert: always, node: {type: queue}}' % \
+                         routing_key
+        self.transport.session.sender.assert_called_with(address_string)
+        mock_Message_cls.assert_called_with(content=mock_message,
+                                            subject=None)
+        mock_sender = self.transport.session.sender.return_value
+        mock_sender.send.assert_called_with(mock_Message_cls.return_value,
+                                            sync=True)
+        mock_sender.close.assert_called_with()
+
+    @patch(QPID_MODULE + '.qpid')
+    def test_channel__put_onto_exchange(self, mock_qpid):
+        mock_routing_key = 'routingkey'
+        mock_exchange_name = 'myexchange'
+        mock_message = Mock()
+        mock_Message_cls = mock_qpid.messaging.Message
+
+        self.channel._put(mock_routing_key, mock_message, mock_exchange_name)
+
+        address_string = '%s/%s; {assert: always, node: {type: topic}}' % \
+                         (mock_exchange_name, mock_routing_key)
+        self.transport.session.sender.assert_called_with(address_string)
+        mock_Message_cls.assert_called_with(content=mock_message,
+                                            subject=mock_routing_key)
+        mock_sender = self.transport.session.sender.return_value
+        mock_sender.send.assert_called_with(mock_Message_cls.return_value,
+                                            sync=True)
+        mock_sender.close.assert_called_with()
+
+
+@case_no_python3
+@case_no_pypy
+class TestChannelGet(ChannelTestBase):
+
+    def test_channel__get(self):
+        mock_queue = Mock()
+
+        result = self.channel._get(mock_queue)
+
+        self.transport.session.receiver.assert_called_once_with(mock_queue)
+        mock_rx = self.transport.session.receiver.return_value
+        mock_rx.fetch.assert_called_once_with(timeout=0)
+        mock_rx.close.assert_called_once_with()
+        self.assertTrue(mock_rx.fetch.return_value is result)
+
+
+@case_no_python3
+@case_no_pypy
+class TestChannelClose(ChannelTestBase):
+
+    def setUp(self):
+        super(TestChannelClose, self).setUp()
+        self.patch_basic_cancel = patch.object(self.channel, 'basic_cancel')
+        self.mock_basic_cancel = self.patch_basic_cancel.start()
+        self.mock_receiver1 = Mock()
+        self.mock_receiver2 = Mock()
+        self.channel._receivers = {1: self.mock_receiver1,
+                                   2: self.mock_receiver2}
+        self.channel.closed = False
+
+    def tearDown(self):
+        self.patch_basic_cancel.stop()
+        super(TestChannelClose, self).tearDown()
+
+    def test_channel_close_sets_close_attribute(self):
+        self.channel.close()
+        self.assertTrue(self.channel.closed)
+
+    def test_channel_close_calls_basic_cancel_on_all_receivers(self):
+        self.channel.close()
+        self.mock_basic_cancel.assert_has_calls([call(1), call(2)])
+
+    def test_channel_close_calls_close_channel_on_connection(self):
+        self.channel.close()
+        self.conn.close_channel.assert_called_once_with(self.channel)
+
+    def test_channel_close_calls_close_on_broker_agent(self):
+        self.channel.close()
+        self.channel._broker.close.assert_called_once_with()
+
+    def test_channel_close_does_nothing_if_already_closed(self):
+        self.channel.closed = True
+        self.channel.close()
+        self.assertTrue(not self.mock_basic_cancel.called)
+
+    def test_channel_close_does_not_call_close_channel_if_conn_is_None(self):
+        self.channel.connection = None
+        self.channel.close()
+        self.assertTrue(not self.conn.close_channel.called)
+
+
+@case_no_python3
+@case_no_pypy
+class TestChannelBasicQoS(ChannelTestBase):
+
+    def test_channel_basic_qos_always_returns_one(self):
+        self.channel.basic_qos(2)
+        self.assertTrue(self.channel.qos.prefetch_count is 1)
+
+
+@case_no_python3
+@case_no_pypy
+class TestChannelBasicGet(ChannelTestBase):
+
+    def setUp(self):
+        super(TestChannelBasicGet, self).setUp()
+        self.channel.Message = Mock()
+        self.channel._get = Mock()
+
+    def test_channel_basic_get_calls__get_with_queue(self):
+        mock_queue = Mock()
+        self.channel.basic_get(mock_queue)
+        self.channel._get.assert_called_once_with(mock_queue)
+
+    def test_channel_basic_get_creates_Message_correctly(self):
+        mock_queue = Mock()
+        self.channel.basic_get(mock_queue)
+        mock_raw_message = self.channel._get.return_value.content
+        self.channel.Message.assert_called_once_with(self.channel,
+                                                     mock_raw_message)
+
+    def test_channel_basic_get_acknowledges_message_by_default(self):
+        mock_queue = Mock()
+        self.channel.basic_get(mock_queue)
+        mock_qpid_message = self.channel._get.return_value
+        acknowledge = self.transport.session.acknowledge
+        acknowledge.assert_called_once_with(message=mock_qpid_message)
+
+    def test_channel_basic_get_acknowledges_message_with_no_ack_False(self):
+        mock_queue = Mock()
+        self.channel.basic_get(mock_queue, no_ack=False)
+        mock_qpid_message = self.channel._get.return_value
+        acknowledge = self.transport.session.acknowledge
+        acknowledge.assert_called_once_with(message=mock_qpid_message)
+
+    def test_channel_basic_get_acknowledges_message_with_no_ack_True(self):
+        mock_queue = Mock()
+        self.channel.basic_get(mock_queue, no_ack=True)
+        mock_qpid_message = self.channel._get.return_value
+        acknowledge = self.transport.session.acknowledge
+        acknowledge.assert_called_once_with(message=mock_qpid_message)
+
+    def test_channel_basic_get_returns_correct_message(self):
+        mock_queue = Mock()
+        basic_get_result = self.channel.basic_get(mock_queue)
+        expected_message = self.channel.Message.return_value
+        self.assertTrue(expected_message is basic_get_result)
+
+    def test_basic_get_returns_None_when_channel__get_raises_Empty(self):
+        mock_queue = Mock()
+        self.channel._get = Mock(side_effect=kombu.five.Empty)
+        basic_get_result = self.channel.basic_get(mock_queue)
+        self.assertEqual(self.channel.Message.call_count, 0)
+        self.assertTrue(basic_get_result is None)
+
+
+@case_no_python3
+@case_no_pypy
+class TestChannelBasicCancel(ChannelTestBase):
+
+    def setUp(self):
+        super(TestChannelBasicCancel, self).setUp()
+        self.channel._receivers = {1: Mock()}
+
+    def test_channel_basic_cancel_no_error_if_consumer_tag_not_found(self):
+        self.channel.basic_cancel(2)
+
+    def test_channel_basic_cancel_pops_receiver(self):
+        self.channel.basic_cancel(1)
+        self.assertTrue(1 not in self.channel._receivers)
+
+    def test_channel_basic_cancel_closes_receiver(self):
+        mock_receiver = self.channel._receivers[1]
+        self.channel.basic_cancel(1)
+        mock_receiver.close.assert_called_once_with()
+
+    def test_channel_basic_cancel_pops__tag_to_queue(self):
+        self.channel._tag_to_queue = Mock()
+        self.channel.basic_cancel(1)
+        self.channel._tag_to_queue.pop.assert_called_once_with(1, None)
+
+    def test_channel_basic_cancel_pops_connection__callbacks(self):
+        self.channel._tag_to_queue = Mock()
+        self.channel.basic_cancel(1)
+        mock_queue = self.channel._tag_to_queue.pop.return_value
+        self.conn._callbacks.pop.assert_called_once_with(mock_queue, None)
+
+
+@case_no_python3
+@case_no_pypy
+class TestChannelInit(ChannelTestBase, ExtraAssertionsMixin):
+
+    def test_channel___init__sets_variables_as_expected(self):
+        self.assertTrue(self.conn is self.channel.connection)
+        self.assertTrue(self.transport is self.channel.transport)
+        self.assertFalse(self.channel.closed)
+        self.conn.get_qpid_connection.assert_called_once_with()
+        expected_broker_agent = self.mock_broker_agent.return_value
+        self.assertTrue(self.channel._broker is expected_broker_agent)
+        self.assertDictEqual(self.channel._tag_to_queue, {})
+        self.assertDictEqual(self.channel._receivers, {})
+        self.assertTrue(self.channel._qos is None)
+
+
+@case_no_python3
+@case_no_pypy
+class TestChannelBasicConsume(ChannelTestBase, ExtraAssertionsMixin):
+
+    def setUp(self):
+        super(TestChannelBasicConsume, self).setUp()
+        self.conn._callbacks = {}
+
+    def test_channel_basic_consume_adds_queue_to__tag_to_queue(self):
+        mock_tag = Mock()
+        mock_queue = Mock()
+        self.channel.basic_consume(mock_queue, Mock(), Mock(), mock_tag)
+        expected_dict = {mock_tag: mock_queue}
+        self.assertDictEqual(expected_dict, self.channel._tag_to_queue)
+
+    def test_channel_basic_consume_adds_entry_to_connection__callbacks(self):
+        mock_queue = Mock()
+        self.channel.basic_consume(mock_queue, Mock(), Mock(), Mock())
+        self.assertTrue(mock_queue in self.conn._callbacks)
+        if not hasattr(self.conn._callbacks[mock_queue], '__call__'):
+            self.fail('Callback stored must be callable')
+
+    def test_channel_basic_consume_creates_new_receiver(self):
+        mock_queue = Mock()
+        self.channel.basic_consume(mock_queue, Mock(), Mock(), Mock())
+        self.transport.session.receiver.assert_called_once_with(mock_queue)
+
+    def test_channel_basic_consume_saves_new_receiver(self):
+        mock_tag = Mock()
+        self.channel.basic_consume(Mock(), Mock(), Mock(), mock_tag)
+        new_mock_receiver = self.transport.session.receiver.return_value
+        expected_dict = {mock_tag: new_mock_receiver}
+        self.assertDictEqual(expected_dict, self.channel._receivers)
+
+    def test_channel_basic_consume_sets_capacity_on_new_receiver(self):
+        mock_prefetch_count = Mock()
+        self.channel.qos.prefetch_count = mock_prefetch_count
+        self.channel.basic_consume(Mock(), Mock(), Mock(), Mock())
+        new_receiver = self.transport.session.receiver.return_value
+        self.assertTrue(new_receiver.capacity is mock_prefetch_count)
+
+    def get_callback(self, no_ack=Mock(), original_cb=Mock()):
+        self.channel.Message = Mock()
+        mock_queue = Mock()
+        self.channel.basic_consume(mock_queue, no_ack, original_cb, Mock())
+        return self.conn._callbacks[mock_queue]
+
+    def test_channel_basic_consume_callback_creates_Message_correctly(self):
+        callback = self.get_callback()
+        mock_qpid_message = Mock()
+        callback(mock_qpid_message)
+        mock_content = mock_qpid_message.content
+        self.channel.Message.assert_called_once_with(self.channel,
+                                                     mock_content)
+
+    def test_channel_basic_consume_callback_adds_message_to_QoS(self):
+        self.channel._qos = Mock()
+        callback = self.get_callback()
+        mock_qpid_message = Mock()
+        callback(mock_qpid_message)
+        mock_delivery_tag = self.channel.Message.return_value.delivery_tag
+        self.channel._qos.append.assert_called_once_with(mock_qpid_message,
+                                                         mock_delivery_tag)
+
+    def test_channel_basic_consume_callback_gratuitously_acks(self):
+        self.channel.basic_ack = Mock()
+        callback = self.get_callback()
+        mock_qpid_message = Mock()
+        callback(mock_qpid_message)
+        mock_delivery_tag = self.channel.Message.return_value.delivery_tag
+        self.channel.basic_ack.assert_called_once_with(mock_delivery_tag)
+
+    def test_channel_basic_consume_callback_does_not_ack_when_needed(self):
+        self.channel.basic_ack = Mock()
+        callback = self.get_callback(no_ack=False)
+        mock_qpid_message = Mock()
+        callback(mock_qpid_message)
+        self.assertTrue(not self.channel.basic_ack.called)
+
+    def test_channel_basic_consume_callback_calls_real_callback(self):
+        self.channel.basic_ack = Mock()
+        mock_original_callback = Mock()
+        callback = self.get_callback(original_cb=mock_original_callback)
+        mock_qpid_message = Mock()
+        callback(mock_qpid_message)
+        expected_message = self.channel.Message.return_value
+        mock_original_callback.assert_called_once_with(expected_message)
+
+
+@case_no_python3
+@case_no_pypy
+class TestChannelQueueDelete(ChannelTestBase):
+
+    def setUp(self):
+        super(TestChannelQueueDelete, self).setUp()
+        self.patch__has_queue = patch.object(self.channel, '_has_queue')
+        self.mock__has_queue = self.patch__has_queue.start()
+        self.patch__size = patch.object(self.channel, '_size')
+        self.mock__size = self.patch__size.start()
+        self.patch__delete = patch.object(self.channel, '_delete')
+        self.mock__delete = self.patch__delete.start()
+        self.mock_queue = Mock()
+
+    def tearDown(self):
+        self.mock__has_queue.stop()
+        self.mock__size.stop()
+        self.mock__delete.stop()
+        super(TestChannelQueueDelete, self).tearDown()
+
+    def test_channel_queue_delete_checks_if_queue_exists(self):
+        self.channel.queue_delete(self.mock_queue)
+        self.mock__has_queue.assert_called_once_with(self.mock_queue)
+
+    def test_channel_queue_delete_does_nothing_if_queue_does_not_exist(self):
+        self.mock__has_queue.return_value = False
+        self.channel.queue_delete(self.mock_queue)
+        self.assertTrue(not self.mock__delete.called)
+
+    def test_channel_queue_delete__not_empty_and_if_empty_True_no_delete(self):
+        self.mock__size.return_value = 1
+        self.channel.queue_delete(self.mock_queue, if_empty=True)
+        mock_broker = self.mock_broker_agent.return_value
+        self.assertTrue(not mock_broker.getQueue.called)
+
+    def test_channel_queue_delete_calls_get_queue(self):
+        self.channel.queue_delete(self.mock_queue)
+        getQueue = self.mock_broker_agent.return_value.getQueue
+        getQueue.assert_called_once_with(self.mock_queue)
+
+    def test_channel_queue_delete_gets_queue_attribute(self):
+        self.channel.queue_delete(self.mock_queue)
+        queue_obj = self.mock_broker_agent.return_value.getQueue.return_value
+        queue_obj.getAttributes.assert_called_once_with()
+
+    def test_channel_queue_delete__queue_in_use_and_if_unused_no_delete(self):
+        queue_obj = self.mock_broker_agent.return_value.getQueue.return_value
+        queue_obj.getAttributes.return_value = {'consumerCount': 1}
+        self.channel.queue_delete(self.mock_queue, if_unused=True)
+        self.assertTrue(not self.mock__delete.called)
+
+    def test_channel_queue_delete_calls__delete_with_queue(self):
+        self.channel.queue_delete(self.mock_queue)
+        self.mock__delete.assert_called_once_with(self.mock_queue)
+
+
+@case_no_python3
+@case_no_pypy
+class TestChannel(ExtraAssertionsMixin, Case):
+
+    @patch(QPID_MODULE + '.qpidtoollibs')
+    def setUp(self, mock_qpidtoollibs):
+        self.mock_connection = Mock()
+        self.mock_qpid_connection = Mock()
+        self.mock_qpid_session = Mock()
+        self.mock_qpid_connection.session = \
+            Mock(return_value=self.mock_qpid_session)
+        self.mock_connection.get_qpid_connection = \
+            Mock(return_value=self.mock_qpid_connection)
+        self.mock_transport = Mock()
+        self.mock_broker = Mock()
+        self.mock_Message = Mock()
+        self.mock_BrokerAgent = mock_qpidtoollibs.BrokerAgent
+        self.mock_BrokerAgent.return_value = self.mock_broker
+        self.my_channel = Channel(self.mock_connection,
+                                  self.mock_transport)
+        self.my_channel.Message = self.mock_Message
+
+    def test_verify_QoS_class_attribute(self):
+        """Verify that the class attribute QoS refers to the QoS object"""
+        self.assertTrue(QoS is Channel.QoS)
+
+    def test_verify_Message_class_attribute(self):
+        """Verify that the class attribute Message refers to the Message
+        object
+        """
+        self.assertTrue(Message is Channel.Message)
+
+    def test_body_encoding_class_attribute(self):
+        """Verify that the class attribute body_encoding is set to base64"""
+        self.assertEqual('base64', Channel.body_encoding)
+
+    def test_codecs_class_attribute(self):
+        """Verify that the codecs class attribute has a correct key and
+        value
+        """
+        self.assertTrue(isinstance(Channel.codecs, dict))
+        self.assertTrue('base64' in Channel.codecs)
+        self.assertTrue(isinstance(Channel.codecs['base64'], Base64))
+
+    def test_delivery_tags(self):
+        """Test that _delivery_tags is using itertools"""
+        self.assertTrue(isinstance(Channel._delivery_tags, count))
+
+    def test_size(self):
+        """Test getting the number of messages in a queue specified by
+        name and returning them.
+        """
+        message_count = 5
+        mock_queue = Mock()
+        mock_queue_to_check = Mock()
+        mock_queue_to_check.values = {'msgDepth': message_count}
+        self.mock_broker.getQueue.return_value = mock_queue_to_check
+        result = self.my_channel._size(mock_queue)
+        self.mock_broker.getQueue.assert_called_with(mock_queue)
+        self.assertEqual(message_count, result)
+
+    def test_delete(self):
+        """Test deleting a queue calls purge and delQueue with queue name"""
+        mock_queue = Mock()
+        self.my_channel._purge = Mock()
+        result = self.my_channel._delete(mock_queue)
+        self.my_channel._purge.assert_called_with(mock_queue)
+        self.mock_broker.delQueue.assert_called_with(mock_queue)
+        self.assertTrue(result is None)
+
+    def test_has_queue_true(self):
+        """Test checking if a queue exists, and it does"""
+        mock_queue = Mock()
+        self.mock_broker.getQueue.return_value = True
+        result = self.my_channel._has_queue(mock_queue)
+        self.assertTrue(result)
+
+    def test_has_queue_false(self):
+        """Test checking if a queue exists, and it does not"""
+        mock_queue = Mock()
+        self.mock_broker.getQueue.return_value = False
+        result = self.my_channel._has_queue(mock_queue)
+        self.assertFalse(result)
+
+    @patch('amqp.protocol.queue_declare_ok_t')
+    def test_queue_declare_with_exception_raised(self,
+                                                 mock_queue_declare_ok_t):
+        """Test declare_queue, where an exception is raised and silenced"""
+        mock_queue = Mock()
+        mock_passive = Mock()
+        mock_durable = Mock()
+        mock_exclusive = Mock()
+        mock_auto_delete = Mock()
+        mock_nowait = Mock()
+        mock_arguments = Mock()
+        mock_msg_count = Mock()
+        mock_queue.startswith.return_value = False
+        mock_queue.endswith.return_value = False
+        options = {'passive': mock_passive,
+                   'durable': mock_durable,
+                   'exclusive': mock_exclusive,
+                   'auto-delete': mock_auto_delete,
+                   'arguments': mock_arguments}
+        mock_consumer_count = Mock()
+        mock_return_value = Mock()
+        values_dict = {'msgDepth': mock_msg_count,
+                       'consumerCount': mock_consumer_count}
+        mock_queue_data = Mock()
+        mock_queue_data.values = values_dict
+        exception_to_raise = Exception('The foo object already exists.')
+        self.mock_broker.addQueue.side_effect = exception_to_raise
+        self.mock_broker.getQueue.return_value = mock_queue_data
+        mock_queue_declare_ok_t.return_value = mock_return_value
+        result = self.my_channel.queue_declare(mock_queue,
+                                               passive=mock_passive,
+                                               durable=mock_durable,
+                                               exclusive=mock_exclusive,
+                                               auto_delete=mock_auto_delete,
+                                               nowait=mock_nowait,
+                                               arguments=mock_arguments,
+                                               )
+        self.mock_broker.addQueue.assert_called_with(mock_queue,
+                                                     options=options)
+        mock_queue_declare_ok_t.assert_called_with(mock_queue,
+                                                   mock_msg_count,
+                                                   mock_consumer_count)
+        self.assertTrue(mock_return_value is result)
+
+    def test_queue_declare_set_ring_policy_for_celeryev(self):
+        """Test declare_queue sets ring_policy for celeryev"""
+        mock_queue = Mock()
+        mock_queue.startswith.return_value = True
+        mock_queue.endswith.return_value = False
+        expected_default_options = {'passive': False,
+                                    'durable': False,
+                                    'exclusive': False,
+                                    'auto-delete': True,
+                                    'arguments': None,
+                                    'qpid.policy_type': 'ring'}
+        mock_msg_count = Mock()
+        mock_consumer_count = Mock()
+        values_dict = {'msgDepth': mock_msg_count,
+                       'consumerCount': mock_consumer_count}
+        mock_queue_data = Mock()
+        mock_queue_data.values = values_dict
+        self.mock_broker.addQueue.return_value = None
+        self.mock_broker.getQueue.return_value = mock_queue_data
+        self.my_channel.queue_declare(mock_queue)
+        mock_queue.startswith.assert_called_with('celeryev')
+        self.mock_broker.addQueue.assert_called_with(
+            mock_queue, options=expected_default_options)
+
+    def test_queue_declare_set_ring_policy_for_pidbox(self):
+        """Test declare_queue sets ring_policy for pidbox"""
+        mock_queue = Mock()
+        mock_queue.startswith.return_value = False
+        mock_queue.endswith.return_value = True
+        expected_default_options = {'passive': False,
+                                    'durable': False,
+                                    'exclusive': False,
+                                    'auto-delete': True,
+                                    'arguments': None,
+                                    'qpid.policy_type': 'ring'}
+        mock_msg_count = Mock()
+        mock_consumer_count = Mock()
+        values_dict = {'msgDepth': mock_msg_count,
+                       'consumerCount': mock_consumer_count}
+        mock_queue_data = Mock()
+        mock_queue_data.values = values_dict
+        self.mock_broker.addQueue.return_value = None
+        self.mock_broker.getQueue.return_value = mock_queue_data
+        self.my_channel.queue_declare(mock_queue)
+        mock_queue.endswith.assert_called_with('pidbox')
+        self.mock_broker.addQueue.assert_called_with(
+            mock_queue, options=expected_default_options)
+
+    def test_queue_declare_ring_policy_not_set_as_expected(self):
+        """Test declare_queue does not set ring_policy as expected"""
+        mock_queue = Mock()
+        mock_queue.startswith.return_value = False
+        mock_queue.endswith.return_value = False
+        expected_default_options = {'passive': False,
+                                    'durable': False,
+                                    'exclusive': False,
+                                    'auto-delete': True,
+                                    'arguments': None}
+        mock_msg_count = Mock()
+        mock_consumer_count = Mock()
+        values_dict = {'msgDepth': mock_msg_count,
+                       'consumerCount': mock_consumer_count}
+        mock_queue_data = Mock()
+        mock_queue_data.values = values_dict
+        self.mock_broker.addQueue.return_value = None
+        self.mock_broker.getQueue.return_value = mock_queue_data
+        self.my_channel.queue_declare(mock_queue)
+        mock_queue.startswith.assert_called_with('celeryev')
+        mock_queue.endswith.assert_called_with('pidbox')
+        self.mock_broker.addQueue.assert_called_with(
+            mock_queue, options=expected_default_options)
+
+    def test_queue_declare_test_defaults(self):
+        """Test declare_queue defaults"""
+        mock_queue = Mock()
+        mock_queue.startswith.return_value = False
+        mock_queue.endswith.return_value = False
+        expected_default_options = {'passive': False,
+                                    'durable': False,
+                                    'exclusive': False,
+                                    'auto-delete': True,
+                                    'arguments': None}
+        mock_msg_count = Mock()
+        mock_consumer_count = Mock()
+        values_dict = {'msgDepth': mock_msg_count,
+                       'consumerCount': mock_consumer_count}
+        mock_queue_data = Mock()
+        mock_queue_data.values = values_dict
+        self.mock_broker.addQueue.return_value = None
+        self.mock_broker.getQueue.return_value = mock_queue_data
+        self.my_channel.queue_declare(mock_queue)
+        self.mock_broker.addQueue.assert_called_with(
+            mock_queue,
+            options=expected_default_options)
+
+    def test_queue_declare_raises_exception_not_silenced(self):
+        unique_exception = Exception('This exception should not be silenced')
+        mock_queue = Mock()
+        self.mock_broker.addQueue.side_effect = unique_exception
+        self.assertRaises(unique_exception.__class__,
+                          self.my_channel.queue_declare,
+                          mock_queue)
+        self.mock_broker.addQueue.assert_called_once()
+
+    def test_exchange_declare_raises_exception_and_silenced(self):
+        """Create exchange where an exception is raised and then silenced"""
+        self.mock_broker.addExchange.side_effect = \
+            Exception('The foo object already exists.')
+        self.my_channel.exchange_declare()
+
+    def test_exchange_declare_raises_exception_not_silenced(self):
+        """Create Exchange where an exception is raised and not silenced"""
+        unique_exception = Exception('This exception should not be silenced')
+        self.mock_broker.addExchange.side_effect = unique_exception
+        self.assertRaises(unique_exception.__class__,
+                          self.my_channel.exchange_declare)
+
+    def test_exchange_declare(self):
+        """Create Exchange where an exception is NOT raised"""
+        mock_exchange = Mock()
+        mock_type = Mock()
+        mock_durable = Mock()
+        options = {'durable': mock_durable}
+        result = self.my_channel.exchange_declare(mock_exchange,
+                                                  mock_type,
+                                                  mock_durable)
+        self.mock_broker.addExchange.assert_called_with(mock_type,
+                                                        mock_exchange,
+                                                        options)
+        self.assertTrue(result is None)
+
+    def test_exchange_delete(self):
+        """Test the deletion of an exchange by name"""
+        mock_exchange = Mock()
+        result = self.my_channel.exchange_delete(mock_exchange)
+        self.mock_broker.delExchange.assert_called_with(mock_exchange)
+        self.assertTrue(result is None)
+
+    def test_queue_bind(self):
+        """Test binding a queue to an exchange using a routing key"""
+        mock_queue = Mock()
+        mock_exchange = Mock()
+        mock_routing_key = Mock()
+        self.my_channel.queue_bind(mock_queue,
+                                   mock_exchange,
+                                   mock_routing_key)
+        self.mock_broker.bind.assert_called_with(mock_exchange,
+                                                 mock_queue,
+                                                 mock_routing_key)
+
+    def test_queue_unbind(self):
+        """Test unbinding a queue from an exchange using a routing key"""
+        mock_queue = Mock()
+        mock_exchange = Mock()
+        mock_routing_key = Mock()
+        self.my_channel.queue_unbind(mock_queue,
+                                     mock_exchange,
+                                     mock_routing_key)
+        self.mock_broker.unbind.assert_called_with(mock_exchange,
+                                                   mock_queue,
+                                                   mock_routing_key)
+
+    def test_queue_purge(self):
+        """Test purging a queue by name"""
+        mock_queue = Mock()
+        purge_result = Mock()
+        self.my_channel._purge = Mock(return_value=purge_result)
+        result = self.my_channel.queue_purge(mock_queue)
+        self.my_channel._purge.assert_called_with(mock_queue)
+        self.assertTrue(purge_result is result)
+
+    @patch(QPID_MODULE + '.Channel.qos')
+    def test_basic_ack(self, mock_qos):
+        """Test that basic_ack calls the QoS object properly"""
+        mock_delivery_tag = Mock()
+        self.my_channel.basic_ack(mock_delivery_tag)
+        mock_qos.ack.assert_called_with(mock_delivery_tag)
+
+    @patch(QPID_MODULE + '.Channel.qos')
+    def test_basic_reject(self, mock_qos):
+        """Test that basic_reject calls the QoS object properly"""
+        mock_delivery_tag = Mock()
+        mock_requeue_value = Mock()
+        self.my_channel.basic_reject(mock_delivery_tag, mock_requeue_value)
+        mock_qos.reject.assert_called_with(mock_delivery_tag,
+                                           requeue=mock_requeue_value)
+
+    def test_qos_manager_is_none(self):
+        """Test the qos property if the QoS object did not already exist"""
+        self.my_channel._qos = None
+        result = self.my_channel.qos
+        self.assertTrue(isinstance(result, QoS))
+        self.assertEqual(result, self.my_channel._qos)
+
+    def test_qos_manager_already_exists(self):
+        """Test the qos property if the QoS object already exists"""
+        mock_existing_qos = Mock()
+        self.my_channel._qos = mock_existing_qos
+        result = self.my_channel.qos
+        self.assertTrue(mock_existing_qos is result)
+
+    def test_prepare_message(self):
+        """Test that prepare_message() returns the correct result"""
+        mock_body = Mock()
+        mock_priority = Mock()
+        mock_content_encoding = Mock()
+        mock_content_type = Mock()
+        mock_header1 = Mock()
+        mock_header2 = Mock()
+        mock_properties1 = Mock()
+        mock_properties2 = Mock()
+        headers = {'header1': mock_header1, 'header2': mock_header2}
+        properties = {'properties1': mock_properties1,
+                      'properties2': mock_properties2}
+        result = self.my_channel.prepare_message(
+            mock_body,
+            priority=mock_priority,
+            content_type=mock_content_type,
+            content_encoding=mock_content_encoding,
+            headers=headers,
+            properties=properties)
+        self.assertTrue(mock_body is result['body'])
+        self.assertTrue(mock_content_encoding is result['content-encoding'])
+        self.assertTrue(mock_content_type is result['content-type'])
+        self.assertDictEqual(headers, result['headers'])
+        self.assertDictContainsSubset(properties, result['properties'])
+        self.assertTrue(mock_priority is
+                        result['properties']['delivery_info']['priority'])
+
+    @patch('__builtin__.buffer')
+    @patch(QPID_MODULE + '.Channel.body_encoding')
+    @patch(QPID_MODULE + '.Channel.encode_body')
+    @patch(QPID_MODULE + '.Channel._put')
+    def test_basic_publish(self, mock_put,
+                           mock_encode_body,
+                           mock_body_encoding,
+                           mock_buffer):
+        """Test basic_publish()"""
+        mock_original_body = Mock()
+        mock_encoded_body = 'this is my encoded body'
+        mock_message = {'body': mock_original_body,
+                        'properties': {'delivery_info': {}}}
+        mock_encode_body.return_value = (mock_encoded_body,
+                                         mock_body_encoding)
+        mock_exchange = Mock()
+        mock_routing_key = Mock()
+        mock_encoded_buffered_body = Mock()
+        mock_buffer.return_value = mock_encoded_buffered_body
+        self.my_channel.basic_publish(mock_message,
+                                      mock_exchange,
+                                      mock_routing_key)
+        mock_encode_body.assert_called_once(mock_original_body,
+                                            mock_body_encoding)
+        mock_buffer.assert_called_once(mock_encode_body)
+        self.assertTrue(mock_message['body'] is mock_encoded_buffered_body)
+        self.assertTrue(mock_message['properties']['body_encoding'] is
+                        mock_body_encoding)
+        self.assertTrue(
+            isinstance(mock_message['properties']['delivery_tag'], int))
+        self.assertTrue(mock_message['properties']['delivery_info']
+                        ['exchange'] is mock_exchange)
+        self.assertTrue(
+            mock_message['properties']['delivery_info']['routing_key'] is
+            mock_routing_key)
+        mock_put.assert_called_with(mock_routing_key,
+                                    mock_message,
+                                    mock_exchange)
+
+    @patch(QPID_MODULE + '.Channel.codecs')
+    def test_encode_body_expected_encoding(self, mock_codecs):
+        """Test if encode_body() works when encoding is set correctly"""
+        mock_body = Mock()
+        mock_encoder = Mock()
+        mock_encoded_result = Mock()
+        mock_codecs.get.return_value = mock_encoder
+        mock_encoder.encode.return_value = mock_encoded_result
+        result = self.my_channel.encode_body(mock_body, encoding='base64')
+        expected_result = (mock_encoded_result, 'base64')
+        self.assertEqual(expected_result, result)
+
+    @patch(QPID_MODULE + '.Channel.codecs')
+    def test_encode_body_not_expected_encoding(self, mock_codecs):
+        """Test if encode_body() works when encoding is not set correctly"""
+        mock_body = Mock()
+        result = self.my_channel.encode_body(mock_body,
+                                             encoding=None)
+        expected_result = (mock_body, None)
+        self.assertEqual(expected_result, result)
+
+    @patch(QPID_MODULE + '.Channel.codecs')
+    def test_decode_body_expected_encoding(self, mock_codecs):
+        """Test if decode_body() works when encoding is set correctly"""
+        mock_body = Mock()
+        mock_decoder = Mock()
+        mock_decoded_result = Mock()
+        mock_codecs.get.return_value = mock_decoder
+        mock_decoder.decode.return_value = mock_decoded_result
+        result = self.my_channel.decode_body(mock_body, encoding='base64')
+        self.assertEqual(mock_decoded_result, result)
+
+    @patch(QPID_MODULE + '.Channel.codecs')
+    def test_decode_body_not_expected_encoding(self, mock_codecs):
+        """Test if decode_body() works when encoding is not set correctly"""
+        mock_body = Mock()
+        result = self.my_channel.decode_body(mock_body, encoding=None)
+        self.assertEqual(mock_body, result)
+
+    def test_typeof_exchange_exists(self):
+        """Test that typeof() finds an exchange that already exists"""
+        mock_exchange = Mock()
+        mock_qpid_exchange = Mock()
+        mock_attributes = {}
+        mock_type = Mock()
+        mock_attributes['type'] = mock_type
+        mock_qpid_exchange.getAttributes.return_value = mock_attributes
+        self.mock_broker.getExchange.return_value = mock_qpid_exchange
+        result = self.my_channel.typeof(mock_exchange)
+        self.assertTrue(mock_type is result)
+
+    def test_typeof_exchange_does_not_exist(self):
+        """Test that typeof() finds an exchange that does not exists"""
+        mock_exchange = Mock()
+        mock_default = Mock()
+        self.mock_broker.getExchange.return_value = None
+        result = self.my_channel.typeof(mock_exchange, default=mock_default)
+        self.assertTrue(mock_default is result)
+
+
+@case_no_python3
+@case_no_pypy
+class ReceiversMonitorTestBase(Case):
+
+    def setUp(self):
+        self.mock_session = Mock()
+        self.mock_w = Mock()
+        self.monitor = ReceiversMonitor(self.mock_session, self.mock_w)
+
+
+@case_no_python3
+@case_no_pypy
+class TestReceiversMonitorType(ReceiversMonitorTestBase):
+
+    def test_qpid_messaging_receivers_monitor_subclass_of_threading(self):
+        self.assertTrue(isinstance(self.monitor, threading.Thread))
+
+
+@case_no_python3
+@case_no_pypy
+class TestReceiversMonitorInit(ReceiversMonitorTestBase):
+
+    def setUp(self):
+        thread___init___str = QPID_MODULE + '.threading.Thread.__init__'
+        self.patch_parent___init__ = patch(thread___init___str)
+        self.mock_Thread___init__ = self.patch_parent___init__.start()
+        super(TestReceiversMonitorInit, self).setUp()
+
+    def tearDown(self):
+        self.patch_parent___init__.stop()
+
+    def test_qpid_messaging_receivers_monitor_init_saves_session(self):
+        self.assertTrue(self.monitor._session is self.mock_session)
+
+    def test_qpid_messaging_receivers_monitor_init_saves_fd(self):
+        self.assertTrue(self.monitor._w_fd is self.mock_w)
+
+    def test_qpid_messaging_Receivers_monitor_init_calls_parent__init__(self):
+        self.mock_Thread___init__.assert_called_once_with()
+
+
+@case_no_python3
+@case_no_pypy
+class TestReceiversMonitorRun(ReceiversMonitorTestBase):
+
+    @patch.object(ReceiversMonitor, 'monitor_receivers')
+    @patch(QPID_MODULE + '.time.sleep')
+    def test_receivers_monitor_run_calls_monitor_receivers(
+            self, mock_sleep, mock_monitor_receivers):
+        mock_sleep.side_effect = BreakOutException()
+        self.assertRaises(BreakOutException, self.monitor.run)
+        mock_monitor_receivers.assert_called_once_with()
+
+    @patch.object(Transport, 'connection_errors', new=(BreakOutException, ))
+    @patch.object(ReceiversMonitor, 'monitor_receivers')
+    @patch(QPID_MODULE + '.time.sleep')
+    @patch(QPID_MODULE + '.logger')
+    def test_receivers_monitors_run_calls_logs_exception_and_sleeps(
+            self, mock_logger, mock_sleep, mock_monitor_receivers):
+        exc_to_raise = IOError()
+        mock_monitor_receivers.side_effect = exc_to_raise
+        mock_sleep.side_effect = BreakOutException()
+        self.assertRaises(BreakOutException, self.monitor.run)
+        mock_logger.error.assert_called_once_with(exc_to_raise)
+        mock_sleep.assert_called_once_with(10)
+
+    @patch.object(ReceiversMonitor, 'monitor_receivers')
+    @patch(QPID_MODULE + '.time.sleep')
+    def test_receivers_monitor_run_loops_when_exception_is_raised(
+            self, mock_sleep, mock_monitor_receivers):
+        def return_once_raise_on_second_call(*args):
+            mock_sleep.side_effect = BreakOutException()
+            return None
+        mock_sleep.side_effect = return_once_raise_on_second_call
+        self.assertRaises(BreakOutException, self.monitor.run)
+        mock_monitor_receivers.has_calls([call(), call()])
+
+    @patch.object(Transport, 'connection_errors', new=(MockException, ))
+    @patch.object(ReceiversMonitor, 'monitor_receivers')
+    @patch(QPID_MODULE + '.time.sleep')
+    @patch(QPID_MODULE + '.logger')
+    @patch(QPID_MODULE + '.os.write')
+    @patch(QPID_MODULE + '.sys.exc_info')
+    def test_receivers_monitor_exits_when_recoverable_exception_raised(
+            self, mock_sys_exc_info, mock_os_write, mock_logger, mock_sleep,
+            mock_monitor_receivers):
+        mock_monitor_receivers.side_effect = MockException()
+        mock_sleep.side_effect = BreakOutException()
+        try:
+            self.monitor.run()
+        except Exception:
+            self.fail('ReceiversMonitor.run() should exit normally when '
+                      'recoverable error is caught')
+        self.assertTrue(not mock_logger.error.called)
+
+    @patch.object(Transport, 'connection_errors', new=(MockException, ))
+    @patch.object(ReceiversMonitor, 'monitor_receivers')
+    @patch(QPID_MODULE + '.time.sleep')
+    @patch(QPID_MODULE + '.logger')
+    @patch(QPID_MODULE + '.os.write')
+    def test_receivers_monitor_saves_exception_when_recoverable_exc_raised(
+            self, mock_os_write, mock_logger, mock_sleep,
+            mock_monitor_receivers):
+        mock_monitor_receivers.side_effect = MockException()
+        mock_sleep.side_effect = BreakOutException()
+        try:
+            self.monitor.run()
+        except Exception:
+            self.fail('ReceiversMonitor.run() should exit normally when '
+                      'recoverable error is caught')
+        self.assertTrue(
+            self.mock_session.saved_exception is mock_monitor_receivers.side_effect)
+
+    @patch.object(Transport, 'connection_errors', new=(MockException, ))
+    @patch.object(ReceiversMonitor, 'monitor_receivers')
+    @patch(QPID_MODULE + '.time.sleep')
+    @patch(QPID_MODULE + '.logger')
+    @patch(QPID_MODULE + '.os.write')
+    @patch(QPID_MODULE + '.sys.exc_info')
+    def test_receivers_monitor_writes_e_to_pipe_when_recoverable_exc_raised(
+            self, mock_sys_exc_info, mock_os_write, mock_logger, mock_sleep,
+            mock_monitor_receivers):
+        mock_monitor_receivers.side_effect = MockException()
+        mock_sleep.side_effect = BreakOutException()
+        try:
+            self.monitor.run()
+        except Exception:
+            self.fail('ReceiversMonitor.run() should exit normally when '
+                      'recoverable error is caught')
+        mock_os_write.assert_called_once_with(self.mock_w, 'e')
+
+
+@case_no_python3
+@case_no_pypy
+class TestReceiversMonitorMonitorReceivers(ReceiversMonitorTestBase):
+
+    def test_receivers_monitor_monitor_receivers_calls_next_receivers(self):
+        self.mock_session.next_receiver.side_effect = BreakOutException()
+        self.assertRaises(BreakOutException,
+                          self.monitor.monitor_receivers)
+        self.mock_session.next_receiver.assert_called_once_with()
+
+    def test_receivers_monitor_monitor_receivers_writes_to_fd(self):
+        with patch(QPID_MODULE + '.os.write') as mock_os_write:
+            mock_os_write.side_effect = BreakOutException()
+            self.assertRaises(BreakOutException,
+                              self.monitor.monitor_receivers)
+            mock_os_write.assert_called_once_with(self.mock_w, '0')
+
+
+@case_no_python3
+@case_no_pypy
+class TestTransportInit(Case):
+
+    def setUp(self):
+        self.patch_a = patch.object(Transport, 'verify_runtime_environment')
+        self.mock_verify_runtime_environment = self.patch_a.start()
+
+        self.patch_b = patch(QPID_MODULE + '.base.Transport.__init__')
+        self.mock_base_Transport__init__ = self.patch_b.start()
+
+        self.patch_c = patch(QPID_MODULE + '.os')
+        self.mock_os = self.patch_c.start()
+        self.mock_r = Mock()
+        self.mock_w = Mock()
+        self.mock_os.pipe.return_value = (self.mock_r, self.mock_w)
+
+        self.patch_d = patch(QPID_MODULE + '.fcntl')
+        self.mock_fcntl = self.patch_d.start()
+
+    def tearDown(self):
+        self.patch_a.stop()
+        self.patch_b.stop()
+        self.patch_c.stop()
+        self.patch_d.stop()
+
+    def test_Transport___init___calls_verify_runtime_environment(self):
+        Transport(Mock())
+        self.mock_verify_runtime_environment.assert_called_once_with()
+
+    def test_transport___init___calls_parent_class___init__(self):
+        Transport(Mock())
+        self.mock_base_Transport__init__.assert_caled_once_with()
+
+    def test_transport___init___calls_os_pipe(self):
+        Transport(Mock())
+        self.mock_os.pipe.assert_called_once_with()
+
+    def test_transport___init___saves_os_pipe_file_descriptors(self):
+        transport = Transport(Mock())
+        self.assertTrue(transport.r is self.mock_r)
+        self.assertTrue(transport._w is self.mock_w)
+
+    def test_transport___init___sets_non_blocking_behavior_on_r_fd(self):
+        Transport(Mock())
+        self.mock_fcntl.fcntl.assert_called_once_with(
+            self.mock_r,  self.mock_fcntl.F_SETFL,  self.mock_os.O_NONBLOCK)
+
+
+@case_no_python3
+@case_no_pypy
+class TestTransportDrainEvents(Case):
+
+    def setUp(self):
+        self.transport = Transport(Mock())
+        self.transport.session = Mock()
+        self.mock_queue = Mock()
+        self.mock_message = Mock()
+        self.mock_conn = Mock()
+        self.mock_callback = Mock()
+        self.mock_conn._callbacks = {self.mock_queue: self.mock_callback}
+
+    def mock_next_receiver(self, timeout):
+        time.sleep(0.3)
+        mock_receiver = Mock()
+        mock_receiver.source = self.mock_queue
+        mock_receiver.fetch.return_value = self.mock_message
+        return mock_receiver
+
+    def test_socket_timeout_raised_when_all_receivers_empty(self):
+        with patch(QPID_MODULE + '.QpidEmpty', new=MockException):
+            self.transport.session.next_receiver.side_effect = MockException()
+            self.assertRaises(socket.timeout, self.transport.drain_events,
+                              Mock())
+
+    def test_socket_timeout_raised_when_by_timeout(self):
+        self.transport.session.next_receiver = self.mock_next_receiver
+        self.assertRaises(socket.timeout, self.transport.drain_events,
+                          self.mock_conn, timeout=1)
+
+    def test_timeout_returns_no_earlier_then_asked_for(self):
+        self.transport.session.next_receiver = self.mock_next_receiver
+        start_time = datetime.datetime.now()
+        try:
+            self.transport.drain_events(self.mock_conn, timeout=1)
+        except socket.timeout:
+            pass
+        end_time = datetime.datetime.now()
+        td = end_time - start_time
+        elapsed_time_in_s = (td.microseconds + td.seconds * 10**6) / 10**6
+        self.assertTrue(elapsed_time_in_s >= 1)
+
+    def test_callback_is_called(self):
+        self.transport.session.next_receiver = self.mock_next_receiver
+        try:
+            self.transport.drain_events(self.mock_conn, timeout=1)
+        except socket.timeout:
+            pass
+        self.mock_callback.assert_called_with(self.mock_message)
+
+
+@case_no_python3
+@case_no_pypy
+class TestTransportCreateChannel(Case):
+
+    def setUp(self):
+        self.transport = Transport(Mock())
+        self.mock_conn = Mock()
+        self.mock_new_channel = Mock()
+        self.mock_conn.Channel.return_value = self.mock_new_channel
+        self.returned_channel = self.transport.create_channel(self.mock_conn)
+
+    def test_new_channel_created_from_connection(self):
+        self.assertTrue(self.mock_new_channel is self.returned_channel)
+        self.mock_conn.Channel.assert_called_with(self.mock_conn,
+                                                  self.transport)
+
+    def test_new_channel_added_to_connection_channel_list(self):
+        append_method = self.mock_conn.channels.append
+        append_method.assert_called_with(self.mock_new_channel)
+
+
+@case_no_python3
+@case_no_pypy
+class TestTransportEstablishConnection(Case):
+
+    def setUp(self):
+
+        class MockClient(object):
+            pass
+
+        self.client = MockClient()
+        self.client.connect_timeout = 4
+        self.client.ssl = False
+        self.client.transport_options = {}
+        self.transport = Transport(self.client)
+        self.mock_conn = Mock()
+        self.transport.Connection = self.mock_conn
+        path_to_mock = QPID_MODULE + '.ReceiversMonitor'
+        self.patcher = patch(path_to_mock)
+        self.mock_ReceiverMonitor = self.patcher.start()
+
+    def tearDown(self):
+        self.patcher.stop()
+
+    def test_transport_establish_conn_new_option_overwrites_default(self):
+        new_userid_string = 'new-userid'
+        self.client.userid = new_userid_string
+        self.transport.establish_connection()
+        self.mock_conn.assert_called_once_with(username=new_userid_string,
+                                               sasl_mechanisms='PLAIN ANONYMOUS',
+                                               host='127.0.0.1',
+                                               timeout=4,
+                                               password='',
+                                               port=5672,
+                                               transport='tcp')
+
+    def test_transport_establish_conn_sasl_mech_sorting(self):
+        self.client.sasl_mechanisms = 'MECH1 MECH2'
+        self.transport.establish_connection()
+        self.mock_conn.assert_called_once_with(username='guest',
+                                               sasl_mechanisms='MECH1 MECH2',
+                                               host='127.0.0.1',
+                                               timeout=4,
+                                               password='',
+                                               port=5672,
+                                               transport='tcp')
+
+    def test_transport_establish_conn_empty_client_is_default(self):
+        self.transport.establish_connection()
+        self.mock_conn.assert_called_once_with(username='guest',
+                                               sasl_mechanisms='PLAIN ANONYMOUS',
+                                               host='127.0.0.1',
+                                               timeout=4,
+                                               password='',
+                                               port=5672,
+                                               transport='tcp')
+
+    def test_transport_establish_conn_additional_transport_option(self):
+        new_param_value = 'mynewparam'
+        self.client.transport_options['new_param'] = new_param_value
+        self.transport.establish_connection()
+        self.mock_conn.assert_called_once_with(username='guest',
+                                               sasl_mechanisms='PLAIN ANONYMOUS',
+                                               host='127.0.0.1',
+                                               timeout=4,
+                                               new_param=new_param_value,
+                                               password='',
+                                               port=5672,
+                                               transport='tcp')
+
+    def test_transport_establish_conn_transform_localhost_to_127_0_0_1(self):
+        self.client.hostname = 'localhost'
+        self.transport.establish_connection()
+        self.mock_conn.assert_called_once_with(username='guest',
+                                               sasl_mechanisms='PLAIN ANONYMOUS',
+                                               host='127.0.0.1',
+                                               timeout=4,
+                                               password='',
+                                               port=5672,
+                                               transport='tcp')
+
+    def test_transport_establish_conn_set_password(self):
+        self.client.password = 'somepass'
+        self.transport.establish_connection()
+        self.mock_conn.assert_called_once_with(username='guest',
+                                               sasl_mechanisms='PLAIN ANONYMOUS',
+                                               host='127.0.0.1',
+                                               timeout=4,
+                                               password='somepass',
+                                               port=5672,
+                                               transport='tcp')
+
+    def test_transport_establish_conn_no_ssl_sets_transport_tcp(self):
+        self.client.ssl = False
+        self.transport.establish_connection()
+        self.mock_conn.assert_called_once_with(username='guest',
+                                               sasl_mechanisms='PLAIN ANONYMOUS',
+                                               host='127.0.0.1',
+                                               timeout=4,
+                                               password='',
+                                               port=5672,
+                                               transport='tcp')
+
+    def test_transport_establish_conn_with_ssl_with_hostname_check(self):
+        self.client.ssl = {'keyfile': 'my_keyfile',
+                           'certfile': 'my_certfile',
+                           'ca_certs': 'my_cacerts',
+                           'cert_reqs': ssl.CERT_REQUIRED}
+        self.transport.establish_connection()
+        self.mock_conn.assert_called_once_with(username='guest',
+                                               ssl_certfile='my_certfile',
+                                               ssl_trustfile='my_cacerts',
+                                               timeout=4,
+                                               ssl_skip_hostname_check=False,
+                                               sasl_mechanisms='PLAIN ANONYMOUS',
+                                               host='127.0.0.1',
+                                               ssl_keyfile='my_keyfile',
+                                               password='',
+                                               port=5672, transport='ssl')
+
+    def test_transport_establish_conn_with_ssl_skip_hostname_check(self):
+        self.client.ssl = {'keyfile': 'my_keyfile',
+                           'certfile': 'my_certfile',
+                           'ca_certs': 'my_cacerts',
+                           'cert_reqs': ssl.CERT_OPTIONAL}
+        self.transport.establish_connection()
+        self.mock_conn.assert_called_once_with(username='guest',
+                                               ssl_certfile='my_certfile',
+                                               ssl_trustfile='my_cacerts',
+                                               timeout=4,
+                                               ssl_skip_hostname_check=True,
+                                               sasl_mechanisms='PLAIN ANONYMOUS',
+                                               host='127.0.0.1',
+                                               ssl_keyfile='my_keyfile',
+                                               password='',
+                                               port=5672, transport='ssl')
+
+    def test_transport_establish_conn_sets_client_on_connection_object(self):
+        self.transport.establish_connection()
+        self.assertTrue(self.mock_conn.return_value.client is self.client)
+
+    def test_transport_establish_conn_creates_session_on_transport(self):
+        self.transport.establish_connection()
+        qpid_conn = self.mock_conn.return_value.get_qpid_connection
+        new_mock_session = qpid_conn.return_value.session.return_value
+        self.assertTrue(self.transport.session is new_mock_session)
+
+    def test_transport_establish_conn_returns_new_connection_object(self):
+        new_conn = self.transport.establish_connection()
+        self.assertTrue(new_conn is self.mock_conn.return_value)
+
+    def test_transport_establish_conn_creates_ReceiversMonitor(self):
+        self.transport.establish_connection()
+        self.mock_ReceiverMonitor.assert_called_once_with(
+            self.transport.session, self.transport._w)
+
+    def test_transport_establish_conn_daemonizes_thread(self):
+        self.transport.establish_connection()
+        self.assertTrue(self.mock_ReceiverMonitor.return_value.daemon)
+
+    def test_transport_establish_conn_starts_thread(self):
+        self.transport.establish_connection()
+        new_receiver_monitor = self.mock_ReceiverMonitor.return_value
+        new_receiver_monitor.start.assert_called_once_with()
+
+    def test_transport_establish_conn_ignores_hostname_if_not_localhost(self):
+        self.client.hostname = 'some_other_hostname'
+        self.transport.establish_connection()
+        self.mock_conn.assert_called_once_with(username='guest',
+                                               sasl_mechanisms='PLAIN ANONYMOUS',
+                                               host='some_other_hostname',
+                                               timeout=4, password='',
+                                               port=5672, transport='tcp')
+
+
+@case_no_python3
+@case_no_pypy
+class TestTransportClassAttributes(Case):
+
+    def test_verify_Connection_attribute(self):
+        self.assertTrue(Connection is Transport.Connection)
+
+    def test_verify_default_port(self):
+        self.assertEqual(5672, Transport.default_port)
+
+    def test_verify_polling_disabled(self):
+        self.assertTrue(Transport.polling_interval is None)
+
+    def test_transport_verify_supports_asynchronous_events(self):
+        self.assertTrue(Transport.supports_ev)
+
+    def test_verify_driver_type_and_name(self):
+        self.assertEqual('qpid', Transport.driver_type)
+        self.assertEqual('qpid', Transport.driver_name)
+
+    def test_transport_channel_error_contains_qpid_ConnectionError(self):
+        self.assertTrue(ConnectionError in Transport.connection_errors)
+
+    def test_transport_channel_error_contains_socket_error(self):
+        self.assertTrue(select.error in Transport.connection_errors)
+
+
+@case_no_python3
+@case_no_pypy
+class TestTransportRegisterWithEventLoop(Case):
+
+    def test_transport_register_with_event_loop_calls_add_reader(self):
+        transport = Transport(Mock())
+        mock_connection = Mock()
+        mock_loop = Mock()
+        transport.register_with_event_loop(mock_connection, mock_loop)
+        mock_loop.add_reader.assert_called_with(transport.r,
+                                                transport.on_readable,
+                                                mock_connection, mock_loop)
+
+
+@case_no_python3
+@case_no_pypy
+class TestTransportOnReadable(Case):
+
+    def setUp(self):
+        self.patch_a = patch(QPID_MODULE + '.os.read')
+        self.mock_os_read = self.patch_a.start()
+        self.patch_b = patch.object(Transport, 'drain_events')
+        self.mock_drain_events = self.patch_b.start()
+        self.transport = Transport(Mock())
+
+    def tearDown(self):
+        self.patch_a.stop()
+
+    def test_transport_on_readable_reads_symbol_from_fd(self):
+        self.transport.on_readable(Mock(), Mock())
+        self.mock_os_read.assert_called_once_with(self.transport.r, 1)
+
+    def test_transport_on_readable_calls_drain_events(self):
+        mock_connection = Mock()
+        self.transport.on_readable(mock_connection, Mock())
+        self.mock_drain_events.assert_called_with(mock_connection)
+
+    def test_transport_on_readable_catches_socket_timeout(self):
+        self.mock_drain_events.side_effect = socket.timeout()
+        try:
+            self.transport.on_readable(Mock(), Mock())
+        except Exception:
+            self.fail('Transport.on_readable did not catch socket.timeout()')
+
+    def test_transport_on_readable_ignores_non_socket_timeout_exception(self):
+        self.mock_drain_events.side_effect = IOError()
+        self.assertRaises(IOError, self.transport.on_readable, Mock(), Mock())
+
+    def test_transport_on_readable_reads_e_off_of_pipe_raises_exc_info(self):
+        self.transport.session = Mock()
+        try:
+            raise IOError()
+        except Exception as error:
+            self.transport.session.saved_exception = error
+        self.mock_os_read.return_value = 'e'
+        self.assertRaises(IOError, self.transport.on_readable, Mock(), Mock())
+
+
+@case_no_python3
+@case_no_pypy
+class TestTransportVerifyRuntimeEnvironment(Case):
+
+    def setUp(self):
+        self.verify_runtime_environment = Transport.verify_runtime_environment
+        self.patch_a = patch.object(Transport, 'verify_runtime_environment')
+        self.patch_a.start()
+        self.transport = Transport(Mock())
+
+    def tearDown(self):
+        self.patch_a.stop()
+
+    @patch(QPID_MODULE + '.PY3', new=True)
+    def test_transport_verify_runtime_env_raises_exception_for_Python3(self):
+        self.assertRaises(RuntimeError, self.verify_runtime_environment,
+                          self.transport)
+
+    @patch('__builtin__.getattr')
+    def test_transport_verify_runtime_env_raises_exc_for_PyPy(self,
+                                                              mock_getattr):
+        mock_getattr.return_value = True
+        self.assertRaises(RuntimeError, self.verify_runtime_environment,
+                          self.transport)
+
+    def test_transport_verify_runtime_env_raises_no_exception(self):
+        try:
+            self.verify_runtime_environment(self.transport)
+        except Exception:
+            self.fail(
+                "verify_runtime_environment raised an unexpected Exception")
+
+
+@case_no_python3
+@case_no_pypy
+class TestTransport(ExtraAssertionsMixin, Case):
+
+    def setUp(self):
+        """Creates a mock_client to be used in testing."""
+        self.mock_client = Mock()
+
+    def test_close_connection(self):
+        """Test that close_connection calls close on each channel in the
+        list of channels on the connection object.
+        """
+        my_transport = Transport(self.mock_client)
+        mock_connection = Mock()
+        mock_channel_1 = Mock()
+        mock_channel_2 = Mock()
+        mock_connection.channels = [mock_channel_1, mock_channel_2]
+        my_transport.close_connection(mock_connection)
+        mock_channel_1.close.assert_called_with()
+        mock_channel_2.close.assert_called_with()
+
+    def test_default_connection_params(self):
+        """Test that the default_connection_params are correct"""
+        correct_params = {'userid': 'guest', 'password': '',
+                          'port': 5672, 'virtual_host': '',
+                          'hostname': 'localhost',
+                          'sasl_mechanisms': 'PLAIN ANONYMOUS'}
+        my_transport = Transport(self.mock_client)
+        result_params = my_transport.default_connection_params
+        self.assertDictEqual(correct_params, result_params)

--- a/kombu/transport/__init__.py
+++ b/kombu/transport/__init__.py
@@ -68,6 +68,7 @@ TRANSPORT_ALIASES = {
     'zeromq': 'kombu.transport.zmq:Transport',
     'zmq': 'kombu.transport.zmq:Transport',
     'amqplib': 'kombu.transport.amqplib:Transport',
+    'qpid': 'kombu.transport.qpid:Transport',
 }
 
 _transport_cache = {}

--- a/kombu/transport/qpid.py
+++ b/kombu/transport/qpid.py
@@ -1,0 +1,1683 @@
+"""
+kombu.transport.qpid
+=======================
+
+`Qpid`_ transport using `qpid-python`_ as the client and `qpid-tools`_ for
+broker management.
+
+.. _`Qpid`: http://qpid.apache.org/
+.. _`qpid-python`: http://pypi.python.org/pypi/qpid-python/
+.. _`qpid-tools`: http://pypi.python.org/pypi/qpid-tools/
+.. _`Issue 2199`: https://github.com/celery/celery/issues/2199
+
+The use this transport you must install the necessary dependencies. These
+dependencies are available via PyPI and can be installed using the pip
+command:
+
+`pip install qpid-tools qpid-python`
+
+    .. admonition:: Python 3 and PyPy Limitations
+
+        The Qpid transport does not support Python 3 or PyPy environments due
+        to underlying dependencies not being compatible. This version is
+        tested and works with with Python 2.7.
+
+    .. admonition:: Potential Deadlock
+
+        This transport should be used with caution due to a known
+        potential deadlock. See `Issue 2199`_ for more details.
+
+"""
+from __future__ import absolute_import
+
+"""Kombu transport using a Qpid broker as a message store."""
+
+import fcntl
+import os
+import select
+import socket
+import ssl
+import sys
+import threading
+import time
+
+from itertools import count
+
+import amqp.protocol
+
+try:
+    import qpidtoollibs
+except ImportError:  # pragma: no cover
+    qpidtoollibs = None     # noqa
+
+try:
+    from qpid.messaging.exceptions import ConnectionError
+    from qpid.messaging.exceptions import Empty as QpidEmpty
+except ImportError:  # pragma: no cover
+    ConnectionError = None
+    QpidEmpty = None
+
+try:
+    import qpid
+except ImportError:  # pragma: no cover
+    qpid = None
+
+
+from kombu.five import Empty, items
+from kombu.log import get_logger
+from kombu.transport.virtual import Base64, Message
+from kombu.transport import base
+from kombu.utils.compat import OrderedDict
+
+
+logger = get_logger(__name__)
+
+## The Following Import Applies Monkey Patches at Import Time ##
+import kombu.transport.qpid_patches
+################################################################
+
+
+DEFAULT_PORT = 5672
+
+OBJECT_ALREADY_EXISTS_STRING = 'object already exists'
+
+VERSION = (1, 0, 0)
+__version__ = '.'.join(map(str, VERSION))
+
+PY3 = sys.version_info[0] == 3
+
+
+class AuthenticationFailure(Exception):
+    pass
+
+
+class QpidMessagingExceptionHandler(object):
+    """An exception handling decorator that silences some exceptions.
+
+    An exception handling class designed to silence specific exceptions
+    that qpid.messaging raises as part of normal operation. qpid.messaging
+    exceptions require string parsing, and are not machine consumable.
+    This is designed to be used as a decorator, and accepts a whitelist
+    string as an argument.
+
+    Usage:
+    @QpidMessagingExceptionHandler('whitelist string goes here')
+
+    """
+
+    def __init__(self, allowed_exception_string):
+        """Instantiate a QpidMessagingExceptionHandler object.
+
+        :param allowed_exception_string: a string that, if present in the
+            exception message, will be silenced.
+        :type allowed_exception_string: str
+
+        """
+        self.allowed_exception_string = allowed_exception_string
+
+    def __call__(self, original_func):
+        """The decorator method.
+
+        Method that wraps the actual function with exception silencing
+        functionality. Any exception that contains the string
+        self.allowed_exception_string in the message will be silenced.
+
+        :param original_func: function that is automatically passed in
+        when this object is used as a decorator.
+        :type original_func: function
+
+        :return: A function that decorates (wraps) the original function.
+        :rtype: func
+        """
+
+        def decorator(*args, **kwargs):
+            """A runtime-built function that will be returned which contains
+            a reference to the original function, and wraps a call to it in
+            a try/except block that can silence errors.
+            """
+            try:
+                return original_func(*args, **kwargs)
+            except Exception as error:
+                if self.allowed_exception_string not in error.message:
+                    raise
+
+        return decorator
+
+
+class QoS(object):
+    """A helper object for message prefetch and ACKing purposes.
+
+    NOTE: prefetch_count is currently hard set to 1, and needs to be improved
+
+    This object is instantiated 1-for-1 with a :class:`Channel`. QoS
+    allows prefetch_count to be set to the number of outstanding messages
+    the corresponding :class:`Channel` should be allowed to prefetch.
+    Setting prefetch_count to 0 disables prefetch limits, and the object
+    can hold an arbitrary number of messages.
+
+    Messages are added using :meth:`append`, which are held until they are
+    ACKed asynchronously through a call to :meth:`ack`. Messages that are
+    received, but not ACKed will not be delivered by the broker to another
+    consumer until an ACK is received, or the session is closed. Messages
+    are referred to using delivery_tag integers, which are unique per
+    :class:`Channel`. Delivery tags are managed outside of this object and
+    are passed in with a message to :meth:`append`. Un-ACKed messages can
+    be looked up from QoS using :meth:`get` and can be rejected and
+    forgotten using :meth:`reject`.
+
+    """
+
+    def __init__(self, session, prefetch_count=1):
+        """Instantiate a QoS object.
+
+        :keyword prefetch_count: Initial prefetch count, hard set to 1.
+        :type prefetch_count: int
+
+        """
+        self.session = session
+        self.prefetch_count = 1
+        self._not_yet_acked = OrderedDict()
+
+    def can_consume(self):
+        """Return True if the :class:`Channel` can consume more messages,
+        else False.
+
+        Used to ensure the client adheres to currently active prefetch
+        limits.
+
+        :returns: True, if this QoS object can accept more messages
+            without violating the prefetch_count. If prefetch_count is 0,
+            can_consume will always return True.
+        :rtype: bool
+        """
+        return not self.prefetch_count or len(self._not_yet_acked) < self\
+            .prefetch_count
+
+    def can_consume_max_estimate(self):
+        """Return the remaining message capacity for the associated
+        :class:`Channel`.
+
+        Returns an estimated number of outstanding messages that a
+        :class:`Channel` can accept without exceeding prefetch_count. If
+        prefetch_count is 0, then this method returns 1.
+
+        :returns: The number of estimated messages that can be fetched
+            without violating the prefetch_count.
+        :rtype: int
+        """
+        if self.prefetch_count:
+            return self.prefetch_count - len(self._not_yet_acked)
+        else:
+            return 1
+
+    def append(self, message, delivery_tag):
+        """Append message to the list of un-ACKed messages.
+
+        Add a message, referenced by the integer delivery_tag, for ACKing,
+        rejecting, or getting later. Messages are saved into an
+        :class:`~kombu.utils.compat.OrderedDict` by delivery_tag.
+
+        :param message: A received message that has not yet been ACKed.
+        :type message: qpid.messaging.Message
+        :param delivery_tag: An integer number to refer to this message by
+            upon receipt.
+        :type delivery_tag: int
+        """
+        self._not_yet_acked[delivery_tag] = message
+
+    def get(self, delivery_tag):
+        """
+        Get an un-ACKed message by delivery_tag. If called with an invalid
+        delivery_tag a KeyError is raised.
+
+        :param delivery_tag: The delivery tag associated with the message
+            to be returned.
+        :type delivery_tag: int
+
+        :return: An un-ACKed message that is looked up by delivery_tag.
+        :rtype: qpid.messaging.Message
+        """
+        return self._not_yet_acked[delivery_tag]
+
+    def ack(self, delivery_tag):
+        """Acknowledge a message by delivery_tag.
+
+        Called asynchronously once the message has been handled and can be
+        forgotten by the broker.
+
+        :param delivery_tag: the delivery tag associated with the message
+            to be acknowledged.
+        :type delivery_tag: int
+        """
+        message = self._not_yet_acked.pop(delivery_tag)
+        self.session.acknowledge(message=message)
+
+    def reject(self, delivery_tag, requeue=False):
+        """Reject a message by delivery_tag.
+
+        Explicitly notify the broker that the :class:`Channel` associated
+        with this QoS object is rejecting the message that was previously
+        delivered.
+
+        If requeue is False, then the message is not requeued for delivery
+        to another consumer. If requeue is True, then the message is
+        requeued for delivery to another consumer.
+
+        :param delivery_tag: The delivery tag associated with the message
+            to be rejected.
+        :type delivery_tag: int
+        :keyword requeue: If True, the broker will be notified to requeue
+            the message. If False, the broker will be told to drop the
+            message entirely. In both cases, the message will be removed
+            from this object.
+        :type requeue: bool
+        """
+        message = self._not_yet_acked.pop(delivery_tag)
+        QpidDisposition = qpid.messaging.Disposition
+        if requeue:
+            disposition = QpidDisposition(qpid.messaging.RELEASED)
+        else:
+            disposition = QpidDisposition(qpid.messaging.REJECTED)
+        self.session.acknowledge(message=message, disposition=disposition)
+
+
+class Channel(base.StdChannel):
+    """Supports broker configuration and messaging send and receive.
+
+    A Channel object is designed to have method-parity with a Channel as
+    defined in AMQP 0-10 and earlier, which allows for the following broker
+    actions:
+
+        - exchange declare and delete
+        - queue declare and delete
+        - queue bind and unbind operations
+        - queue length and purge operations
+        - sending/receiving/rejecting messages
+        - structuring, encoding, and decoding messages
+        - supports synchronous and asynchronous reads
+        - reading state about the exchange, queues, and bindings
+
+    Channels are designed to all share a single TCP connection with a
+    broker, but provide a level of isolated communication with the broker
+    while benefiting from a shared TCP connection. The Channel is given
+    its :class:`Connection` object by the :class:`Transport` that
+    instantiates the Channel.
+
+    This Channel inherits from :class:`~kombu.transport.base.StdChannel`,
+    which makes this a 'native' Channel versus a 'virtual' Channel which
+    would inherit from :class:`kombu.transports.virtual`.
+
+    Messages sent using this Channel are assigned a delivery_tag. The
+    delivery_tag is generated for a message as they are prepared for
+    sending by :meth:`basic_publish`. The delivery_tag is unique per
+    Channel instance using :meth:`~itertools.count`. The delivery_tag has
+    no meaningful context in other objects, and is only maintained in the
+    memory of this object, and the underlying :class:`QoS` object that
+    provides support.
+
+    Each Channel object instantiates exactly one :class:`QoS` object for
+    prefetch limiting, and asynchronous ACKing. The :class:`QoS` object is
+    lazily instantiated through a property method :meth:`qos`. The
+    :class:`QoS` object is a supporting object that should not be accessed
+    directly except by the Channel itself.
+
+    Synchronous reads on a queue are done using a call to :meth:`basic_get`
+    which uses :meth:`_get` to perform the reading. These methods read
+    immediately and do not accept any form of timeout. :meth:`basic_get`
+    reads synchronously and ACKs messages before returning them. ACKing is
+    done in all cases, because an application that reads messages using
+    qpid.messaging, but does not ACK them will experience a memory leak.
+    The no_ack argument to :meth:`basic_get` does not affect ACKing
+    functionality.
+
+    Asynchronous reads on a queue are done by starting a consumer using
+    :meth:`basic_consume`. Each call to :meth:`basic_consume` will cause a
+    :class:`~qpid.messaging.endpoints.Receiver` to be created on the
+    :class:`~qpid.messaging.endpoints.Session` started by the :class:
+    `Transport`. The receiver will asynchronously read using
+    qpid.messaging, and prefetch messages before the call to
+    :meth:`Transport.basic_drain` occurs. The prefetch_count value of the
+    :class:`QoS` object is the capacity value of the new receiver. The new
+    receiver capacity must always be at least 1, otherwise none of the
+    receivers will appear to be ready for reading, and will never be read
+    from.
+
+    Each call to :meth:`basic_consume` creates a consumer, which is given a
+    consumer tag that is identified by the caller of :meth:`basic_consume`.
+    Already started consumers can be cancelled using by their consumer_tag
+    using :meth:`basic_cancel`. Cancellation of a consumer causes the
+    :class:`~qpid.messaging.endpoints.Receiver` object to be closed.
+
+    Asynchronous message ACKing is supported through :meth:`basic_ack`,
+    and is referenced by delivery_tag. The Channel object uses its
+    :class:`QoS` object to perform the message ACKing.
+
+    """
+
+    #: A class reference that will be instantiated using the qos property.
+    QoS = QoS
+
+    #: A class reference that identifies
+    # :class:`~kombu.transport.virtual.Message` as the message class type
+    Message = Message
+
+    #: Default body encoding.
+    #: NOTE: ``transport_options['body_encoding']`` will override this value.
+    body_encoding = 'base64'
+
+    #: Binary <-> ASCII codecs.
+    codecs = {'base64': Base64()}
+
+    #: counter used to generate delivery tags for this channel.
+    _delivery_tags = count(1)
+
+    def __init__(self, connection, transport):
+        """Instantiate a Channel object.
+
+        :param connection: A Connection object that this Channel can
+            reference. Currently only used to access callbacks.
+        :type connection: Connection
+        :param transport: The Transport this Channel is associated with.
+        :type transport: Transport
+        """
+        self.connection = connection
+        self.transport = transport
+        qpid_connection = connection.get_qpid_connection()
+        self._broker = qpidtoollibs.BrokerAgent(qpid_connection)
+        self.closed = False
+        self._tag_to_queue = {}
+        self._receivers = {}
+        self._qos = None
+
+    def _get(self, queue):
+        """Non-blocking, single-message read from a queue.
+
+        An internal method to perform a non-blocking, single-message read
+        from a queue by name. This method creates a
+        :class:`~qpid.messaging.endpoints.Receiver` to read from the queue
+        using the :class:`~qpid.messaging.endpoints.Session` saved on the
+        associated :class:`Transport`. The receiver is closed before the
+        method exits. If a message is available, a
+        :class:`qpid.messaging.Message` object is returned. If no message is
+        available, a :class:`qpid.messaging.exceptions.Empty` exception is
+        raised.
+
+        This is an internal method. External calls for get functionality
+        should be done using :meth:`basic_get`.
+
+        :param queue: The queue name to get the message from
+        :type queue: str
+
+        :return: The received message.
+        :rtype: :class:`qpid.messaging.Message`
+        """
+        rx = self.transport.session.receiver(queue)
+        try:
+            message = rx.fetch(timeout=0)
+        finally:
+            rx.close()
+        return message
+
+    def _put(self, routing_key, message, exchange=None, **kwargs):
+        """Synchronous send of a single message onto a queue or exchange.
+
+        An internal method which synchronously sends a single message onto
+        a given queue or exchange. If exchange is not specified,
+        the message is sent directly to a queue specified by routing_key.
+        If no queue is found by the name of routing_key while exchange is
+        not specified an exception is raised. If an exchange is specified,
+        then the message is delivered onto the requested
+        exchange using routing_key. Message sending is synchronous using
+        sync=True because large messages in kombu funtests were not being
+        fully sent before the receiver closed.
+
+        This method creates a :class:`qpid.messaging.endpoints.Sender` to
+        send the message to the queue using the
+        :class:`qpid.messaging.endpoints.Session` created and referenced by
+        the associated :class:`Transport`. The sender is closed before the
+        method exits.
+
+        External calls for put functionality should be done using
+        :meth:`basic_publish`.
+
+        :param routing_key: If exchange is None, treated as the queue name
+            to send the message to. If exchange is not None, treated as the
+            routing_key to use as the message is submitted onto the exchange.
+        :type routing_key: str
+        :param message: The message to be sent as prepared by
+            :meth:`basic_publish`.
+        :type message: dict
+        :keyword exchange: keyword parameter of the exchange this message
+            should be sent on. If no exchange is specified, the message is
+            sent directly to a queue specified by routing_key.
+        :type exchange: str
+        """
+        if not exchange:
+            address = '%s; {assert: always, node: {type: queue}}' % \
+                      routing_key
+            msg_subject = None
+        else:
+            address = '%s/%s; {assert: always, node: {type: topic}}' % (
+                exchange, routing_key)
+            msg_subject = str(routing_key)
+        sender = self.transport.session.sender(address)
+        qpid_message = qpid.messaging.Message(content=message,
+                                              subject=msg_subject)
+        try:
+            sender.send(qpid_message, sync=True)
+        finally:
+            sender.close()
+
+    def _purge(self, queue):
+        """Purge all undelivered messages from a queue specified by name.
+
+        An internal method to purge all undelivered messages from a queue
+        specified by name. The queue message depth is first checked,
+        and then the broker is asked to purge that number of messages. The
+        integer number of messages requested to be purged is returned. The
+        actual number of messages purged may be different than the
+        requested number of messages to purge (see below).
+
+        Sometimes delivered messages are asked to be purged, but are not.
+        This case fails silently, which is the correct behavior when a
+        message that has been delivered to a different consumer, who has
+        not ACKed the message, and still has an active session with the
+        broker. Messages in that case are not safe for purging and will be
+        retained by the broker. The client is unable to change this
+        delivery behavior.
+
+        This is an internal method. External calls for purge functionality
+        should be done using :meth:`queue_purge`.
+
+        :param queue: the name of the queue to be purged
+        :type queue: str
+
+        :return: The number of messages requested to be purged.
+        :rtype: int
+        """
+        queue_to_purge = self._broker.getQueue(queue)
+        message_count = queue_to_purge.values['msgDepth']
+        if message_count > 0:
+            queue_to_purge.purge(message_count)
+        return message_count
+
+    def _size(self, queue):
+        """Get the number of messages in a queue specified by name.
+
+        An internal method to return the number of messages in a queue
+        specified by name. It returns an integer count of the number
+        of messages currently in the queue.
+
+        :param queue: The name of the queue to be inspected for the number
+            of messages
+        :type queue: str
+
+        :return the number of messages in the queue specified by name.
+        :rtype: int
+        """
+        queue_to_check = self._broker.getQueue(queue)
+        message_depth = queue_to_check.values['msgDepth']
+        return message_depth
+
+    def _delete(self, queue, *args, **kwargs):
+        """Delete a queue and all messages on that queue.
+
+        An internal method to delete a queue specified by name and all the
+        messages on it. First, all messages are purged from a queue using a
+        call to :meth:`_purge`. Second, the broker is asked to delete the
+        queue.
+
+        This is an internal method. External calls for queue delete
+        functionality should be done using :meth:`queue_delete`.
+
+        :param queue: The name of the queue to be deleted.
+        :type queue: str
+        """
+        self._purge(queue)
+        self._broker.delQueue(queue)
+
+    def _has_queue(self, queue, **kwargs):
+        """Determine if the broker has a queue specified by name.
+
+        :param queue: The queue name to check if the queue exists.
+        :type queue: str
+
+        :return: True if a queue exists on the broker, and false
+            otherwise.
+        :rtype: bool
+        """
+        if self._broker.getQueue(queue):
+            return True
+        else:
+            return False
+
+    def queue_declare(self, queue, passive=False, durable=False,
+                      exclusive=False, auto_delete=True, nowait=False,
+                      arguments=None):
+        """Create a new queue specified by name.
+
+        If the queue already exists, no change is made to the queue,
+        and the return value returns information about the existing queue.
+
+        The queue name is required and specified as the first argument.
+
+        If passive is True, the server will not create the queue. The
+        client can use this to check whether a queue exists without
+        modifying the server state. Default is False.
+
+        If durable is True, the queue will be durable. Durable queues
+        remain active when a server restarts. Non-durable queues (
+        transient queues) are purged if/when a server restarts. Note that
+        durable queues do not necessarily hold persistent messages,
+        although it does not make sense to send persistent messages to a
+        transient queue. Default is False.
+
+        If exclusive is True, the queue will be exclusive. Exclusive queues
+        may only be consumed by the current connection. Setting the
+        'exclusive' flag always implies 'auto-delete'. Default is False.
+
+        If auto_delete is True,  the queue is deleted when all consumers
+        have finished using it. The last consumer can be cancelled either
+        explicitly or because its channel is closed. If there was no
+        consumer ever on the queue, it won't be deleted. Default is True.
+
+        The nowait parameter is unused. It was part of the 0-9-1 protocol,
+        but this AMQP client implements 0-10 which removed the nowait option.
+
+        The arguments parameter is a set of arguments for the declaration of
+        the queue. Arguments are passed as a dict or None. This field is
+        ignored if passive is True. Default is None.
+
+        This method returns a :class:`~collections.namedtuple` with the name
+        'queue_declare_ok_t' and the queue name as 'queue', message count
+        on the queue as 'message_count', and the number of active consumers
+        as 'consumer_count'. The named tuple values are ordered as queue,
+        message_count, and consumer_count respectively.
+
+        Due to Celery's non-ACKing of events, a ring policy is set on any
+        queue that starts with the string 'celeryev' or ends with the string
+        'pidbox'. These are celery event queues, and Celery does not ack
+        them, causing the messages to build-up. Eventually Qpid stops serving
+        messages unless the 'ring' policy is set, at which point the buffer
+        backing the queue becomes circular.
+
+        :param queue: The name of the queue to be created.
+        :type queue: str
+        :param passive: If True, the sever will not create the queue.
+        :type passive: bool
+        :param durable: If True, the queue will be durable.
+        :type durable: bool
+        :param exclusive: If True, the queue will be exclusive.
+        :type exclusive: bool
+        :param auto_delete: If True, the queue is deleted when all
+            consumers have finished using it.
+        :type auto_delete: bool
+        :param nowait: This parameter is unused since the 0-10
+            specification does not include it.
+        :type nowait: bool
+        :param arguments: A set of arguments for the declaration of the
+            queue.
+        :type arguments: dict or None
+
+        :return: A named tuple representing the declared queue as a named
+            tuple. The tuple values are ordered as queue, message count,
+            and the active consumer count.
+        :rtype: :class:`~collections.namedtuple`
+
+        """
+        options = {'passive': passive,
+                   'durable': durable,
+                   'exclusive': exclusive,
+                   'auto-delete': auto_delete,
+                   'arguments': arguments}
+        if queue.startswith('celeryev') or queue.endswith('pidbox'):
+            options['qpid.policy_type'] = 'ring'
+        try:
+            self._broker.addQueue(queue, options=options)
+        except Exception as err:
+            if OBJECT_ALREADY_EXISTS_STRING not in err.message:
+                raise err
+        queue_to_check = self._broker.getQueue(queue)
+        message_count = queue_to_check.values['msgDepth']
+        consumer_count = queue_to_check.values['consumerCount']
+        return amqp.protocol.queue_declare_ok_t(queue, message_count,
+                                                consumer_count)
+
+    def queue_delete(self, queue, if_unused=False, if_empty=False, **kwargs):
+        """Delete a queue by name.
+
+        Delete a queue specified by name. Using the if_unused keyword
+        argument, the delete can only occur if there are 0 consumers bound
+        to it. Using the if_empty keyword argument, the delete can only
+        occur if there are 0 messages in the queue.
+
+        :param queue: The name of the queue to be deleted.
+        :type queue: str
+        :keyword if_unused: If True, delete only if the queue has 0
+            consumers. If False, delete a queue even with consumers bound
+            to it.
+        :type if_unused: bool
+        :keyword if_empty: If True, only delete the queue if it is empty. If
+            False, delete the queue if it is empty or not.
+        :type if_empty: bool
+        """
+        if self._has_queue(queue):
+            if if_empty and self._size(queue):
+                return
+            queue_obj = self._broker.getQueue(queue)
+            consumer_count = queue_obj.getAttributes()['consumerCount']
+            if if_unused and consumer_count > 0:
+                return
+            self._delete(queue)
+
+    @QpidMessagingExceptionHandler(OBJECT_ALREADY_EXISTS_STRING)
+    def exchange_declare(self, exchange='', type='direct', durable=False,
+                         **kwargs):
+        """Create a new exchange.
+
+        Create an exchange of a specific type, and optionally have the
+        exchange be durable. If an exchange of the requested name already
+        exists, no action is taken and no exceptions are raised. Durable
+        exchanges will survive a broker restart, non-durable exchanges will
+        not.
+
+        Exchanges provide behaviors based on their type. The expected
+        behaviors are those defined in the AMQP 0-10 and prior
+        specifications including 'direct', 'topic', and 'fanout'
+        functionality.
+
+        :keyword type: The exchange type. Valid values include 'direct',
+        'topic', and 'fanout'.
+        :type type: str
+        :keyword exchange: The name of the exchange to be created. If no
+        exchange is specified, then a blank string will be used as the name.
+        :type exchange: str
+        :keyword durable: True if the exchange should be durable, or False
+        otherwise.
+        :type durable: bool
+        """
+        options = {'durable': durable}
+        self._broker.addExchange(type, exchange, options)
+
+    def exchange_delete(self, exchange_name, **kwargs):
+        """Delete an exchange specified by name
+
+        :param exchange_name: The name of the exchange to be deleted.
+        :type exchange_name: str
+        """
+        self._broker.delExchange(exchange_name)
+
+    def queue_bind(self, queue, exchange, routing_key, **kwargs):
+        """Bind a queue to an exchange with a bind key.
+
+        Bind a queue specified by name, to an exchange specified by name,
+        with a specific bind key. The queue and exchange must already
+        exist on the broker for the bind to complete successfully. Queues
+        may be bound to exchanges multiple times with different keys.
+
+        :param queue: The name of the queue to be bound.
+        :type queue: str
+        :param exchange: The name of the exchange that the queue should be
+            bound to.
+        :type exchange: str
+        :param routing_key: The bind key that the specified queue should
+            bind to the specified exchange with.
+        :type routing_key: str
+        """
+        self._broker.bind(exchange, queue, routing_key)
+
+    def queue_unbind(self, queue, exchange, routing_key, **kwargs):
+        """Unbind a queue from an exchange with a given bind key.
+
+        Unbind a queue specified by name, from an exchange specified by
+        name, that is already bound with a bind key. The queue and
+        exchange must already exist on the broker, and bound with the bind
+        key for the operation to complete successfully. Queues may be
+        bound to exchanges multiple times with different keys, thus the
+        bind key is a required field to unbind in an explicit way.
+
+        :param queue: The name of the queue to be unbound.
+        :type queue: str
+        :param exchange: The name of the exchange that the queue should be
+            unbound from.
+        :type exchange: str
+        :param routing_key: The existing bind key between the specified
+            queue and a specified exchange that should be unbound.
+        :type routing_key: str
+        """
+        self._broker.unbind(exchange, queue, routing_key)
+
+    def queue_purge(self, queue, **kwargs):
+        """Remove all undelivered messages from queue.
+
+        Purge all undelivered messages from a queue specified by name. The
+        queue message depth is first checked, and then the broker is asked
+        to purge that number of messages. The integer number of messages
+        requested to be purged is returned. The actual number of messages
+        purged may be different than the requested number of messages to
+        purge.
+
+        Sometimes delivered messages are asked to be purged, but are not.
+        This case fails silently, which is the correct behavior when a
+        message that has been delivered to a different consumer, who has
+        not ACKed the message, and still has an active session with the
+        broker. Messages in that case are not safe for purging and will be
+        retained by the broker. The client is unable to change this
+        delivery behavior.
+
+        Internally, this method relies on :meth:`_purge`.
+
+        :param queue: The name of the queue which should have all messages
+            removed.
+        :type queue: str
+
+        :return: The number of messages requested to be purged.
+        :rtype: int
+        """
+        return self._purge(queue)
+
+    def basic_get(self, queue, no_ack=False, **kwargs):
+        """Non-blocking single message get and ACK from a queue by name.
+
+        Internally this method uses :meth:`_get` to fetch the message. If
+        an :class:`~qpid.messaging.exceptions.Empty` exception is raised by
+        :meth:`_get`, this method silences it and returns None. If
+        :meth:`_get` does return a message, that message is ACKed. The no_ack
+        parameter has no effect on ACKing behavior, and all messages are
+        ACKed in all cases. This method never adds fetched Messages to the
+        internal QoS object for asynchronous ACKing.
+
+        This method converts the object type of the method as it passes
+        through. Fetching from the broker, :meth:`_get` returns a
+        :class:`qpid.messaging.Message`, but this method takes the payload
+        of the :class:`qpid.messaging.Message` and instantiates a
+        :class:`~kombu.transport.virtual.Message` object with the payload
+        based on the class setting of self.Message.
+
+        :param queue: The queue name to fetch a message from.
+        :type queue: str
+        :keyword no_ack: The no_ack parameter has no effect on the ACK
+            behavior of this method. Un-ACKed messages create a memory leak in
+            qpid.messaging, and need to be ACKed in all cases.
+        :type noack: bool
+
+        :return: The received message.
+        :rtype: :class:`~kombu.transport.virtual.Message`
+        """
+        try:
+            qpid_message = self._get(queue)
+            raw_message = qpid_message.content
+            message = self.Message(self, raw_message)
+            self.transport.session.acknowledge(message=qpid_message)
+            return message
+        except Empty:
+            pass
+
+    def basic_ack(self, delivery_tag):
+        """Acknowledge a message by delivery_tag.
+
+        Acknowledges a message referenced by delivery_tag. Messages can
+        only be ACKed using :meth:`basic_ack` if they were acquired using
+        :meth:`basic_consume`. This is the ACKing portion of the
+        asynchronous read behavior.
+
+        Internally, this method uses the :class:`QoS` object, which stores
+        messages and is responsible for the ACKing.
+
+        :param delivery_tag: The delivery tag associated with the message
+            to be acknowledged.
+        :type delivery_tag: int
+        """
+        self.qos.ack(delivery_tag)
+
+    def basic_reject(self, delivery_tag, requeue=False):
+        """Reject a message by delivery_tag.
+
+        Rejects a message that has been received by the Channel, but not
+        yet acknowledged. Messages are referenced by their delivery_tag.
+
+        If requeue is False, the rejected message will be dropped by the
+        broker and not delivered to any other consumers. If requeue is
+        True, then the rejected message will be requeued for delivery to
+        another consumer, potentially to the same consumer who rejected the
+        message previously.
+
+        :param delivery_tag: The delivery tag associated with the message
+            to be rejected.
+        :type delivery_tag: int
+        :keyword requeue: If False, the rejected message will be dropped by
+            the broker and not delivered to any other consumers. If True,
+            then the rejected message will be requeued for delivery to
+            another consumer, potentially to the same consumer who rejected
+            the message previously.
+        :type requeue: bool
+
+        """
+        self.qos.reject(delivery_tag, requeue=requeue)
+
+    def basic_consume(self, queue, no_ack, callback, consumer_tag, **kwargs):
+        """Start an asynchronous consumer that reads from a queue.
+
+        This method starts a consumer of type
+        :class:`~qpid.messaging.endpoints.Receiver` using the
+        :class:`~qpid.messaging.endpoints.Session` created and referenced by
+        the :class:`Transport` that reads messages from a queue
+        specified by name until stopped by a call to :meth:`basic_cancel`.
+
+
+        Messages are available later through a synchronous call to
+        :meth:`Transport.drain_events`, which will drain from the consumer
+        started by this method. :meth:`Transport.drain_events` is
+        synchronous, but the receiving of messages over the network occurs
+        asynchronously, so it should still perform well.
+        :meth:`Transport.drain_events` calls the callback provided here with
+        the Message of type self.Message.
+
+        Each consumer is referenced by a consumer_tag, which is provided by
+        the caller of this method.
+
+        This method sets up the callback onto the self.connection object in a
+        dict keyed by queue name. :meth:`~Transport.drain_events` is
+        responsible for calling that callback upon message receipt.
+
+        All messages that are received are added to the QoS object to be
+        saved for asynchronous ACKing later after the message has been
+        handled by the caller of :meth:`~Transport.drain_events`. Messages
+        can be ACKed after being received through a call to :meth:`basic_ack`.
+
+        If no_ack is True, the messages are immediately ACKed to avoid a
+        memory leak in qpid.messaging when messages go un-ACKed. The no_ack
+        flag indicates that the receiver of the message does not intent to
+        call :meth:`basic_ack`.
+
+        :meth:`basic_consume` transforms the message object type prior to
+        calling the callback. Initially the message comes in as a
+        :class:`qpid.messaging.Message`. This method unpacks the payload
+        of the :class:`qpid.messaging.Message` and creates a new object of
+        type self.Message.
+
+        This method wraps the user delivered callback in a runtime-built
+        function which provides the type transformation from
+        :class:`qpid.messaging.Message` to
+        :class:`~kombu.transport.virtual.Message`, and adds the message to
+        the associated :class:`QoS` object for asynchronous ACKing
+        if necessary.
+
+        :param queue: The name of the queue to consume messages from
+        :type queue: str
+        :param no_ack: If True, then messages will not be saved for ACKing
+            later, but will be ACKed immediately. If False, then messages
+            will be saved for ACKing later with a call to :meth:`basic_ack`.
+        :type no_ack: bool
+        :param callback: a callable that will be called when messages
+            arrive on the queue.
+        :type callback: a callable object
+        :param consumer_tag: a tag to reference the created consumer by.
+            This consumer_tag is needed to cancel the consumer.
+        :type consumer_tag: an immutable object
+        """
+        self._tag_to_queue[consumer_tag] = queue
+
+        def _callback(qpid_message):
+            raw_message = qpid_message.content
+            message = self.Message(self, raw_message)
+            delivery_tag = message.delivery_tag
+            self.qos.append(qpid_message, delivery_tag)
+            if no_ack:
+                # Celery will not ack this message later, so we should to
+                # avoid a memory leak in qpid.messaging due to un-ACKed
+                # messages.
+                self.basic_ack(delivery_tag)
+            return callback(message)
+
+        self.connection._callbacks[queue] = _callback
+        new_receiver = self.transport.session.receiver(queue)
+        new_receiver.capacity = self.qos.prefetch_count
+        self._receivers[consumer_tag] = new_receiver
+
+    def basic_cancel(self, consumer_tag):
+        """Cancel consumer by consumer tag.
+
+        Request the consumer stops reading messages from its queue. The
+        consumer is a :class:`~qpid.messaging.endpoints.Receiver`, and it is
+        closed using :meth:`~qpid.messaging.endpoints.Receiver.close`.
+
+        This method also cleans up all lingering references of the consumer.
+
+        :param consumer_tag: The tag which refers to the consumer to be
+            cancelled. Originally specified when the consumer was created
+            as a parameter to :meth:`basic_consume`.
+        :type consumer_tag: an immutable object
+        """
+        if consumer_tag in self._receivers:
+            receiver = self._receivers.pop(consumer_tag)
+            receiver.close()
+            queue = self._tag_to_queue.pop(consumer_tag, None)
+            self.connection._callbacks.pop(queue, None)
+
+    def close(self):
+        """Close Channel and all associated messages.
+
+        This cancels all consumers by calling :meth:`basic_cancel` for each
+        known consumer_tag. It also closes the self._broker sessions. Closing
+        the sessions implicitly causes all outstanding, un-ACKed messages to
+        be considered undelivered by the broker.
+        """
+        if not self.closed:
+            self.closed = True
+            for consumer_tag in self._receivers.keys():
+                self.basic_cancel(consumer_tag)
+            if self.connection is not None:
+                self.connection.close_channel(self)
+            self._broker.close()
+
+    @property
+    def qos(self):
+        """:class:`QoS` manager for this channel.
+
+        Lazily instantiates an object of type :class:`QoS` upon access to
+        the self.qos attribute.
+
+        :return: An already existing, or newly created QoS object
+        :rtype: :class:`QoS`
+        """
+        if self._qos is None:
+            self._qos = self.QoS(self.transport.session)
+        return self._qos
+
+    def basic_qos(self, prefetch_count, *args):
+        """Change :class:`QoS` settings for this Channel.
+
+        Set the number of un-acknowledged messages this Channel can fetch and
+        hold. The prefetch_value is also used as the capacity for any new
+        :class:`~qpid.messaging.endpoints.Receiver` objects.
+
+        Currently, this value is hard coded to 1.
+
+        :param prefetch_count: Not used. This method is hard-coded to 1.
+        :type prefetch_count: int
+        """
+        self.qos.prefetch_count = 1
+
+    def prepare_message(self, body, priority=None, content_type=None,
+                        content_encoding=None, headers=None, properties=None):
+        """Prepare message data for sending.
+
+        This message is typically called by
+        :meth:`kombu.messaging.Producer._publish` as a preparation step in
+        message publication.
+
+        :param body: The body of the message
+        :type body: str
+        :keyword priority: A number between 0 and 9 that sets the priority of
+            the message.
+        :type priority: int
+        :keyword content_type: The content_type the message body should be
+            treated as. If this is unset, the
+            :class:`qpid.messaging.endpoints.Sender` object tries to
+            autodetect the content_type from the body.
+        :type content_type: str
+        :keyword content_encoding: The content_encoding the message body is
+            encoded as.
+        :type content_encoding: str
+        :keyword headers: Additional Message headers that should be set.
+            Passed in as a key-value pair.
+        :type headers: dict
+        :keyword properties: Message properties to be set on the message.
+        :type properties: dict
+
+        :return: Returns a dict object that encapsulates message
+            attributes. See parameters for more details on attributes that
+            can be set.
+        :rtype: dict
+        """
+        properties = properties or {}
+        info = properties.setdefault('delivery_info', {})
+        info['priority'] = priority or 0
+
+        return {'body': body,
+                'content-encoding': content_encoding,
+                'content-type': content_type,
+                'headers': headers or {},
+                'properties': properties or {}}
+
+    def basic_publish(self, message, exchange, routing_key, **kwargs):
+        """Publish message onto an exchange using a routing key.
+
+        Publish a message onto an exchange specified by name using a
+        routing key specified by routing_key. Prepares the message in the
+        following ways before sending:
+
+        - encodes the body using :meth:`encode_body`
+        - wraps the body as a buffer object, so that
+            :class:`qpid.messaging.endpoints.Sender` uses a content type
+            that can support arbitrarily large messages.
+        - assigns a delivery_tag generated through self._delivery_tags
+        - sets the exchange and routing_key info as delivery_info
+
+        Internally uses :meth:`_put` to send the message synchronously. This
+        message is typically called by
+        :class:`kombu.messaging.Producer._publish` as the final step in
+        message publication.
+
+        :param message: A dict containing key value pairs with the message
+            data. A valid message dict can be generated using the
+            :meth:`prepare_message` method.
+        :type message: dict
+        :param exchange: The name of the exchange to submit this message
+            onto.
+        :type exchange: str
+        :param routing_key: The routing key to be used as the message is
+            submitted onto the exchange.
+        :type routing_key: str
+        """
+        message['body'], body_encoding = self.encode_body(
+            message['body'], self.body_encoding,
+        )
+        message['body'] = buffer(message['body'])
+        props = message['properties']
+        props.update(
+            body_encoding=body_encoding,
+            delivery_tag=next(self._delivery_tags),
+        )
+        props['delivery_info'].update(
+            exchange=exchange,
+            routing_key=routing_key,
+        )
+        self._put(routing_key, message, exchange, **kwargs)
+
+    def encode_body(self, body, encoding=None):
+        """Encode a body using an optionally specified encoding.
+
+        The encoding can be specified by name, and is looked up in
+        self.codecs. self.codecs uses strings as its keys which specify
+        the name of the encoding, and then the value is an instantiated
+        object that can provide encoding/decoding of that type through
+        encode and decode methods.
+
+        :param body: The body to be encoded.
+        :type body: str
+        :keyword encoding: The encoding type to be used. Must be a supported
+            codec listed in self.codecs.
+        :type encoding: str
+
+        :return: If encoding is specified, return a tuple with the first
+            position being the encoded body, and the second position the
+            encoding used. If encoding is not specified, the body is passed
+            through unchanged.
+        :rtype: tuple
+        """
+        if encoding:
+            return self.codecs.get(encoding).encode(body), encoding
+        return body, encoding
+
+    def decode_body(self, body, encoding=None):
+        """Decode a body using an optionally specified encoding.
+
+        The encoding can be specified by name, and is looked up in
+        self.codecs. self.codecs uses strings as its keys which specify
+        the name of the encoding, and then the value is an instantiated
+        object that can provide encoding/decoding of that type through
+        encode and decode methods.
+
+        :param body: The body to be encoded.
+        :type body: str
+        :keyword encoding: The encoding type to be used. Must be a supported
+            codec listed in self.codecs.
+        :type encoding: str
+
+        :return: If encoding is specified, the decoded body is returned.
+            If encoding is not specified, the body is returned unchanged.
+        :rtype: str
+        """
+        if encoding:
+            return self.codecs.get(encoding).decode(body)
+        return body
+
+    def typeof(self, exchange, default='direct'):
+        """Get the exchange type.
+
+        Lookup and return the exchange type for an exchange specified by
+        name. Exchange types are expected to be 'direct', 'topic',
+        and 'fanout', which correspond with exchange functionality as
+        specified in AMQP 0-10 and earlier. If the exchange cannot be
+        found, the default exchange type is returned.
+
+        :param exchange: The exchange to have its type lookup up.
+        :type exchange: str
+        :keyword default: The type of exchange to assume if the exchange does
+            not exist.
+        :type default: str
+
+        :return: The exchange type either 'direct', 'topic', or 'fanout'.
+        :rtype: str
+        """
+        qpid_exchange = self._broker.getExchange(exchange)
+        if qpid_exchange:
+            qpid_exchange_attributes = qpid_exchange.getAttributes()
+            return qpid_exchange_attributes["type"]
+        else:
+            return default
+
+
+class Connection(object):
+    """Encapsulate a connection object for the :class:`Transport`.
+
+    A Connection object is created by a :class:`Transport` during a call to
+    :meth:`Transport.establish_connection`. The :class:`Transport` passes in
+    connection options as keywords that should be used for any connections
+    created. Each :class:`Transport` creates exactly one Connection.
+
+    A Connection object maintains a reference to a
+    :class:`~qpid.messaging.endpoints.Connection` which can be accessed
+    through a bound getter method named :meth:`get_qpid_connection` method.
+    Each Channel uses a the Connection for each
+    :class:`~qpidtoollibs.BrokerAgent`, and the Transport maintains a session
+    for all senders and receivers.
+
+    The Connection object is also responsible for maintaining the
+    dictionary of references to callbacks that should be called when
+    messages are received. These callbacks are saved in _callbacks,
+    and keyed on the queue name associated with the received message. The
+    _callbacks are setup in :meth:`Channel.basic_consume`, removed in
+    :meth:`Channel.basic_cancel`, and called in
+    :meth:`Transport.drain_events`.
+
+    The following keys are expected to be passed in as keyword arguments
+    at a minimum:
+
+    All keyword arguments are collected into the connection_options dict
+    and passed directly through to
+    :meth:`qpid.messaging.endpoints.Connection.establish`.
+    """
+
+    # A class reference to the :class:`Channel` object
+    Channel = Channel
+    SASL_ANONYMOUS_MECH = 'ANONYMOUS'
+
+    def __init__(self, **connection_options):
+        """Instantiate a Connection object.
+
+        The following parameters are expected:
+
+        * host: The host that connections should connect to.
+        * port: The port that connection should connect to.
+        * username: The username that connections should connect with.
+        * password: The password that connections should connect with.
+        * transport: The transport type that connections should use. Either
+              'tcp', or 'ssl' are expected as values.
+        * timeout: the timeout used when a Connection connects to the broker.
+        * sasl_mechanisms: The sasl authentication mechanism type to use.
+              refer to SASL documentation for an explanation of valid values.
+
+        Creates a :class:`qpid.messaging.endpoints.Connection` object with
+        the saved parameters, and stores it as _qpid_conn.
+
+        qpid.messaging has an AuthenticationFailure exception type, but
+        instead raises a ConnectionError with a message that indicates an
+        authentication failure occurred in those situations. ConnectionError
+        is listed as a recoverable error type, so kombu will attempt to retry
+        if a ConnectionError is raised. Retrying the operation without
+        adjusting the credentials is not correct, so this method specifically
+        checks for a ConnectionError that indicates an Authentication Failure
+        occurred. In those situations, the error type is mutated while
+        preserving the original message and raised so kombu will allow the
+        exception to not be considered recoverable.
+
+        """
+        self.connection_options = connection_options
+        self.channels = []
+        self._callbacks = {}
+        self._qpid_conn = None
+        establish = qpid.messaging.Connection.establish
+
+        # There is a behavior difference in qpid.messaging's sasl_mechanism
+        # selection method and cyrus-sasl's. The former will put PLAIN before
+        # ANONYMOUS if a username and password is given, but the latter will
+        # simply take whichever mech is listed first. Thus, if we had
+        # "ANONYMOUS PLAIN" as the default, the user would never be able to
+        # select PLAIN if cyrus-sasl was installed.
+
+        # The following code will put ANONYMOUS last in the mech list, and then
+        # try sasl mechs one by one. This should still result in secure
+        # behavior since it will select the first suitable mech. Unsuitable
+        # mechs will be rejected by the server.
+
+        sasl_mechanisms = [x for x in connection_options['sasl_mechanisms'].split() \
+                           if x != self.SASL_ANONYMOUS_MECH]
+        if self.SASL_ANONYMOUS_MECH in connection_options['sasl_mechanisms'].split():
+            sasl_mechanisms.append(self.SASL_ANONYMOUS_MECH)
+
+        for sasl_mech in sasl_mechanisms:
+            try:
+                logger.debug("Attempting to connect to qpid with SASL mechanism %s" % sasl_mech)
+                modified_conn_opts = self.connection_options
+                modified_conn_opts['sasl_mechanisms'] = sasl_mech
+                self._qpid_conn = establish(**modified_conn_opts)
+                # connection was successful if we got this far
+                logger.info("Connected to qpid with SASL mechanism %s" % sasl_mech)
+                break
+            except ConnectionError as conn_exc:
+                coded_as_auth_failure = getattr(conn_exc, 'code', None) == 320
+                contains_auth_fail_text = 'Authentication failed' in conn_exc.text
+                contains_mech_fail_text = 'sasl negotiation failed: no mechanism agreed'\
+                                          in conn_exc.text
+                if coded_as_auth_failure or contains_auth_fail_text or contains_mech_fail_text:
+                    logger.debug("Unable to connect to qpid with SASL mechanism %s" % sasl_mech)
+                    continue
+                raise
+
+        if not self.get_qpid_connection():
+            exc = sys.exc_info()
+            logger.error("Unable to authenticate to qpid using the following mechanisms: %s" %
+                         sasl_mechanisms)
+            raise AuthenticationFailure(sys.exc_info()[1])
+
+    def get_qpid_connection(self):
+        """Return the existing connection (singleton).
+
+        :return: The existing qpid.messaging.Connection
+        :rtype: :class:`qpid.messaging.endpoints.Connection`
+        """
+        return self._qpid_conn
+
+    def close_channel(self, channel):
+        """Close a Channel.
+
+        Close a channel specified by a reference to the :class:`Channel`
+        object.
+
+        :param channel: Channel that should be closed.
+        :type channel: Channel
+        """
+        try:
+            self.channels.remove(channel)
+        except ValueError:
+            pass
+        finally:
+            channel.connection = None
+
+
+class ReceiversMonitor(threading.Thread):
+    """A monitoring thread that reads and handles messages from all receivers.
+
+    A single instance of ReceiversMonitor is expected to be created by
+    :class:`Transport`.
+
+    In :meth:`monitor_receivers`, the thread monitors all receivers
+    associated with the session created by the Transport using the blocking
+    call to session.next_receiver(). When any receiver has messages
+    available, a symbol '0' is written to the self._w_fd file descriptor. The
+    :meth:`monitor_receivers` is designed not to exit, and loops over
+    session.next_receiver() forever.
+
+    The entry point of the thread is :meth:`run` which calls
+    :meth:`monitor_receivers` and catches and logs all exceptions raised.
+    After an exception is logged, the method sleeps for 10 seconds, and
+    re-enters :meth:`monitor_receivers`
+
+    The thread is designed to be daemonized, and will be forcefully killed
+    when all non-daemon threads have already exited.
+    """
+
+    def __init__(self, session, w):
+        """Instantiate a ReceiversMonitor object
+
+        :param session: The session which needs all of its receivers
+            monitored.
+        :type session: :class:`qpid.messaging.endpoints.Session`
+        :param w: The file descriptor to write the '0' into when
+            next_receiver unblocks.
+        :type w: int
+        """
+        super(ReceiversMonitor, self).__init__()
+        self._session = session
+        self._w_fd = w
+
+    def run(self):
+        """Thread entry point for ReceiversMonitor
+
+        Calls :meth:`monitor_receivers` with a log-and-reenter behavior. This
+        guards against unexpected exceptions which could cause this thread to
+        exit unexpectedly.
+
+        If a recoverable error occurs, then the exception needs to be
+        propagated to the Main Thread where an exception handler can properly
+        handle it. An Exception is checked if it is recoverable, and if so,
+        it is stored as saved_exception on the self._session object. The
+        character 'e' is then written to the self.w_fd file descriptor
+        causing Main Thread to raise the saved exception. Once the Exception
+        info is saved and the file descriptor is written, this Thread
+        gracefully exits.
+
+        Typically recoverable errors are connection errors, and can be
+        recovered through a call to Transport.establish_connection which will
+        spawn a new ReceiversMonitor Thread.
+        """
+        while True:
+            try:
+                self.monitor_receivers()
+            except Exception as error:
+                if isinstance(error, Transport.connection_errors):
+                    self._session.saved_exception = error
+                    os.write(self._w_fd, 'e')
+                    return
+                logger.error(error)
+            time.sleep(10)
+
+    def monitor_receivers(self):
+        """Monitor all receivers, and write to _w_fd when a message is ready.
+
+        The call to next_receiver() blocks until a message is ready. Once a
+        message is ready, write a '0' to _w_fd.
+        """
+        while True:
+            self._session.next_receiver()
+            os.write(self._w_fd, '0')
+
+
+class Transport(base.Transport):
+    """Kombu native transport for a Qpid broker.
+
+    Provide a native transport for Kombu that allows consumers and
+    producers to read and write messages to/from a broker. This Transport
+    is capable of supporting both synchronous and asynchronous reading.
+    All writes are synchronous through the :class:`Channel` objects that
+    support this Transport.
+
+    Asynchronous reads are done using a call to :meth:`drain_events`,
+    which synchronously reads messages that were fetched asynchronously, and
+    then handles them through calls to the callback handlers maintained on
+    the :class:`Connection` object.
+
+    The Transport also provides methods to establish and close a connection
+    to the broker. This Transport establishes a factory-like pattern that
+    allows for singleton pattern to consolidate all Connections into a single
+    one.
+
+    The Transport can create :class:`Channel` objects to communicate with the
+    broker with using the :meth:`create_channel` method.
+
+    The Transport identifies recoverable errors, allowing for error recovery
+    when certain exceptions occur. These exception types are stored in the
+    Transport class attribute connection_errors. This adds support for Kombu
+    to retry an operation if a ConnectionError occurs. ConnectionErrors occur
+    when the Transport cannot communicate with the Qpid broker.
+
+    """
+
+    # Reference to the class that should be used as the Connection object
+    Connection = Connection
+
+    # The default port
+    default_port = DEFAULT_PORT
+
+    # This Transport does not specify a polling interval.
+    polling_interval = None
+
+    # This Transport does support the Celery asynchronous event model.
+    supports_ev = True
+
+    # The driver type and name for identification purposes.
+    driver_type = 'qpid'
+    driver_name = 'qpid'
+
+    connection_errors = (
+        ConnectionError,
+        select.error
+    )
+
+    def __init__(self, *args, **kwargs):
+        """Instantiate a Transport object.
+
+        This method creates a pipe, and saves the read and write file
+        descriptors as attributes. The behavior of the read file descriptor
+        is modified to be non-blocking using fcntl.fcntl.
+        """
+        self.verify_runtime_environment()
+        super(Transport, self).__init__(*args, **kwargs)
+        self.r, self._w = os.pipe()
+        fcntl.fcntl(self.r, fcntl.F_SETFL, os.O_NONBLOCK)
+
+    def verify_runtime_environment(self):
+        """Verify that the runtime environment is acceptable.
+
+        This method is called as part of __init__ and raises a RuntimeError
+        in Python3 or PyPi environments. This module is not compatible with
+        Python3 or PyPi. The RuntimeError identifies this to the user up
+        front along with suggesting Python 2.7 be used instead.
+        """
+        if getattr(sys, 'pypy_version_info', None):
+            raise RuntimeError('The Qpid transport for Kombu does not '
+                               'support PyPy. Try using Python 2.7')
+        if PY3:
+            raise RuntimeError('The Qpid transport for Kombu does not '
+                               'support Python 3. Try using Python 2.7')
+
+    def on_readable(self, connection, loop):
+        """Handle any messages associated with this Transport.
+
+        This method clears a single message from the externally monitored
+        file descriptor by issuing a read call to the self.r file descriptor
+        which removes a single '0' character that was placed into the pipe
+        by :class:`ReceiversMonitor`. Once a '0' is read, all available
+        events are drained through a call to :meth:`drain_events`.
+
+        The behavior of self.r is adjusted in __init__ to be non-blocking,
+        ensuring that an accidental call to this method when no more messages
+        will arrive will not cause indefinite blocking.
+
+        If the self.r file descriptor returns the character 'e', a
+        recoverable error occurred in the background thread, and this thread
+        should raise the saved exception. The exception is stored as
+        saved_exception on the session object.
+
+        Nothing is expected to be returned from :meth:`drain_events` because
+        :meth:`drain_events` handles messages by calling callbacks that are
+        maintained on the :class:`Connection` object. When
+        :meth:`drain_events` returns, all associated messages have been
+        handled.
+
+        This method calls drain_events() which reads as many messages as are
+        available for this Transport, and then returns. It blocks in the
+        sense that reading and handling a large number of messages may take
+        time, but it does not block waiting for a new message to arrive. When
+        :meth:`drain_events` is called a timeout is not specified, which
+        causes this behavior.
+
+        One interesting behavior of note is where multiple messages are
+        ready, and this method removes a single '0' character from
+        self.r, but :meth:`drain_events` may handle an arbitrary amount of
+        messages. In that case, extra '0' characters may be left on self.r
+        to be read, where messages corresponding with those '0' characters
+        have already been handled. The external epoll loop will incorrectly
+        think additional data is ready for reading, and will call
+        on_readable unnecessarily, once for each '0' to be read. Additional
+        calls to :meth:`on_readable` produce no negative side effects,
+        and will eventually clear out the symbols from the self.r file
+        descriptor. If new messages show up during this draining period,
+        they will also be properly handled.
+
+        :param connection: The connection associated with the readable
+            events, which contains the callbacks that need to be called for
+            the readable objects.
+        :type connection: Connection
+        :param loop: The asynchronous loop object that contains epoll like
+            functionality.
+        :type loop: kombu.async.Hub
+        """
+        symbol = os.read(self.r, 1)
+        if symbol == 'e':
+            raise self.session.saved_exception
+        try:
+            self.drain_events(connection)
+        except socket.timeout:
+            pass
+
+    def register_with_event_loop(self, connection, loop):
+        """Register a file descriptor and callback with the loop.
+
+        Register the callback self.on_readable to be called when an
+        external epoll loop sees that the file descriptor registered is
+        ready for reading. The file descriptor is created by this Transport,
+        and is updated by the ReceiversMonitor thread.
+
+        Because supports_ev == True, Celery expects to call this method to
+        give the Transport an opportunity to register a read file descriptor
+        for external monitoring by celery using an Event I/O notification
+        mechanism such as epoll. A callback is also registered that is to
+        be called once the external epoll loop is ready to handle the epoll
+        event associated with messages that are ready to be handled for
+        this Transport.
+
+        The registration call is made exactly once per Transport after the
+        Transport is instantiated.
+
+        :param connection: A reference to the connection associated with
+            this Transport.
+        :type connection: Connection
+        :param loop: A reference to the external loop.
+        :type loop: kombu.async.hub.Hub
+        """
+        loop.add_reader(self.r, self.on_readable, connection, loop)
+
+    def establish_connection(self):
+        """Establish a Connection object.
+
+        Determines the correct options to use when creating any connections
+        needed by this Transport, and create a :class:`Connection` object
+        which saves those values for connections generated as they are
+        needed. The options are a mixture of what is passed in through the
+        creator of the Transport, and the defaults provided by
+        :meth:`default_connection_params`. Options cover broker network
+        settings, timeout behaviors, authentication, and identity
+        verification settings.
+
+        This method also creates and stores a
+        :class:`~qpid.messaging.endpoints.Session` using the
+        :class:`~qpid.messaging.endpoints.Connection` created by this method.
+        The Session is stored on self.
+
+        :return: The created :class:`Connection` object is returned.
+        :rtype: :class:`Connection`
+        """
+        conninfo = self.client
+        for name, default_value in items(self.default_connection_params):
+            if not getattr(conninfo, name, None):
+                setattr(conninfo, name, default_value)
+        if conninfo.hostname == 'localhost':
+            conninfo.hostname = '127.0.0.1'
+        if conninfo.ssl:
+            conninfo.qpid_transport = 'ssl'
+            conninfo.transport_options['ssl_keyfile'] = conninfo.ssl[
+                'keyfile']
+            conninfo.transport_options['ssl_certfile'] = conninfo.ssl[
+                'certfile']
+            conninfo.transport_options['ssl_trustfile'] = conninfo.ssl[
+                'ca_certs']
+            if conninfo.ssl['cert_reqs'] == ssl.CERT_REQUIRED:
+                conninfo.transport_options['ssl_skip_hostname_check'] = False
+            else:
+                conninfo.transport_options['ssl_skip_hostname_check'] = True
+        else:
+            conninfo.qpid_transport = 'tcp'
+        opts = dict({'host': conninfo.hostname, 'port': conninfo.port,
+                     'username': conninfo.userid,
+                     'password': conninfo.password,
+                     'transport': conninfo.qpid_transport,
+                     'timeout': conninfo.connect_timeout,
+                     'sasl_mechanisms': conninfo.sasl_mechanisms},
+                    **conninfo.transport_options or {})
+        conn = self.Connection(**opts)
+        conn.client = self.client
+        self.session = conn.get_qpid_connection().session()
+        monitor_thread = ReceiversMonitor(self.session, self._w)
+        monitor_thread.daemon = True
+        monitor_thread.start()
+        return conn
+
+    def close_connection(self, connection):
+        """Close the :class:`Connection` object, and all associated
+        :class:`Channel` objects.
+
+        Iterates through all :class:`Channel` objects associated with the
+        :class:`Connection`, pops them from the list of channels, and calls
+        :meth:Channel.close` on each.
+
+        :param connection: The Connection that should be closed
+        :type connection: Connection
+        """
+        for channel in connection.channels:
+                channel.close()
+
+    def drain_events(self, connection, timeout=0, **kwargs):
+        """Handle and call callbacks for all ready Transport messages.
+
+        Drains all events that are ready from all
+        :class:`~qpid.messaging.endpoints.Receiver` that are asynchronously
+        fetching messages.
+
+        For each drained message, the message is called to the appropriate
+        callback. Callbacks are organized by queue name.
+
+        :param connection: The :class:`Connection` that contains the
+            callbacks, indexed by queue name, which will be called by this
+            method.
+        :type connection: Connection
+        :keyword timeout: The timeout that limits how long this method will
+            run for. The timeout could interrupt a blocking read that is
+            waiting for a new message, or cause this method to return before
+            all messages are drained. Defaults to 0.
+        :type timeout: int
+        """
+        start_time = time.time()
+        elapsed_time = -1
+        while elapsed_time < timeout:
+            try:
+                receiver = self.session.next_receiver(timeout=timeout)
+                message = receiver.fetch()
+                queue = receiver.source
+            except QpidEmpty:
+                raise socket.timeout()
+            else:
+                connection._callbacks[queue](message)
+            elapsed_time = time.time() - start_time
+        raise socket.timeout()
+
+    def create_channel(self, connection):
+        """Create and return a :class:`Channel`.
+
+        Creates a new :class:`Channel`, and append the :class:`Channel` to the
+        list of channels known by the :class:`Connection`. Once the new
+        :class:`Channel` is created, it is returned.
+
+        :param connection: The connection that should support the new
+            :class:`Channel`.
+        :type connection: Connection
+
+        :return: The new Channel that is made.
+        :rtype: :class:`Channel`.
+        """
+        channel = connection.Channel(connection, self)
+        connection.channels.append(channel)
+        return channel
+
+    @property
+    def default_connection_params(self):
+        """Return a dict with default connection parameters.
+
+        These connection parameters will be used whenever the creator of
+        Transport does not specify a required parameter.
+
+        NOTE: password is set to '' by default instead of None so the a
+        connection is attempted[1]. An empty password is considered valid for
+        qpidd if "auth=no" is set on the server.
+
+        [1] https://issues.apache.org/jira/browse/QPID-6109
+
+        :return: A dict containing the default parameters.
+        :rtype: dict
+        """
+        return {'userid': 'guest', 'password': '',
+                'port': self.default_port, 'virtual_host': '',
+                'hostname': 'localhost', 'sasl_mechanisms': 'PLAIN ANONYMOUS'}

--- a/kombu/transport/qpid_patches.py
+++ b/kombu/transport/qpid_patches.py
@@ -1,0 +1,166 @@
+# This module applies two patches to qpid.messaging that are required for
+# correct operation. Each patch fixes a bug. See links to the bugs below:
+# https://issues.apache.org/jira/browse/QPID-5637
+# https://issues.apache.org/jira/browse/QPID-5557
+
+### Begin Monkey Patch 1 ###
+# https://issues.apache.org/jira/browse/QPID-5637
+
+#############################################################################
+#  _   _  ___ _____ _____
+# | \ | |/ _ \_   _| ____|
+# |  \| | | | || | |  _|
+# | |\  | |_| || | | |___
+# |_| \_|\___/ |_| |_____|
+#
+# If you have code that also uses qpid.messaging and imports kombu,
+# or causes this file to be imported, then you need to make sure that this
+# import occurs first.
+#
+# Failure to do this will cause the following exception:
+# AttributeError: 'Selector' object has no attribute '_current_pid'
+#
+# Fix this by importing this module prior to using qpid.messaging in other
+# code that also uses this module.
+#############################################################################
+
+
+# this import is needed for Python 2.6. Without it, qpid.py will "mask" the
+# system's qpid lib
+from __future__ import absolute_import
+
+import os
+
+
+# Imports for Monkey Patch 1
+try:
+    from qpid.selector import Selector
+except ImportError:  # pragma: no cover
+    Selector = None     # noqa
+import atexit
+
+
+# Prepare for Monkey Patch 1
+def default_monkey():  # pragma: no cover
+    Selector.lock.acquire()
+    try:
+        if Selector.DEFAULT is None:
+            sel = Selector()
+            atexit.register(sel.stop)
+            sel.start()
+            Selector.DEFAULT = sel
+            Selector._current_pid = os.getpid()
+        elif Selector._current_pid != os.getpid():
+            sel = Selector()
+            atexit.register(sel.stop)
+            sel.start()
+            Selector.DEFAULT = sel
+            Selector._current_pid = os.getpid()
+        return Selector.DEFAULT
+    finally:
+        Selector.lock.release()
+
+# Apply Monkey Patch 1
+
+try:
+    import qpid.selector
+    qpid.selector.Selector.default = staticmethod(default_monkey)
+except ImportError:  # pragma: no cover
+    pass
+
+### End Monkey Patch 1 ###
+
+### Begin Monkey Patch 2 ###
+# https://issues.apache.org/jira/browse/QPID-5557
+
+# Imports for Monkey Patch 2
+try:
+    from qpid.ops import ExchangeQuery, QueueQuery
+except ImportError:  # pragma: no cover
+    ExchangeQuery = None
+    QueueQuery = None
+
+try:
+    from qpid.messaging.exceptions import NotFound, AssertionFailed, ConnectionError
+except ImportError:  # pragma: no cover
+    NotFound = None
+    AssertionFailed = None
+    ConnectionError = None
+
+
+# Prepare for Monkey Patch 2
+def resolve_declare_monkey(self, sst, lnk, dir, action):  # pragma: no cover
+    declare = lnk.options.get("create") in ("always", dir)
+    assrt = lnk.options.get("assert") in ("always", dir)
+    requested_type = lnk.options.get("node", {}).get("type")
+
+    def do_resolved(type, subtype):
+        err = None
+        if type is None:
+            if declare:
+                err = self.declare(sst, lnk, action)
+            else:
+                err = NotFound(text="no such queue: %s" % lnk.name)
+        else:
+            if assrt:
+                expected = lnk.options.get("node", {}).get("type")
+                if expected and type != expected:
+                    err = AssertionFailed(
+                        text="expected %s, got %s" % (expected, type))
+            if err is None:
+                action(type, subtype)
+        if err:
+            tgt = lnk.target
+            tgt.error = err
+            del self._attachments[tgt]
+            tgt.closed = True
+            return
+
+    self.resolve(sst, lnk.name, do_resolved, node_type=requested_type,
+                 force=declare)
+
+
+def resolve_monkey(self, sst, name, action, force=False,
+                   node_type=None):  # pragma: no cover
+    if not force and not node_type:
+        try:
+            type, subtype = self.address_cache[name]
+            action(type, subtype)
+            return
+        except KeyError:
+            pass
+    args = []
+
+    def do_result(r):
+        args.append(r)
+
+    def do_action(r):
+        do_result(r)
+        er, qr = args
+        if node_type == "topic" and not er.not_found:
+            type, subtype = "topic", er.type
+        elif node_type == "queue" and qr.queue:
+            type, subtype = "queue", None
+        elif er.not_found and not qr.queue:
+            type, subtype = None, None
+        elif qr.queue:
+            type, subtype = "queue", None
+        else:
+            type, subtype = "topic", er.type
+        if type is not None:
+            self.address_cache[name] = (type, subtype)
+        action(type, subtype)
+
+    sst.write_query(ExchangeQuery(name), do_result)
+    sst.write_query(QueueQuery(name), do_action)
+
+
+# Apply monkey patch 2
+try:
+    import qpid.messaging.driver
+    qpid.messaging.driver.Engine.resolve_declare = resolve_declare_monkey
+    qpid.messaging.driver.Engine.resolve = resolve_monkey
+except ImportError:  # pragma: no cover
+    pass
+
+### End Monkey Patch 2 ###

--- a/requirements/extras/qpid.txt
+++ b/requirements/extras/qpid.txt
@@ -1,0 +1,2 @@
+qpid-python>=0.26
+qpid-tools>=0.26

--- a/requirements/funtest.txt
+++ b/requirements/funtest.txt
@@ -22,3 +22,7 @@ django-kombu
 
 # SQS transport
 boto
+
+# Qpid transport
+qpid-python>=0.26
+qpid-tools>=0.26

--- a/setup.py
+++ b/setup.py
@@ -135,6 +135,7 @@ extras_require = extra['extras_require'] = {
     'librabbitmq': extras('librabbitmq.txt'),
     'pyro': extras('pyro.txt'),
     'slmq': extras('slmq.txt'),
+    'qpid': extras('qpid.txt'),
 }
 
 extras_require[':python_version=="2.6"'] = reqs('py26.txt')


### PR DESCRIPTION
This code is compliant with 2.6, and was originally designed to run against the 3.0 release stream. It is the same as master, except for two things:
- OrderedDict is provided from kombu.utils.compat in the 3.0 release stream. This has been adjusted to use that.
- The doc backporting involved some adjustments because of documentation differences between master and the 3.0 release stream.
