### PR TITLE
SQS: Set delivery tag to SQS message receipt handle

### DIFF
--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -206,6 +206,8 @@ class Channel(virtual.Channel):
             payload['properties']['delivery_info'].update({
                 'sqs_message': message, 'sqs_queue': queue,
             })
+            # set delivery tag to SQS receipt handle
+            payload['properties']['delivery_tag'] = message.receipt_handle
         return payload
 
     def _messages_to_python(self, messages, queue):


### PR DESCRIPTION
This addresses #137 and reports like [this Stack Overflow question](http://stackoverflow.com/questions/17262958/celery-with-sqs-errors-in-logs).  I received similar errors occasionally while using the SQS transport with Celery.

My understanding of the reason for this problem is that SQS messages may be delivered twice, especially if you are polling frequently.  So that means the same delivery_tag UUID could be delivered to the same client in separate `boto.sqs.message.Message` instances.  This results in an error when acking the same delivery_tag twice (depending on whether the `kombu.transport.virtual:QoS._flush()` occurs between acks?), which raises a KeyError the second time (as reported above).  As a result the unacked duplicate message is actually left on the SQS queue until the visibility timeout expires, relying on a future worker run to ack it again later.

To distinguish between duplicate messages the SQS API requires you use an SQS message's "receipt handle" to delete a message.  From [the Amazon SQS docs](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/ImportantIdentifiers.html):
> If you receive a message more than once, each time you receive it, you get a different receipt handle. You must provide the most recently received receipt handle when you request to delete the message or the message might not be deleted.

So this change uses the receipt handle as the delivery_tag, leaving idempotency of tasks when duplicates are received up to the user.  I'm not sure if the delivery_tag is required to be the request UUID, so let me know if this is actually a bad idea.  However it is working in my use case and I am able to ack all messages even when duplicates are received without this exception.