### PR TITLE
fixes celery/kombu#439 better handling for a purge of missing Queue

### DIFF
--- a/kombu/tests/transport/test_qpid.py
+++ b/kombu/tests/transport/test_qpid.py
@@ -522,6 +522,11 @@ class TestChannelPurge(ChannelTestBase):
         result = self.channel._purge(self.mock_queue)
         self.assertEqual(result, 5)
 
+    @patch(QPID_MODULE + '.ChannelError', new=MockException)
+    def test_channel__purge_raises_channel_error_if_queue_does_not_exist(self):
+        self.mock_broker_agent.return_value.getQueue.return_value = None
+        self.assertRaises(MockException, self.channel._purge, self.mock_queue)
+
 
 @case_no_python3
 @case_no_pypy

--- a/kombu/transport/qpid.py
+++ b/kombu/transport/qpid.py
@@ -62,7 +62,7 @@ try:
 except ImportError:  # pragma: no cover
     qpid = None
 
-
+from kombu.exceptions import ChannelError
 from kombu.five import Empty, items
 from kombu.log import get_logger
 from kombu.transport.virtual import Base64, Message
@@ -503,6 +503,9 @@ class Channel(base.StdChannel):
         :rtype: int
         """
         queue_to_purge = self._broker.getQueue(queue)
+        if queue_to_purge is None:
+            raise ChannelError("queue.purge: server channel error 404, message: "
+                               "NOT_FOUND - no queue '%s'" % queue)
         message_count = queue_to_purge.values['msgDepth']
         if message_count > 0:
             queue_to_purge.purge(message_count)


### PR DESCRIPTION
Causes a purge of a non-existing queue to raise a kombu.exceptions.ChannelError similar to what RabbitMQ does. It also adds a test for coverage of the new branch of code.
