### PR TITLE
Fix message priority conversion for Redis and Beanstalk transports

### DIFF
--- a/kombu/tests/transport/test_redis.py
+++ b/kombu/tests/transport/test_redis.py
@@ -103,18 +103,18 @@ class Client(object):
             raise Empty()
 
     def brpop(self, keys, timeout=None):
-        key = keys[0]
-        try:
-            item = self.queues[key].get(timeout=timeout)
-        except Empty:
-            pass
-        else:
-            return key, item
+        for key in keys:
+            try:
+                item = self.queues[key].get_nowait()
+            except Empty:
+                pass
+            else:
+                return key, item
 
     def rpop(self, key):
         try:
             return self.queues[key].get_nowait()
-        except KeyError:
+        except (KeyError, Empty):
             pass
 
     def __contains__(self, k):
@@ -205,7 +205,8 @@ class Channel(redis.Channel):
         return ResponseError
 
     def _new_queue(self, queue, **kwargs):
-        self.client._new_queue(queue)
+        for pri in self.priority_steps:
+            self.client._new_queue(self._q_for_pri(queue, pri))
 
     def pipeline(self):
         return Pipeline(Client())
@@ -237,10 +238,9 @@ class test_Channel(Case):
             chan.queue_bind(n, n, n)
             msg = chan.prepare_message('quick brown fox')
             chan.basic_publish(msg, n, n)
-            q, payload = chan.client.brpop([n])
-            self.assertEqual(q, n)
+            payload = chan._get(n)
             self.assertTrue(payload)
-            pymsg = chan.message_to_python(loads(payload))
+            pymsg = chan.message_to_python(payload)
             return pymsg.delivery_tag
 
     def test_delivery_tag_is_uuid(self):
@@ -556,19 +556,19 @@ class test_Channel(Case):
 
         self.channel._put('george', msg1)
         client.lpush.assert_called_with(
-            self.channel._q_for_pri('george', 3), dumps(msg1),
+            self.channel._q_for_pri('george', 6), dumps(msg1),
         )
 
         msg2 = {'properties': {'delivery_info': {'priority': 313}}}
         self.channel._put('george', msg2)
         client.lpush.assert_called_with(
-            self.channel._q_for_pri('george', 9), dumps(msg2),
+            self.channel._q_for_pri('george', 0), dumps(msg2),
         )
 
         msg3 = {'properties': {'delivery_info': {}}}
         self.channel._put('george', msg3)
         client.lpush.assert_called_with(
-            self.channel._q_for_pri('george', 0), dumps(msg3),
+            self.channel._q_for_pri('george', 9), dumps(msg3),
         )
 
     def test_delete(self):

--- a/kombu/transport/beanstalk.py
+++ b/kombu/transport/beanstalk.py
@@ -47,7 +47,7 @@ class Channel(virtual.Channel):
 
     def _put(self, queue, message, **kwargs):
         extra = {}
-        priority = self._get_message_priority(message)
+        priority = self._get_message_priority(message, reverse=True)
         ttr = message['properties'].get('ttr')
         if ttr is not None:
             extra['ttr'] = ttr

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -605,7 +605,7 @@ class Channel(virtual.Channel):
         queues = self._consume_cycle()
         if not queues:
             return
-        keys = [self._q_for_pri(queue, pri) for pri in PRIORITY_STEPS
+        keys = [self._q_for_pri(queue, pri) for pri in self.priority_steps
                 for queue in queues] + [timeout or 0]
         self._in_poll = True
         self.client.connection.send_command('BRPOP', *keys)
@@ -639,7 +639,7 @@ class Channel(virtual.Channel):
 
     def _get(self, queue):
         with self.conn_or_acquire() as client:
-            for pri in PRIORITY_STEPS:
+            for pri in self.priority_steps:
                 item = client.rpop(self._q_for_pri(queue, pri))
                 if item:
                     return loads(bytes_to_str(item))
@@ -648,7 +648,7 @@ class Channel(virtual.Channel):
     def _size(self, queue):
         with self.conn_or_acquire() as client:
             cmds = client.pipeline()
-            for pri in PRIORITY_STEPS:
+            for pri in self.priority_steps:
                 cmds = cmds.llen(self._q_for_pri(queue, pri))
             sizes = cmds.execute()
             return sum(size for size in sizes
@@ -664,7 +664,7 @@ class Channel(virtual.Channel):
 
     def _put(self, queue, message, **kwargs):
         """Deliver message."""
-        pri = self._get_message_priority(message)
+        pri = self._get_message_priority(message, reverse=True)
 
         with self.conn_or_acquire() as client:
             client.lpush(self._q_for_pri(queue, pri), dumps(message))
@@ -701,14 +701,14 @@ class Channel(virtual.Channel):
                                        pattern or '',
                                        queue or '']))
             cmds = client.pipeline()
-            for pri in PRIORITY_STEPS:
+            for pri in self.priority_steps:
                 cmds = cmds.delete(self._q_for_pri(queue, pri))
             cmds.execute()
 
     def _has_queue(self, queue, **kwargs):
         with self.conn_or_acquire() as client:
             cmds = client.pipeline()
-            for pri in PRIORITY_STEPS:
+            for pri in self.priority_steps:
                 cmds = cmds.exists(self._q_for_pri(queue, pri))
             return any(cmds.execute())
 
@@ -723,7 +723,7 @@ class Channel(virtual.Channel):
     def _purge(self, queue):
         with self.conn_or_acquire() as client:
             cmds = client.pipeline()
-            for pri in PRIORITY_STEPS:
+            for pri in self.priority_steps:
                 priq = self._q_for_pri(queue, pri)
                 cmds = cmds.llen(priq).delete(priq)
             sizes = cmds.execute()


### PR DESCRIPTION
[AMQP protocol](http://www.amqp.org/sites/amqp.org/files/amqp.pdf) defines message priority field as:

>This field contains the relative Message priority. **Higher numbers indicate higher priority** Messages. Messages with higher priorities MAY be delivered before those with lower priorities.

but current Redis and Beanstalk transports relay on opposite logic. 

Redis transport iterates over its priority steps from lower ones:

    for pri in PRIORITY_STEPS:
        item = client.rpop(self._q_for_pri(queue, pri))
so low priority values are handled in the first place.

[Beanstalk protocol](https://raw.githubusercontent.com/kr/beanstalkd/master/doc/protocol.txt) also says:

> <pri> is an integer < `2**32`. **Jobs with smaller priority values will be scheduled before jobs with larger priorities**. The most urgent priority is 0; the least urgent priority is 4,294,967,295.