### PR TITLE
Add additional string to check for when connecting to qpid

### DIFF
--- a/kombu/tests/transport/test_qpid.py
+++ b/kombu/tests/transport/test_qpid.py
@@ -398,6 +398,34 @@ class TestConnectionInit(ExtraAssertionsMixin, ConnectionTestBase):
     @patch(QPID_MODULE + '.ConnectionError', new=(QpidException, ))
     @patch(QPID_MODULE + '.sys.exc_info')
     @patch(QPID_MODULE + '.qpid')
+    def test_connection__init__mutates_ConnError_by_message2(self, mock_qpid,
+                                                            mock_exc_info):
+        """
+        Test for PLAIN connection via python-saslwrapper, sans cyrus-sasl-plain
+
+        This test is specific for what is returned when we attempt to connect
+        with PLAIN mech and python-saslwrapper is installed, but
+        cyrus-sasl-plain is not installed.
+        """
+        my_conn_error = QpidException()
+        my_conn_error.text = 'Error in sasl_client_start (-4) SASL(-4): no '\
+                             'mechanism available'
+        mock_qpid.messaging.Connection.establish.side_effect = my_conn_error
+        mock_exc_info.return_value = ('a', 'b', None)
+        try:
+            self.conn = Connection(**self.connection_options)
+        except AuthenticationFailure as error:
+            exc_info = sys.exc_info()
+            self.assertTrue(not isinstance(error, QpidException))
+            self.assertTrue(exc_info[1] is 'b')
+            self.assertTrue(exc_info[2] is None)
+        else:
+            self.fail('ConnectionError type was not mutated correctly')
+
+
+    @patch(QPID_MODULE + '.ConnectionError', new=(QpidException, ))
+    @patch(QPID_MODULE + '.sys.exc_info')
+    @patch(QPID_MODULE + '.qpid')
     def test_unknown_connection_error(self, mock_qpid, mock_exc_info):
         # If we get a connection error that we don't understand,
         # bubble it up as-is

--- a/kombu/transport/qpid.py
+++ b/kombu/transport/qpid.py
@@ -1285,14 +1285,20 @@ class Connection(object):
                 )
                 break
             except ConnectionError as conn_exc:
+                # if we get one of these errors, do not raise an exception.
+                # Raising will cause the connection to be retried. Instead,
+                # just continue on to the next mech.
                 coded_as_auth_failure = getattr(conn_exc, 'code', None) == 320
                 contains_auth_fail_text = \
                     'Authentication failed' in conn_exc.text
                 contains_mech_fail_text = \
                     'sasl negotiation failed: no mechanism agreed' \
                     in conn_exc.text
+                contains_mech_unavail_text = 'no mechanism available' \
+                    in conn_exc.text
                 if coded_as_auth_failure or \
-                        contains_auth_fail_text or contains_mech_fail_text:
+                        contains_auth_fail_text or contains_mech_fail_text or \
+                        contains_mech_unavail_text:
                     logger.debug(
                         'Unable to connect to qpid with SASL mechanism %s',
                         sasl_mech,


### PR DESCRIPTION
When we connect to qpid, we need to ensure that we skip to the next SASL
mechanism if the current mechanism fails. Otherwise, we will keep retrying the
connection with a non-working mech.

This patch adds an additional string that is returned when PLAIN is not
available, but python-saslwrapper is installed.