### PR TITLE
Handle TimeoutError raised by py-redis library

### DIFF
--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -88,7 +88,8 @@ def get_redis_error_classes():
             IOError,
             OSError,
             exceptions.ConnectionError,
-            exceptions.AuthenticationError)),
+            exceptions.AuthenticationError,
+            exceptions.TimeoutError)),
         (virtual.Transport.channel_errors + (
             DataError,
             exceptions.InvalidResponse,


### PR DESCRIPTION
We had a problem with our celery app not executing tasks in production system. Over time we reached almost 2.5M tasks to be executed. At this time redis started closing sockets for psubscribers due to high load. The first problem was in redis-py library which has no timeout on socket and ended up in endless loop [right here](https://github.com/andymccurdy/redis-py/blob/master/redis/connection.py#L120). It keeps waiting for data on already closed socket so it never receives it. This can be easily fixed by setting socket timeout in celery options:
```python
BROKER_TRANSPORT_OPTIONS={'socket_timeout': 1}
```

This caused another problem because this throws redis.exceptions.TimeoutError which is never caught so the workers would die immediately. In line 87 we see that socket.error is caught but this is not what is being raised by redis-py. It throws its own exception - TimeoutError which is added to be handled in this pull request.

This can be easily reproduced with this simple celery app

```python
#tasks.py
from celery import Celery

BROKER_TRANSPORT_OPTIONS = {'socket_timeout': 1}
app = Celery('tasks', broker='redis://127.0.0.1:6379/0')

@app.task
def add(x, y):
    print x + y
```

Run the worker
```
celery -A tasks worker --loglevel=info
```

Run redis monitor
```
redis-cli -h 127.127.0.1 monitor
```

This should keep doing brpops on celery key
```
1422968197.050553 [0 192.192.1.1:32821] "BRPOP" "celery" "celery\x06\x163" "celery\x06\x166" "celery\x06\x169" "1"
```

We can see clients connected to redis with this command
```
redis-cli -h 127.127.0.1 client list
```

Some of them should be celery's subscribers (note the cmd=psubscribe at the end)

```
id=171214 addr=192.192.1.1:32825 fd=14 name= age=281 idle=2 flags=N db=0 sub=0 psub=1 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=psubscribe
id=171215 addr=192.192.1.1:32826 fd=15 name= age=281 idle=281 flags=N db=0 sub=0 psub=1 multi=-1 qbuf=0 qbuf-free=0 obl=0 oll=0 omem=0 events=r cmd=psubscribe
```
We can simulate what redis does in high load with this command
```
redis-cli -h 127.0.0.1 client kill 192.192.1.1:32826
```

And our worker will die
```python
[2015-02-03 14:03:28,301: WARNING/MainProcess] celery@user-ThinkPad-T410s ready.
[2015-02-03 14:03:44,405: ERROR/MainProcess] Unrecoverable error: TimeoutError('Timeout reading from socket',)
Traceback (most recent call last):
  File "/home/user/redis-timeout-sample/venv/local/lib/python2.7/site-packages/celery/worker/__init__.py", line 206, in start
    self.blueprint.start(self)
  File "/home/user/redis-timeout-sample/venv/local/lib/python2.7/site-packages/celery/bootsteps.py", line 123, in start
    step.start(parent)
  File "/home/user/redis-timeout-sample/venv/local/lib/python2.7/site-packages/celery/bootsteps.py", line 374, in start
    return self.obj.start()
  File "/home/user/redis-timeout-sample/venv/local/lib/python2.7/site-packages/celery/worker/consumer.py", line 278, in start
    blueprint.start(self)
  File "/home/user/redis-timeout-sample/venv/local/lib/python2.7/site-packages/celery/bootsteps.py", line 123, in start
    step.start(parent)
  File "/home/user/redis-timeout-sample/venv/local/lib/python2.7/site-packages/celery/worker/consumer.py", line 821, in start
    c.loop(*c.loop_args())
  File "/home/user/redis-timeout-sample/venv/local/lib/python2.7/site-packages/celery/worker/loops.py", line 70, in asynloop
    next(loop)
  File "/home/user/redis-timeout-sample/venv/local/lib/python2.7/site-packages/kombu/async/hub.py", line 324, in create_loop
    cb(*cbargs)
  File "/home/user/redis-timeout-sample/venv/local/lib/python2.7/site-packages/kombu/transport/redis.py", line 949, in on_readable
    item = self.cycle.on_readable(fileno)
  File "/home/user/redis-timeout-sample/venv/local/lib/python2.7/site-packages/kombu/transport/redis.py", line 322, in on_readable
    return chan.handlers[type]()
  File "/home/user/redis-timeout-sample/venv/local/lib/python2.7/site-packages/kombu/transport/redis.py", line 584, in _receive
    response = c.parse_response()
  File "/home/user/redis-timeout-sample/venv/local/lib/python2.7/site-packages/redis/client.py", line 2150, in parse_response
    return self._execute(connection, connection.read_response)
  File "/home/user/redis-timeout-sample/venv/local/lib/python2.7/site-packages/redis/client.py", line 2143, in _execute
    return command(*args)
  File "/home/user/redis-timeout-sample/venv/local/lib/python2.7/site-packages/redis/connection.py", line 569, in read_response
    response = self._parser.read_response()
  File "/home/user/redis-timeout-sample/venv/local/lib/python2.7/site-packages/redis/connection.py", line 224, in read_response
    response = self._buffer.readline()
  File "/home/user/redis-timeout-sample/venv/local/lib/python2.7/site-packages/redis/connection.py", line 162, in readline
    self._read_from_socket()
  File "/home/user/redis-timeout-sample/venv/local/lib/python2.7/site-packages/redis/connection.py", line 133, in _read_from_socket
    raise TimeoutError("Timeout reading from socket")
TimeoutError: Timeout reading from socket

```