### PR TITLE
fix json serializable error for Queue.as_dict()

### DIFF
--- a/kombu/abstract.py
+++ b/kombu/abstract.py
@@ -41,6 +41,8 @@ class Object(object):
         def f(obj, type):
             if recurse and isinstance(obj, Object):
                 return obj.as_dict(recurse=True)
+            if recurse and hasattr(obj, '__iter__'):
+                obj = [f(o, None) for o in obj]
             return type(obj) if type else obj
         return {
             attr: f(getattr(self, attr), type) for attr, type in self.attrs

--- a/kombu/abstract.py
+++ b/kombu/abstract.py
@@ -41,8 +41,6 @@ class Object(object):
         def f(obj, type):
             if recurse and isinstance(obj, Object):
                 return obj.as_dict(recurse=True)
-            if recurse and hasattr(obj, '__iter__'):
-                obj = [f(o, None) for o in obj]
             return type(obj) if type else obj
         return {
             attr: f(getattr(self, attr), type) for attr, type in self.attrs

--- a/kombu/entity.py
+++ b/kombu/entity.py
@@ -737,3 +737,13 @@ class Queue(MaybeChannelBound):
                      queue_arguments=q_arguments,
                      binding_arguments=b_arguments,
                      bindings=bindings)
+
+    def as_dict(self, recurse=False):
+        res = super(Queue, self).as_dict(recurse)
+        if not recurse:
+            return res
+        bindings = res.get('bindings')
+        if bindings:
+            res['bindings'] = [b.as_dict(recurse=True) for b in bindings]
+        return res
+

--- a/kombu/entity.py
+++ b/kombu/entity.py
@@ -7,7 +7,7 @@ Exchange and Queue declarations.
 """
 from __future__ import absolute_import
 
-from .abstract import MaybeChannelBound
+from .abstract import MaybeChannelBound, Object
 from .exceptions import ContentDisallowed
 from .five import string_t
 from .serialization import prepare_accept_content
@@ -299,7 +299,7 @@ class Exchange(MaybeChannelBound):
         return not self.auto_delete
 
 
-class binding(object):
+class binding(Object):
     """Represents a queue or exchange binding.
 
     :keyword exchange: Exchange to bind to.
@@ -308,6 +308,13 @@ class binding(object):
     :keyword unbind_arguments: Arguments for unbind operation.
 
     """
+
+    attrs = (
+        ('exchange', None),
+        ('routing_key', None),
+        ('arguments', None),
+        ('unbind_arguments', None)
+    )
 
     def __init__(self, exchange=None, routing_key='',
                  arguments=None, unbind_arguments=None):

--- a/kombu/tests/test_entities.py
+++ b/kombu/tests/test_entities.py
@@ -4,6 +4,7 @@ import pickle
 
 from kombu import Connection, Exchange, Producer, Queue, binding
 from kombu.exceptions import NotBoundError
+from kombu.serialization import registry
 
 from .case import Case, Mock, call
 from .mocks import Transport
@@ -366,6 +367,13 @@ class test_Queue(Case):
         q = Queue('foo', self.exchange, 'rk')
         d = q.as_dict(recurse=True)
         self.assertEqual(d['exchange']['name'], self.exchange.name)
+
+    def test_queue_dump(self):
+        b = binding(self.exchange, 'rk')
+        q = Queue('foo', self.exchange, 'rk', bindings=[b])
+        d = q.as_dict(recurse=True)
+        self.assertEqual(d['bindings'][0]['routing_key'], 'rk')
+        registry.dumps(d)
 
     def test__repr__(self):
         b = Queue('foo', self.exchange, 'foo')


### PR DESCRIPTION
Fix for https://groups.google.com/forum/#!searchin/celery-users/binding/celery-users/qeUiHmR7xmk/fmWA9rvIsCAJ

When celery config has a Queue with not-empty bindings,  worker can't reply to ` celery inspect active_queues`.
It just raises an error
```
[2015-02-12 12:22:03,554: ERROR/MainProcess] Control command error: EncodeError(TypeError('<binding: exchange->queue_name> is not JSON serializable',),)
```
It's because `Queue.as_dict()` method returns a dict where bindings is a set of `kombu.binding objects`.

Fix is to recursively descent to `set` members and make `binding` implement `as_dict()` 