### PR TITLE
Add django postgresql transport that replicates 'acks_late' 

### DIFF
--- a/funtests/tests/test_django_postgres.py
+++ b/funtests/tests/test_django_postgres.py
@@ -5,8 +5,8 @@ from kombu.tests.case import redirect_stdouts
 from funtests import transport
 
 
-class test_django(transport.TransportCase):
-    transport = 'django'
+class test_django_postgres(transport.TransportCase):
+    transport = 'django_postgres'
     prefix = 'django'
     event_loop_max = 10
 
@@ -21,12 +21,10 @@ class test_django(transport.TransportCase):
             from django.conf import settings
             if not settings.configured:
                 settings.configure(
-                    DATABASE_ENGINE='sqlite3',
-                    DATABASE_NAME=':memory:',
                     DATABASES={
                         'default': {
-                            'ENGINE': 'django.db.backends.sqlite3',
-                            'NAME': ':memory:',
+                            'ENGINE': 'django.db.backends.postgresql_psycopg2',
+                            'NAME': 'kombu',
                         },
                     },
                     INSTALLED_APPS=('kombu.transport.django', ),

--- a/kombu/tests/case.py
+++ b/kombu/tests/case.py
@@ -7,7 +7,6 @@ import types
 
 from contextlib import contextmanager
 from functools import wraps
-from io import StringIO
 
 try:
     from unittest import mock
@@ -16,7 +15,7 @@ except ImportError:
 
 from nose import SkipTest
 
-from kombu.five import builtins, string_t
+from kombu.five import builtins, string_t, WhateverIO
 from kombu.utils.encoding import ensure_bytes
 
 try:
@@ -169,8 +168,8 @@ def redirect_stdouts(fun):
 
     @wraps(fun)
     def _inner(*args, **kwargs):
-        sys.stdout = StringIO()
-        sys.stderr = StringIO()
+        sys.stdout = WhateverIO()
+        sys.stderr = WhateverIO()
         try:
             return fun(*args, **dict(kwargs,
                                      stdout=sys.stdout, stderr=sys.stderr))

--- a/kombu/transport/__init__.py
+++ b/kombu/transport/__init__.py
@@ -55,6 +55,7 @@ TRANSPORT_ALIASES = {
     'couchdb': 'kombu.transport.couchdb:Transport',
     'zookeeper': 'kombu.transport.zookeeper:Transport',
     'django': 'kombu.transport.django:Transport',
+    'django_postgres': 'kombu.transport.django.postgres:Transport',
     'sqlalchemy': 'kombu.transport.sqlalchemy:Transport',
     'sqla': 'kombu.transport.sqlalchemy:Transport',
     'SLMQ': 'kombu.transport.SLMQ.Transport',

--- a/kombu/transport/django/managers.py
+++ b/kombu/transport/django/managers.py
@@ -92,7 +92,7 @@ class PostgresMessageManager(MessageManager):
         results = self.raw(
             pgsql.LOCK_JOB, dict(app_id=pgsql.APP_ID, queue=queue)
         )
-        if results:
+        if list(results):
             return results[0]
 
     def ack(self, delivery_tag):

--- a/kombu/transport/django/models.py
+++ b/kombu/transport/django/models.py
@@ -5,7 +5,7 @@ import django
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
-from .managers import QueueManager, MessageManager
+from .managers import QueueManager, MessageManager, PostgresMessageManager
 
 
 class Queue(models.Model):
@@ -29,6 +29,7 @@ class Message(models.Model):
     queue = models.ForeignKey(Queue, related_name='messages')
 
     objects = MessageManager()
+    pg_objects = PostgresMessageManager()
 
     class Meta:
         if django.VERSION >= (1, 7):

--- a/kombu/transport/django/pgsql.py
+++ b/kombu/transport/django/pgsql.py
@@ -1,0 +1,40 @@
+APP_ID = 100001
+
+LOCK_JOB = """
+WITH RECURSIVE job AS (
+  SELECT (j).*, pg_try_advisory_lock(%(app_id)s, (j).id) AS locked
+  FROM (
+    SELECT j
+    FROM djkombu_message AS j
+    JOIN djkombu_queue AS q ON j.queue_id = q.id
+    WHERE q.name = %(queue)s
+    ORDER BY j.id
+    LIMIT 1
+  ) AS t1
+  UNION ALL (
+    SELECT (j).*, pg_try_advisory_lock(%(app_id)s, (j).id) AS locked
+    FROM (
+      SELECT (
+        SELECT j
+        FROM djkombu_message AS j
+        JOIN djkombu_queue AS q ON j.queue_id = q.id
+        WHERE q.name = %(queue)s
+        AND j.id > job.id
+        ORDER BY j.id
+        LIMIT 1
+      ) AS j
+    FROM job
+    WHERE NOT job.locked
+    LIMIT 1
+    ) AS t1
+  )
+)
+SELECT id, queue_id, payload, sent_at
+FROM job
+WHERE locked
+LIMIT 1
+"""
+
+UNLOCK = """
+SELECT pg_advisory_unlock(%(app_id)s, %(lock_id)s)
+"""

--- a/kombu/transport/django/postgres.py
+++ b/kombu/transport/django/postgres.py
@@ -1,0 +1,69 @@
+"""
+kombu.transport.django_postgres
+=====================
+
+Django database transport optimized for PostgreSQL
+ using advisory locks to hide messages that are held
+ by a worker.
+
+Inspired by `que` by Chris Hanks: https://github.com/chanks/que
+"""
+from __future__ import absolute_import
+
+from kombu.transport import virtual
+
+from . import Channel as DjangoChannel, Transport as DjangoTransport
+from .models import Message
+
+try:
+    from django.apps import AppConfig
+except ImportError:  # pragma: no cover
+    pass
+else:
+    class KombuAppConfig(AppConfig):
+        name = 'kombu.transport.django.postgres'
+        label = name.replace('.', '_')
+        verbose_name = 'Message queue'
+
+    default_app_config = 'kombu.transport.django.postgres.KombuAppConfig'
+
+
+class QoS(virtual.QoS):
+    """
+    QoS that uses PostgreSQL advisory locks to reserve messages
+    """
+    restore_at_shutdown = False
+
+    def ack(self, delivery_tag):
+        """Acknowledge message and remove from transactional state."""
+        self._delivered[delivery_tag].ack()
+        self._quick_ack(delivery_tag)
+
+    def reject(self, delivery_tag, requeue=False):
+        """Ack or reject and remove from transactional state."""
+        self._delivered[delivery_tag].reject(requeue)
+        self._quick_ack(delivery_tag)
+
+
+class Channel(DjangoChannel):
+    QoS = QoS
+
+    def _get(self, queue, **kwargs):
+        return super(Channel, self)._get(queue, 'pg_objects', **kwargs)
+
+    def _restore(self, message):
+        raise NotImplementedError('Should never be called. Use qos.reject instead')
+
+    def basic_reject(self, delivery_tag, requeue=False):
+        Message.pg_objects.reject(delivery_tag)
+
+    def basic_ack(self, delivery_tag):
+        Message.pg_objects.ack(delivery_tag)
+
+
+class Transport(DjangoTransport):
+    Channel = Channel
+
+    polling_interval = 1
+    driver_type = 'sql'
+    driver_name = 'postgres'

--- a/kombu/transport/django/postgres.py
+++ b/kombu/transport/django/postgres.py
@@ -6,6 +6,9 @@ Django database transport optimized for PostgreSQL
  using advisory locks to hide messages that are held
  by a worker.
 
+This transport is meant to be used with `CELERY_ACKS_LATE = True`,
+so messages are not acknowledged until after they have completed.
+
 Inspired by `que` by Chris Hanks: https://github.com/chanks/que
 """
 from __future__ import absolute_import

--- a/requirements/funtest.txt
+++ b/requirements/funtest.txt
@@ -14,11 +14,10 @@ beanstalkc
 kazoo
 
 # SQLAlchemy transport
-kombu-sqlalchemy
+sqlalchemy
 
 # Django ORM transport
 Django
-django-kombu
 
 # SQS transport
 boto


### PR DESCRIPTION
By using by using postgresql's advisory locks, we can mark a row as 'locked' until either the worker's connection to the database is lost (and the locks are released) or the row is deleted because the task finished processing.

Inspired by [que](https://github.com/chanks/que) by @chanks

@ask I'd like to get your feedback on the approach, and I'd like your suggestions on what to improve before considering this pull request. Should I use the kombu.common.QoS if implementing a transport that acks correctly? Or follow the Redis `ack_emulation` somehow?