### PR TITLE
Fix #476, file descriptor leak in transport.qpid.Transport.

### DIFF
--- a/kombu/tests/transport/test_qpid.py
+++ b/kombu/tests/transport/test_qpid.py
@@ -2023,3 +2023,26 @@ class TestTransport(ExtraAssertionsMixin, Case):
         my_transport = Transport(self.mock_client)
         result_params = my_transport.default_connection_params
         self.assertDictEqual(correct_params, result_params)
+
+    @patch('os.close')
+    def test_del(self, close):
+        my_transport = Transport(self.mock_client)
+        my_transport.__del__()
+        self.assertEqual(
+            close.call_args_list,
+            [
+                ((my_transport.r,), {}),
+                ((my_transport._w,), {}),
+            ])
+
+    @patch('os.close')
+    def test_del_failed(self, close):
+        close.side_effect = OSError()
+        my_transport = Transport(self.mock_client)
+        my_transport.__del__()
+        self.assertEqual(
+            close.call_args_list,
+            [
+                ((my_transport.r,), {}),
+                ((my_transport._w,), {}),
+            ])

--- a/kombu/transport/qpid.py
+++ b/kombu/transport/qpid.py
@@ -1707,3 +1707,14 @@ class Transport(base.Transport):
         return {'userid': 'guest', 'password': '',
                 'port': self.default_port, 'virtual_host': '',
                 'hostname': 'localhost', 'sasl_mechanisms': 'PLAIN ANONYMOUS'}
+
+    def __del__(self):
+        """
+        Ensure file descriptors opened in __init__() are closed.
+        """
+        for fd in (self.r, self._w):
+            try:
+                os.close(fd)
+            except OSError:
+                # ignored
+                pass


### PR DESCRIPTION
https://github.com/celery/kombu/issues/476

errno = EBADF is raised when calling os.close() on an already closed file descriptor.

Thought hard about logging cases when the os.close() raised OSError with errno != EBADF but decided an invalid or already closed file descriptor is really the only reason the close() would fail.  So, in the interest of simplicity, I decided to just ignore it.

Also, base.Transport does not implement ```__del__()``` so did not do: super(Transport, self).```__del__()```.
