### PR TITLE
fixing htmlclean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ docsclean:
 	-rm -rf "$(SPHINX_BUILDDIR)"
 
 htmlclean:
-	-rm -rf "$(SPHINX)"
+	(cd "$(SPHINX_DIR)"; make html)
 
 apicheck:
 	extra/release/doc4allmods kombu

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ docsclean:
 	-rm -rf "$(SPHINX_BUILDDIR)"
 
 htmlclean:
-	(cd "$(SPHINX_DIR)"; make html)
+	(cd "$(SPHINX_DIR)"; make clean)
 
 apicheck:
 	extra/release/doc4allmods kombu


### PR DESCRIPTION
Not sure what this was supposed to do since `$(SPHINX)` wasn't defined anywhere.  Changed to call clean within docs dir.