### PR TITLE
Might fix worker hanging for redis

### DIFF
--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -800,7 +800,7 @@ class Channel(virtual.Channel):
                 channel._on_connection_disconnect(self)
                 super(Connection, self).disconnect()
         connparams['connection_class'] = Connection
-
+        connparams.update(socket_timeout=5)
         return connparams
 
     def _create_client(self):

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -384,7 +384,7 @@ class Channel(virtual.Channel):
     unacked_restore_limit = None
     visibility_timeout = 3600   # 1 hour
     priority_steps = PRIORITY_STEPS
-    socket_timeout = None
+    socket_timeout = 60
     max_connections = 10
     #: Transport option to enable disable fanout keyprefix.
     #: Should be enabled by default, but that is not
@@ -800,7 +800,6 @@ class Channel(virtual.Channel):
                 channel._on_connection_disconnect(self)
                 super(Connection, self).disconnect()
         connparams['connection_class'] = Connection
-        connparams.update(socket_timeout=5)
         return connparams
 
     def _create_client(self):


### PR DESCRIPTION
TL;DR

This might fix the worker hanging on redis broker/backend. This is not a request to merge on master as is since ideally we would want to make this configurable.


-------------------------------------------------------------------------------------------------------------------------------------------
The investigation was as follows.

Setup:
Redis broker and backend. Celery 3.1.18 and corresponding versions in dependencies.

Symptoms-
Workers stop processing.

Followed the MainProcess with strace (got that hint from https://github.com/celery/celery/issues/2296)
It showed that things were getting stuck as follows

```
epoll_ctl(7, EPOLL_CTL_ADD, 9, {EPOLLIN|EPOLLERR|EPOLLHUP, {u32=9, u64=14370965520218325001}}) = -1 EEXIST (File exists)
epoll_ctl(7, EPOLL_CTL_ADD, 36, {EPOLLIN|EPOLLERR|EPOLLHUP, {u32=36, u64=14370965520218325028}}) = -1 EEXIST (File exists)
epoll_ctl(7, EPOLL_CTL_ADD, 37, {EPOLLIN|EPOLLERR|EPOLLHUP, {u32=37, u64=14370965520218325029}}) = -1 EEXIST (File exists)
gettimeofday({1435024884, 159678}, NULL) = 0
epoll_wait(7, {{EPOLLIN, {u32=9, u64=14370965520218325001}}}, 1023, 505) = 1
recvfrom(9, "*2\r\n$5\r\nfaces\r\n$7217\r\n{\"body\": \""..., 65536, 0, NULL, NULL) = 7240
recvfrom(9, "\n", 65536, 0, NULL, NULL) = 1
recvfrom(9,  <detached ...>
```

fd 9 of the main process was a tcp socket to redis.

Used [debuggy](http://code.activestate.com/recipes/576515/) to figure out what was happening and got this stack trace.

```
  File "env/lib/python2.7/site-packages/celery/bin/base.py", line 274, in __call__
    ret = self.run(*args, **kwargs)
  File "env/lib/python2.7/site-packages/celery/bin/worker.py", line 212, in run
    state_db=self.node_format(state_db, hostname), **kwargs
  File "env/lib/python2.7/site-packages/celery/worker/__init__.py", line 206, in start
    self.blueprint.start(self)
  File "env/lib/python2.7/site-packages/celery/bootsteps.py", line 123, in start
    step.start(parent)
  File "env/lib/python2.7/site-packages/celery/bootsteps.py", line 374, in start
    return self.obj.start()
  File "env/lib/python2.7/site-packages/celery/worker/consumer.py", line 278, in start
    blueprint.start(self)
  File "env/lib/python2.7/site-packages/celery/bootsteps.py", line 123, in start
    step.start(parent)
  File "env/lib/python2.7/site-packages/celery/worker/consumer.py", line 821, in start
    c.loop(*c.loop_args())
  File "env/lib/python2.7/site-packages/celery/worker/loops.py", line 70, in asynloop
    next(loop)
  File "env/lib/python2.7/site-packages/kombu/async/hub.py", line 324, in create_loop
    cb(*cbargs)
  File "env/lib/python2.7/site-packages/kombu/transport/redis.py", line 950, in on_readable
    item = self.cycle.on_readable(fileno)
  File "env/lib/python2.7/site-packages/kombu/transport/redis.py", line 322, in on_readable
    return chan.handlers[type]()
  File "env/lib/python2.7/site-packages/kombu/transport/redis.py", line 619, in _brpop_read
    **options)
  File "env/lib/python2.7/site-packages/redis/client.py", line 541, in parse_response
    response = connection.read_response()
  File "env/lib/python2.7/site-packages/redis/connection.py", line 545, in read_response
    response = self._parser.read_response()
  File "env/lib/python2.7/site-packages/redis/connection.py", line 315, in read_response
    buffer = self._sock.recv(socket_read_size)
  File "env/lib/python2.7/site-packages/celery/apps/worker.py", line 347, in cry_handler
    safe_say(cry())
  File "env/lib/python2.7/site-packages/celery/utils/__init__.py", line 227, in cry
    traceback.print_stack(frame, file=out)
```

This looks a lot like https://github.com/andymccurdy/redis-py/issues/519 

But, then again, I'm not sure about that. But, setting a timeout on the socket seems to work (hasnt hanged yet).

Please pull in the complementary fix https://github.com/celery/celery/pull/2679 for redis backend from the celery repo! 

This might also fix https://github.com/celery/celery/issues/2464.