### PR TITLE
fix DecodeError with simplejson with python 2.6

### DIFF
--- a/kombu/serialization.py
+++ b/kombu/serialization.py
@@ -312,7 +312,7 @@ def register_json():
     def _loads(obj):
         if isinstance(obj, bytes_t):
             obj = obj.decode()
-        return json_loads(obj)
+        return json_loads(str(obj))
 
     registry.register('json', json_dumps, _loads,
                       content_type='application/json',


### PR DESCRIPTION
With python 2.6 and simplejson, `serialization.register_json()` raise a DecodeError on `json_loads(u'[unicode_json_object]')`

```  
  File "/home/local/users/jclement/DEV/pipeline/studio/venv2.6/lib/python2.6/site-packages/celery/result.py", line 169, in get
    no_ack=no_ack,
  File "/home/local/users/jclement/DEV/pipeline/studio/venv2.6/lib/python2.6/site-packages/celery/backends/amqp.py", line 155, in wait_for
    on_interval=on_interval)
  File "/home/local/users/jclement/DEV/pipeline/studio/venv2.6/lib/python2.6/site-packages/celery/backends/amqp.py", line 231, in consume
    conn, consumer, timeout, on_interval)[task_id]
  File "/home/local/users/jclement/DEV/pipeline/studio/venv2.6/lib/python2.6/site-packages/celery/backends/amqp.py", line 212, in drain_events
    wait(timeout=1)
  File "/home/local/users/jclement/DEV/pipeline/studio/venv2.6/lib/python2.6/site-packages/kombu/connection.py", line 275, in drain_events
    return self.transport.drain_events(self.connection, **kwargs)
  File "/home/local/users/jclement/DEV/pipeline/studio/venv2.6/lib/python2.6/site-packages/kombu/transport/pyamqp.py", line 95, in drain_events
    return connection.drain_events(**kwargs)
  File "/home/local/users/jclement/DEV/pipeline/studio/venv2.6/lib/python2.6/site-packages/amqp/connection.py", line 325, in drain_events
    return amqp_method(channel, args, content)
  File "/home/local/users/jclement/DEV/pipeline/studio/venv2.6/lib/python2.6/site-packages/amqp/channel.py", line 1908, in _basic_deliver
    fun(msg)
  File "/home/local/users/jclement/DEV/pipeline/studio/venv2.6/lib/python2.6/site-packages/kombu/messaging.py", line 590, in _receive_callback
    decoded = None if on_m else message.decode()
  File "/home/local/users/jclement/DEV/pipeline/studio/venv2.6/lib/python2.6/site-packages/kombu/message.py", line 142, in decode
    self.content_encoding, accept=self.accept)
  File "/home/local/users/jclement/DEV/pipeline/studio/venv2.6/lib/python2.6/site-packages/kombu/serialization.py", line 184, in loads
    return decode(data)
  File "/servers/Software/Python/2.6.9s/lib/python2.6/contextlib.py", line 34, in __exit__
    self.gen.throw(type, value, traceback)
  File "/home/local/users/jclement/DEV/pipeline/studio/venv2.6/lib/python2.6/site-packages/kombu/serialization.py", line 59, in _reraise_errors
    reraise(wrapper, wrapper(exc), sys.exc_info()[2])
  File "/home/local/users/jclement/DEV/pipeline/studio/venv2.6/lib/python2.6/site-packages/kombu/serialization.py", line 55, in _reraise_errors
    yield
  File "/home/local/users/jclement/DEV/pipeline/studio/venv2.6/lib/python2.6/site-packages/kombu/serialization.py", line 184, in loads
    return decode(data)
  File "/home/local/users/jclement/DEV/pipeline/studio/venv2.6/lib/python2.6/site-packages/kombu/serialization.py", line 316, in _loads
    return json_loads(obj)
  File "/home/local/users/jclement/DEV/pipeline/studio/venv2.6/lib/python2.6/site-packages/anyjson/__init__.py", line 135, in loads
    return implementation.loads(value)
  File "/home/local/users/jclement/DEV/pipeline/studio/venv2.6/lib/python2.6/site-packages/anyjson/__init__.py", line 99, in loads
    return self._decode(s)
  File "/home/local/users/jclement/DEV/pipeline/studio/venv2.6/lib/python2.6/site-packages/simplejson/__init__.py", line 516, in loads
    return _default_decoder.decode(s)
  File "/home/local/users/jclement/DEV/pipeline/studio/venv2.6/lib/python2.6/site-packages/simplejson/decoder.py", line 371, in decode
    obj, end = self.raw_decode(s)
  File "/home/local/users/jclement/DEV/pipeline/studio/venv2.6/lib/python2.6/site-packages/simplejson/decoder.py", line 401, in raw_decode
    return self.scan_once(s, idx=_w(s, idx).end())
DecodeError: Expecting value: line 1 column 1 (char 0)```