### PR TITLE
Fix kombu.transport.django migration for Django 1.7+

### DIFF
--- a/kombu/transport/django/migrations/0001_initial.py
+++ b/kombu/transport/django/migrations/0001_initial.py
@@ -1,57 +1,44 @@
-# encoding: utf-8
-from __future__ import absolute_import
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 
-# flake8: noqa
-import datetime
-from south.db import db
-from south.v2 import SchemaMigration
-from django.db import models
-
-class Migration(SchemaMigration):
-
-    def forwards(self, orm):
-
-        # Adding model 'Queue'
-        db.create_table('djkombu_queue', (
-            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
-            ('name', self.gf('django.db.models.fields.CharField')(unique=True, max_length=200)),
-        ))
-        db.send_create_signal('django', ['Queue'])
-
-        # Adding model 'Message'
-        db.create_table('djkombu_message', (
-            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
-            ('visible', self.gf('django.db.models.fields.BooleanField')(default=True, db_index=True)),
-            ('sent_at', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, null=True, db_index=True, blank=True)),
-            ('payload', self.gf('django.db.models.fields.TextField')()),
-            ('queue', self.gf('django.db.models.fields.related.ForeignKey')(related_name='messages', to=orm['django.Queue'])),
-        ))
-        db.send_create_signal('django', ['Message'])
+from django.db import models, migrations
 
 
-    def backwards(self, orm):
+class Migration(migrations.Migration):
 
-        # Deleting model 'Queue'
-        db.delete_table('djkombu_queue')
+    dependencies = [
+    ]
 
-        # Deleting model 'Message'
-        db.delete_table('djkombu_message')
-
-
-    models = {
-        'django.message': {
-            'Meta': {'object_name': 'Message', 'db_table': "'djkombu_message'"},
-            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'payload': ('django.db.models.fields.TextField', [], {}),
-            'queue': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'messages'", 'to': "orm['django.Queue']"}),
-            'sent_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
-            'visible': ('django.db.models.fields.BooleanField', [], {'default': 'True', 'db_index': 'True'})
-        },
-        'django.queue': {
-            'Meta': {'object_name': 'Queue', 'db_table': "'djkombu_queue'"},
-            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '200'})
-        }
-    }
-
-    complete_apps = ['django']
+    operations = [
+        migrations.CreateModel(
+            name='Message',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('visible', models.BooleanField(default=True, db_index=True)),
+                ('sent_at', models.DateTimeField(db_index=True, auto_now_add=True, null=True)),
+                ('payload', models.TextField(verbose_name='payload')),
+            ],
+            options={
+                'db_table': 'djkombu_message',
+                'verbose_name': 'message',
+                'verbose_name_plural': 'messages',
+            },
+        ),
+        migrations.CreateModel(
+            name='Queue',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(unique=True, max_length=200, verbose_name='name')),
+            ],
+            options={
+                'db_table': 'djkombu_queue',
+                'verbose_name': 'queue',
+                'verbose_name_plural': 'queues',
+            },
+        ),
+        migrations.AddField(
+            model_name='message',
+            name='queue',
+            field=models.ForeignKey(related_name='messages', to='kombu_transport_django.Queue'),
+        ),
+    ]

--- a/kombu/transport/django/south_migrations/0001_initial.py
+++ b/kombu/transport/django/south_migrations/0001_initial.py
@@ -1,0 +1,57 @@
+# encoding: utf-8
+from __future__ import absolute_import
+
+# flake8: noqa
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+
+        # Adding model 'Queue'
+        db.create_table('djkombu_queue', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('name', self.gf('django.db.models.fields.CharField')(unique=True, max_length=200)),
+        ))
+        db.send_create_signal('django', ['Queue'])
+
+        # Adding model 'Message'
+        db.create_table('djkombu_message', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('visible', self.gf('django.db.models.fields.BooleanField')(default=True, db_index=True)),
+            ('sent_at', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, null=True, db_index=True, blank=True)),
+            ('payload', self.gf('django.db.models.fields.TextField')()),
+            ('queue', self.gf('django.db.models.fields.related.ForeignKey')(related_name='messages', to=orm['django.Queue'])),
+        ))
+        db.send_create_signal('django', ['Message'])
+
+
+    def backwards(self, orm):
+
+        # Deleting model 'Queue'
+        db.delete_table('djkombu_queue')
+
+        # Deleting model 'Message'
+        db.delete_table('djkombu_message')
+
+
+    models = {
+        'django.message': {
+            'Meta': {'object_name': 'Message', 'db_table': "'djkombu_message'"},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'payload': ('django.db.models.fields.TextField', [], {}),
+            'queue': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'messages'", 'to': "orm['django.Queue']"}),
+            'sent_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'visible': ('django.db.models.fields.BooleanField', [], {'default': 'True', 'db_index': 'True'})
+        },
+        'django.queue': {
+            'Meta': {'object_name': 'Queue', 'db_table': "'djkombu_queue'"},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '200'})
+        }
+    }
+
+    complete_apps = ['django']


### PR DESCRIPTION
South doesn't support django 1.7+, so `kombu.transport.django` breaks things for users using supported django versions.

This PR uses the recommended approach for libraries [1], which is to mandate South 1.0+ for django<1.7 users, and stick south migrations in a different directory, and provide core migrations for django 1.7+ users.

[1] See https://south.readthedocs.org/en/latest/releasenotes/1.0.html