### PR TITLE
Remove surplus % from parameters of log.debug

### DIFF
--- a/kombu/async/aws/connection.py
+++ b/kombu/async/aws/connection.py
@@ -166,7 +166,7 @@ class AsyncConnection(object):
     def _mexe(self, request, sender=None, callback=None):
         callback = callback or promise()
         boto.log.debug(
-            'HTTP %s %s/%s headers=%s body=%s',
+            'HTTP %s/%s headers=%s body=%s',
             request.host, request.path,
             request.headers, request.body,
         )


### PR DESCRIPTION
There are 5 % with only 4 parameters, remove the surplus one.