### PR TITLE
Print access_key when SQS auth failed.

### DIFF
--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -99,7 +99,14 @@ class Channel(virtual.Channel):
         # exists with a different visibility_timeout, so this prepopulates
         # the queue_cache to protect us from recreating
         # queues that are known to already exist.
-        queues = self.sqs.get_all_queues(prefix=self.queue_name_prefix)
+        queues = None
+        try:
+          queues = self.sqs.get_all_queues(prefix=self.queue_name_prefix)
+        except exception.SQSError, e:
+          if e.status == 403:
+            raise RuntimeError('SQS authorization error, access_key=%s' % self.sqs.access_key)
+          else:
+            raise e
         for queue in queues:
             self._queue_cache[queue.name] = queue
 

--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -101,12 +101,12 @@ class Channel(virtual.Channel):
         # queues that are known to already exist.
         queues = None
         try:
-          queues = self.sqs.get_all_queues(prefix=self.queue_name_prefix)
+            queues = self.sqs.get_all_queues(prefix=self.queue_name_prefix)
         except exception.SQSError, e:
-          if e.status == 403:
-            raise RuntimeError('SQS authorization error, access_key=%s' % self.sqs.access_key)
-          else:
-            raise e
+            if e.status == 403:
+                raise RuntimeError('SQS authorization error, access_key=%s' % self.sqs.access_key)
+            else:
+                raise e
         for queue in queues:
             self._queue_cache[queue.name] = queue
 


### PR DESCRIPTION
boto will try many scenarios to get access_key and secret key.
1. get from arguments.
2. get from .boto configuration file.
3. get from environment variables.
4. get from metadata service in elastic beanstalk environment.
So when we get access denied error, it is hard to identify whether we are using the wrong account or the access policy is wrong, this fix will show the access_key for access denied error, it will help developer diagnose problem.