### PR TITLE
Fix typo and api name error of test cases.

### DIFF
--- a/kombu/tests/transport/test_qpid.py
+++ b/kombu/tests/transport/test_qpid.py
@@ -1535,8 +1535,9 @@ class TestTransportInit(Case):
         self.verify_runtime_environment.assert_called_once_with()
 
     def test_transport___init___calls_parent_class___init__(self):
-        Transport(Mock())
-        self.base_Transport__init__.assert_caled_once_with()
+        args = Mock()
+        Transport(args)
+        self.base_Transport__init__.assert_called_once_with(args)
 
     def test_transport___init___calls_os_pipe(self):
         Transport(Mock())

--- a/kombu/tests/transport/test_redis.py
+++ b/kombu/tests/transport/test_redis.py
@@ -578,8 +578,8 @@ class test_Channel(Case):
         srem = x.client.srem = Mock()
 
         x._delete('queue', 'exchange', 'routing_key', None)
-        delete.assert_has_call('queue')
-        srem.assert_has_call(x.keyprefix_queue % ('exchange',),
+        delete.assert_any_call('queue')
+        srem.assert_any_call(x.keyprefix_queue % ('exchange',),
                              x.sep.join(['routing_key', '', 'queue']))
 
     def test_has_queue(self):
@@ -587,7 +587,7 @@ class test_Channel(Case):
         exists = self.channel.client.exists = Mock()
         exists.return_value = True
         self.assertTrue(self.channel._has_queue('foo'))
-        exists.assert_has_call('foo')
+        exists.assert_any_call('foo')
 
         exists.return_value = False
         self.assertFalse(self.channel._has_queue('foo'))


### PR DESCRIPTION
- fix test_qpid failure by replacing assert_caled_once_with(typo error caled->called)
- fix test_redis failure by replacing assert_has_call(not exist) with assert_any_call