### PR TITLE
Fix libSystem.dylib import on OS X 10.11

### DIFF
--- a/kombu/five.py
+++ b/kombu/five.py
@@ -49,7 +49,7 @@ if sys.version_info < (3, 3):
 
     if SYSTEM == 'Darwin' and has_ctypes:
         from ctypes.util import find_library
-        libSystem = ctypes.CDLL('libSystem.dylib')
+        libSystem = ctypes.CDLL(find_library('libSystem.dylib'))
         CoreServices = ctypes.CDLL(find_library('CoreServices'),
                                    use_errno=True)
         mach_absolute_time = libSystem.mach_absolute_time


### PR DESCRIPTION
PR for #521 

This will also need to be ported in py-amqp eventually since the master simply inherits from amqp.five