### PR TITLE
Fix test_sqs for python 3.x

### DIFF
--- a/kombu/tests/transport/test_SQS.py
+++ b/kombu/tests/transport/test_SQS.py
@@ -164,7 +164,7 @@ class test_Channel(Case):
         self.assertEqual(len(results), 1)
 
         # Now test getting many messages
-        for i in xrange(3):
+        for i in range(3):
             message = 'message: {0}'.format(i)
             self.producer.publish(message)
 
@@ -210,11 +210,11 @@ class test_Channel(Case):
         self.assertEqual(message, results)
 
     def test_puts_and_gets(self):
-        for i in xrange(3):
+        for i in range(3):
             message = 'message: %s' % i
             self.producer.publish(message)
 
-        for i in xrange(3):
+        for i in range(3):
             self.assertEqual('message: %s' % i,
                              self.queue(self.channel).get().payload)
 
@@ -233,7 +233,7 @@ class test_Channel(Case):
         self.channel.qos.prefetch_count = 5
 
         # Now, generate all the messages
-        for i in xrange(message_count):
+        for i in range(message_count):
             message = 'message: %s' % i
             self.producer.publish(message)
 
@@ -262,11 +262,11 @@ class test_Channel(Case):
         self.channel.qos.prefetch_count = 5
 
         # Now, generate all the messages
-        for i in xrange(message_count):
+        for i in range(message_count):
             self.producer.publish('message: %s' % i)
 
         # Now drain all the events
-        for i in xrange(message_count):
+        for i in range(message_count):
             self.channel.drain_events()
 
         # How many times was the SQSConnectionMock get_message method called?
@@ -283,11 +283,11 @@ class test_Channel(Case):
         self.channel.qos.prefetch_count = None
 
         # Now, generate all the messages
-        for i in xrange(message_count):
+        for i in range(message_count):
             self.producer.publish('message: %s' % i)
 
         # Now drain all the events
-        for i in xrange(message_count):
+        for i in range(message_count):
             self.channel.drain_events()
 
         # How many times was the SQSConnectionMock get_message method called?

--- a/requirements/test-ci3.txt
+++ b/requirements/test-ci3.txt
@@ -3,3 +3,4 @@ coveralls
 redis
 PyYAML
 msgpack-python>0.2.0  # 0.2.0 dropped 2.5 support
+boto


### PR DESCRIPTION
This is the only test failure for me under Python 3.x, and after applying this simple fix all tests passed here with Python 3.5. `boto` was added to test-ci3 to prevent it from happening in the future.

The master branch doesn't have the problem, though.