### PR TITLE
ability not to log dispatch errors

### DIFF
--- a/kombu/pidbox.py
+++ b/kombu/pidbox.py
@@ -106,7 +106,9 @@ class Node(object):
         except SystemExit:
             raise
         except Exception as exc:
-            error('pidbox command error: %r', exc, exc_info=1)
+            no_logging = arguments.get('no_logging', False)
+            if not no_logging:
+                error('pidbox command error: %r', exc, exc_info=1)
             reply = {'error': repr(exc)}
 
         if reply_to:


### PR DESCRIPTION
I suggest to control when to log exception of handling dispatched method and when not to log. 
Anyway, negative answer containing exception details will return to the sender, so he will handle it properly.
Usage example:
from celery.app import app_or_default
from celery.app.control import Control
control = Control(app_or_default())
reply = control.pool_shrink(1, [worker_name], reply=True, no_logging=True)
