### PR TITLE
Add django postgresql transport that supports 'acks_late' by using postgresql's advisory locks

### DIFF
--- a/funtests/tests/test_django_postgres.py
+++ b/funtests/tests/test_django_postgres.py
@@ -5,8 +5,8 @@ from kombu.tests.case import redirect_stdouts
 from funtests import transport
 
 
-class test_django(transport.TransportCase):
-    transport = 'django'
+class test_django_postgres(transport.TransportCase):
+    transport = 'django_postgres'
     prefix = 'django'
     event_loop_max = 10
 
@@ -21,12 +21,10 @@ class test_django(transport.TransportCase):
             from django.conf import settings
             if not settings.configured:
                 settings.configure(
-                    DATABASE_ENGINE='sqlite3',
-                    DATABASE_NAME=':memory:',
                     DATABASES={
                         'default': {
-                            'ENGINE': 'django.db.backends.sqlite3',
-                            'NAME': ':memory:',
+                            'ENGINE': 'django.db.backends.postgresql_psycopg2',
+                            'NAME': 'kombu',
                         },
                     },
                     INSTALLED_APPS=('kombu.transport.django',),

--- a/kombu/tests/case.py
+++ b/kombu/tests/case.py
@@ -7,7 +7,6 @@ import types
 
 from contextlib import contextmanager
 from functools import wraps
-from io import StringIO
 
 try:
     from unittest import mock
@@ -16,7 +15,7 @@ except ImportError:
 
 from nose import SkipTest
 
-from kombu.five import builtins, string_t
+from kombu.five import builtins, string_t, WhateverIO
 from kombu.utils.encoding import ensure_bytes
 
 try:
@@ -170,8 +169,8 @@ def redirect_stdouts(fun):
 
     @wraps(fun)
     def _inner(*args, **kwargs):
-        sys.stdout = StringIO()
-        sys.stderr = StringIO()
+        sys.stdout = WhateverIO()
+        sys.stderr = WhateverIO()
         try:
             return fun(*args, **dict(kwargs,
                                      stdout=sys.stdout, stderr=sys.stderr))

--- a/kombu/transport/__init__.py
+++ b/kombu/transport/__init__.py
@@ -55,6 +55,7 @@ TRANSPORT_ALIASES = {
     'couchdb': 'kombu.transport.couchdb:Transport',
     'zookeeper': 'kombu.transport.zookeeper:Transport',
     'django': 'kombu.transport.django:Transport',
+    'django_postgres': 'kombu.transport.django.postgres:Transport',
     'sqlalchemy': 'kombu.transport.sqlalchemy:Transport',
     'sqla': 'kombu.transport.sqlalchemy:Transport',
     'SLMQ': 'kombu.transport.SLMQ.Transport',

--- a/kombu/transport/django/__init__.py
+++ b/kombu/transport/django/__init__.py
@@ -11,6 +11,8 @@ from kombu.utils.encoding import bytes_to_str
 from kombu.utils.json import loads, dumps
 
 
+from .models import Queue, Message
+
 try:
     from django.apps import AppConfig
 except ImportError:  # pragma: no cover
@@ -45,10 +47,12 @@ class Channel(virtual.Channel):
             return
         super(Channel, self).basic_consume(queue, *args, **kwargs)
 
-    def _get(self, queue):
-        m = self.Queue.objects.fetch(queue)
-        if m:
-            return loads(bytes_to_str(m))
+    def _get(self, queue, manager='objects', **kwargs):
+        message = getattr(Message, manager).pop(queue)
+        if message:
+            payload = loads(bytes_to_str(message.payload))
+            payload['properties']['delivery_tag'] = message.pk
+            return payload
         raise Empty()
 
     def _size(self, queue):

--- a/kombu/transport/django/managers.py
+++ b/kombu/transport/django/managers.py
@@ -21,20 +21,14 @@ else:
                 return fun(*args, **kwargs)
         return _commit
 
+from . import pgsql
+
 
 class QueueManager(models.Manager):
 
     def publish(self, queue_name, payload):
         queue, created = self.get_or_create(name=queue_name)
         queue.messages.create(payload=payload)
-
-    def fetch(self, queue_name):
-        try:
-            queue = self.get(name=queue_name)
-        except self.model.DoesNotExist:
-            return
-
-        return queue.messages.pop()
 
     def size(self, queue_name):
         return self.get(name=queue_name).messages.count()
@@ -65,10 +59,10 @@ class MessageManager(models.Manager):
     cleanup_every = 10
 
     @commit_on_success
-    def pop(self):
+    def pop(self, queue):
         try:
             resultset = select_for_update(
-                self.filter(visible=True).order_by('sent_at', 'id')
+                self.filter(visible=True, queue__name=queue).order_by('sent_at', 'id')
             )
             result = resultset[0:1].get()
             result.visible = False
@@ -77,7 +71,7 @@ class MessageManager(models.Manager):
             recv[0] += 1
             if not recv[0] % self.cleanup_every:
                 self.cleanup()
-            return result.payload
+            return result
         except self.model.DoesNotExist:
             pass
 
@@ -93,3 +87,23 @@ class MessageManager(models.Manager):
         if connections:
             return connections[router.db_for_write(self.model)]
         return connection
+
+
+class PostgresMessageManager(MessageManager):
+    def pop(self, queue):
+        results = self.raw(
+            pgsql.LOCK_JOB, dict(app_id=pgsql.APP_ID, queue=queue)
+        )
+        if list(results):
+            return results[0]
+
+    def ack(self, delivery_tag):
+        """Delete the message and remove the advisory lock"""
+        self.filter(pk=delivery_tag).delete()
+        cursor = self.connection_for_write().cursor()
+        cursor.execute(pgsql.UNLOCK, dict(app_id=pgsql.APP_ID, lock_id=delivery_tag))
+
+    def reject(self, delivery_tag):
+        """Remove the advisory lock without deleting the message"""
+        cursor = self.connection_for_write().cursor()
+        cursor.execute(pgsql.UNLOCK, dict(app_id=pgsql.APP_ID, lock_id=delivery_tag))

--- a/kombu/transport/django/models.py
+++ b/kombu/transport/django/models.py
@@ -5,7 +5,7 @@ import django
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
-from .managers import QueueManager, MessageManager
+from .managers import QueueManager, MessageManager, PostgresMessageManager
 
 
 class Queue(models.Model):
@@ -29,6 +29,7 @@ class Message(models.Model):
     queue = models.ForeignKey(Queue, related_name='messages')
 
     objects = MessageManager()
+    pg_objects = PostgresMessageManager()
 
     class Meta:
         if django.VERSION >= (1, 7):

--- a/kombu/transport/django/pgsql.py
+++ b/kombu/transport/django/pgsql.py
@@ -1,0 +1,40 @@
+APP_ID = 100001
+
+LOCK_JOB = """
+WITH RECURSIVE job AS (
+  SELECT (j).*, pg_try_advisory_lock(%(app_id)s, (j).id) AS locked
+  FROM (
+    SELECT j
+    FROM djkombu_message AS j
+    JOIN djkombu_queue AS q ON j.queue_id = q.id
+    WHERE q.name = %(queue)s
+    ORDER BY j.id
+    LIMIT 1
+  ) AS t1
+  UNION ALL (
+    SELECT (j).*, pg_try_advisory_lock(%(app_id)s, (j).id) AS locked
+    FROM (
+      SELECT (
+        SELECT j
+        FROM djkombu_message AS j
+        JOIN djkombu_queue AS q ON j.queue_id = q.id
+        WHERE q.name = %(queue)s
+        AND j.id > job.id
+        ORDER BY j.id
+        LIMIT 1
+      ) AS j
+    FROM job
+    WHERE NOT job.locked
+    LIMIT 1
+    ) AS t1
+  )
+)
+SELECT id, queue_id, payload, sent_at
+FROM job
+WHERE locked
+LIMIT 1
+"""
+
+UNLOCK = """
+SELECT pg_advisory_unlock(%(app_id)s, %(lock_id)s)
+"""

--- a/kombu/transport/django/postgres.py
+++ b/kombu/transport/django/postgres.py
@@ -1,0 +1,72 @@
+"""
+kombu.transport.django_postgres
+=====================
+
+Django database transport optimized for PostgreSQL
+ using advisory locks to hide messages that are held
+ by a worker.
+
+This transport is meant to be used with `CELERY_ACKS_LATE = True`,
+so messages are not acknowledged until after they have completed.
+
+Inspired by `que` by Chris Hanks: https://github.com/chanks/que
+"""
+from __future__ import absolute_import
+
+from kombu.transport import virtual
+
+from . import Channel as DjangoChannel, Transport as DjangoTransport
+from .models import Message
+
+try:
+    from django.apps import AppConfig
+except ImportError:  # pragma: no cover
+    pass
+else:
+    class KombuAppConfig(AppConfig):
+        name = 'kombu.transport.django.postgres'
+        label = name.replace('.', '_')
+        verbose_name = 'Message queue'
+
+    default_app_config = 'kombu.transport.django.postgres.KombuAppConfig'
+
+
+class QoS(virtual.QoS):
+    """
+    QoS that uses PostgreSQL advisory locks to reserve messages
+    """
+    restore_at_shutdown = False
+
+    def ack(self, delivery_tag):
+        """Acknowledge message and remove from transactional state."""
+        self._delivered[delivery_tag].ack()
+        self._quick_ack(delivery_tag)
+
+    def reject(self, delivery_tag, requeue=False):
+        """Ack or reject and remove from transactional state."""
+        self._delivered[delivery_tag].reject(requeue)
+        self._quick_ack(delivery_tag)
+
+
+class Channel(DjangoChannel):
+    QoS = QoS
+
+    def _get(self, queue, **kwargs):
+        return super(Channel, self)._get(queue, 'pg_objects', **kwargs)
+
+    def _restore(self, message):
+        raise NotImplementedError('Should never be called. Use qos.reject instead')
+
+    def basic_reject(self, delivery_tag, requeue=False):
+        Message.pg_objects.reject(delivery_tag)
+
+    def basic_ack(self, delivery_tag):
+        Message.pg_objects.ack(delivery_tag)
+
+
+class Transport(DjangoTransport):
+    Channel = Channel
+
+    polling_interval = 1
+    driver_type = 'sql'
+    driver_name = 'postgres'

--- a/requirements/funtest.txt
+++ b/requirements/funtest.txt
@@ -14,11 +14,10 @@ beanstalkc
 kazoo
 
 # SQLAlchemy transport
-kombu-sqlalchemy
+sqlalchemy
 
 # Django ORM transport
 Django
-django-kombu
 
 # SQS transport
 boto


### PR DESCRIPTION
- remove outdated funtest requirements
- add a note about using CELERY_ACKS_LATE