### PR TITLE
Fix uuid shim in upcoming Python 3.5.1.

### DIFF
--- a/kombu/utils/__init__.py
+++ b/kombu/utils/__init__.py
@@ -16,7 +16,11 @@ from contextlib import contextmanager
 from itertools import count, repeat
 from functools import wraps
 from time import sleep
-from uuid import UUID, uuid4 as _uuid4, _uuid_generate_random
+from uuid import UUID, uuid4
+try:
+    from uuid import _uuid_generate_random
+except ImportError:
+    _uuid_generate_random = None
 
 from kombu.five import items, reraise, string_t
 
@@ -140,13 +144,12 @@ def say(m, *fargs, **fkwargs):
     print(str(m).format(*fargs, **fkwargs), file=sys.stderr)
 
 
-def uuid4():
-    # Workaround for http://bugs.python.org/issue4607
-    if ctypes and _uuid_generate_random:  # pragma: no cover
+if ctypes and _uuid_generate_random:  # pragma: no cover
+    def uuid4():
+        # Workaround for http://bugs.python.org/issue4607
         buffer = ctypes.create_string_buffer(16)
         _uuid_generate_random(buffer)
         return UUID(bytes=buffer.raw)
-    return _uuid4()
 
 
 def uuid():


### PR DESCRIPTION
After a recent change in cpython, uuid._uuid_generate_random() no longer
exists.

https://hg.python.org/cpython/rev/70be1f9c9255
http://bugs.python.org/issue25515

The issue being worked around was resolved in 2007, so it might be
sensible to just remove the work around.

Tested with 3.5.0 and 3.5 tip at this point:
https://hg.python.org/cpython/shortlog/f928dcb448a9