### PR TITLE
Multiple queue bindings for virtual transports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ kombu/tests/cover
 kombu/tests/coverage.xml
 .coverage
 dump.rdb
+.idea/

--- a/kombu/tests/transport/virtual/test_base.py
+++ b/kombu/tests/transport/virtual/test_base.py
@@ -28,11 +28,9 @@ class test_BrokerState(Case):
     def test_constructor(self):
         s = virtual.BrokerState()
         self.assertTrue(hasattr(s, 'exchanges'))
-        self.assertTrue(hasattr(s, 'bindings'))
 
-        t = virtual.BrokerState(exchanges=16, bindings=32)
+        t = virtual.BrokerState(exchanges=16)
         self.assertEqual(t.exchanges, 16)
-        self.assertEqual(t.bindings, 32)
 
 
 class test_QoS(Case):

--- a/kombu/tests/transport/virtual/test_base.py
+++ b/kombu/tests/transport/virtual/test_base.py
@@ -202,8 +202,7 @@ class test_Channel(Case):
             self.channel.exchange_unbind('dest', 'src', 'key')
 
     def test_queue_unbind_interface(self):
-        with self.assertRaises(NotImplementedError):
-            self.channel.queue_unbind('dest', 'ex', 'key')
+        self.channel.queue_unbind('dest', 'ex', 'key')
 
     def test_management(self):
         m = self.channel.connection.client.get_manager()
@@ -244,16 +243,16 @@ class test_Channel(Case):
 
         c.exchange_declare(ex, 'direct', durable=True, auto_delete=True)
         self.assertIn(ex, c.state.exchanges)
-        self.assertNotIn(ex, c.state.bindings)  # no bindings yet
+        self.assertFalse(c.state.has_binding(ex, ex, ex))  # no bindings yet
         c.exchange_delete(ex)
         self.assertNotIn(ex, c.state.exchanges)
 
         c.exchange_declare(ex, 'direct', durable=True, auto_delete=True)
         c.queue_declare(ex)
         c.queue_bind(ex, ex, ex)
-        self.assertTrue(c.state.bindings[ex])
+        self.assertTrue(c.state.has_binding(ex, ex, ex))
         c.exchange_delete(ex)
-        self.assertNotIn(ex, c.state.bindings)
+        self.assertFalse(c.state.has_binding(ex, ex, ex))
         self.assertIn(ex, c.purged)
 
     def test_queue_delete__if_empty(self, n='test_queue_delete__if_empty'):
@@ -275,11 +274,11 @@ class test_Channel(Case):
         c.queue_bind(n, n, n)
 
         c.queue_delete(n, if_empty=True)
-        self.assertIn(n, c.state.bindings)
+        self.assertTrue(c.state.has_binding(n, n, n))
 
         c.size = 0
         c.queue_delete(n, if_empty=True)
-        self.assertNotIn(n, c.state.bindings)
+        self.assertFalse(c.state.has_binding(n, n, n))
         self.assertIn(n, c.purged)
 
     def test_queue_purge(self, n='test_queue_purge'):

--- a/kombu/transport/virtual/__init__.py
+++ b/kombu/transport/virtual/__init__.py
@@ -13,6 +13,7 @@ import base64
 import socket
 import sys
 import warnings
+import collections
 
 from array import array
 from collections import OrderedDict
@@ -79,16 +80,66 @@ class BrokerState(object):
     #: exchange declarations.
     exchanges = None
 
-    #: active bindings.
-    bindings = None
+    # This is the actual bindings registry, used to store bindings and to
+    # test 'in' relationships in constant time. It has the following structure:
+    # {
+    #    (queue, exchange, routing_key): arguments,
+    #    ...
+    # }
+    __bindings = None
+
+    # The queue index is used to access directly (constant time)
+    # all the bindings of a certain queue. It has the following structure:
+    # {
+    #    queue: { (queue, exchange, routing_key), ... }
+    #    ...
+    # }
+    __queue_index = None
 
     def __init__(self, exchanges=None, bindings=None):
         self.exchanges = {} if exchanges is None else exchanges
-        self.bindings = {} if bindings is None else bindings
+        self.bindings = {} if bindings is None else bindings  # TODO
+        #
+        self.__bindings = dict()
+        self.__queue_index = collections.defaultdict(set)
 
     def clear(self):
         self.exchanges.clear()
-        self.bindings.clear()
+        # self.bindings.clear()
+        self.__bindings.clear()
+        self.__queue_index.clear()
+
+    def has_binding(self, queue, exchange, routing_key):
+        return (queue, exchange, routing_key) in self.__bindings
+
+    def binding_declare(self, queue, exchange, routing_key, arguments):
+        if not self.has_binding(queue, exchange, routing_key):
+            key = (queue, exchange, routing_key)
+            self.__bindings[key] = arguments
+            self.__queue_index[queue].add(key)
+
+    def binding_delete(self, queue, exchange, routing_key):
+        if self.has_binding(queue, exchange, routing_key):
+            key = (queue, exchange, routing_key)
+            del self.__bindings[key]
+            self.__queue_index[queue].remove(key)
+
+    def queue_bindings(self, queue):
+        for queue, exchange, routing_key in self.__queue_index[queue]:
+            yield (
+                # Not yelding directly from self.__queue_index because
+                # we need to remove 'queue' field and retrieve 'arguments'
+                # as needed by client code:
+                exchange,
+                routing_key,
+                self.__bindings[(queue, exchange, routing_key)]
+            )
+
+    def queue_bindings_delete(self, queue):
+        if queue in self.__queue_index:
+            for binding in self.__queue_index[queue]:
+                del self.__bindings[binding]
+            del self.__queue_index[queue]
 
 
 class QoS(object):
@@ -466,15 +517,12 @@ class Channel(AbstractChannel, base.StdChannel):
         """Delete queue."""
         if if_empty and self._size(queue):
             return
-        try:
-            exchange, routing_key, arguments = self.state.bindings[queue]
-        except KeyError:
-            return
-        meta = self.typeof(exchange).prepare_bind(
-            queue, exchange, routing_key, arguments,
-        )
-        self._delete(queue, exchange, *meta)
-        self.state.bindings.pop(queue, None)
+        for exchange, routing_key, arguments in self.state.queue_bindings(queue):
+            meta = self.typeof(exchange).prepare_bind(
+                queue, exchange, routing_key, arguments,
+            )
+            self._delete(queue, exchange, *meta)
+        self.state.queue_bindings_delete(queue)
 
     def after_reply_message_received(self, queue):
         self.queue_delete(queue)
@@ -490,11 +538,13 @@ class Channel(AbstractChannel, base.StdChannel):
     def queue_bind(self, queue, exchange=None, routing_key='',
                    arguments=None, **kwargs):
         """Bind `queue` to `exchange` with `routing key`."""
-        if queue in self.state.bindings:
-            return
         exchange = exchange or 'amq.direct'
+        if self.state.has_binding(queue, exchange, routing_key):
+            return
+        # Add binding:
+        self.state.binding_declare(queue, exchange, routing_key, arguments)
+        # Update exchange's routing table:
         table = self.state.exchanges[exchange].setdefault('table', [])
-        self.state.bindings[queue] = exchange, routing_key, arguments
         meta = self.typeof(exchange).prepare_bind(
             queue, exchange, routing_key, arguments,
         )
@@ -504,7 +554,10 @@ class Channel(AbstractChannel, base.StdChannel):
 
     def queue_unbind(self, queue, exchange=None, routing_key='',
                      arguments=None, **kwargs):
-        raise NotImplementedError('transport does not support queue_unbind')
+        # Remove queue binding:
+        self.state.binding_delete(queue, exchange, routing_key)
+        # Remove binding from exchange's routing table:
+        # TODO
 
     def list_bindings(self):
         return ((queue, exchange, rkey)

--- a/kombu/transport/virtual/__init__.py
+++ b/kombu/transport/virtual/__init__.py
@@ -123,6 +123,13 @@ class BrokerState(object):
             key = (queue, exchange, routing_key)
             del self.__bindings[key]
             self.__queue_index[queue].remove(key)
+            # TODO: delete binding from exchange's routing table
+
+    def queue_bindings_delete(self, queue):
+        if queue in self.__queue_index:
+            for binding in self.__queue_index[queue]:
+                del self.__bindings[binding]
+            del self.__queue_index[queue]
 
     def queue_bindings(self, queue):
         for queue, exchange, routing_key in self.__queue_index[queue]:
@@ -134,12 +141,6 @@ class BrokerState(object):
                 routing_key,
                 self.__bindings[(queue, exchange, routing_key)]
             )
-
-    def queue_bindings_delete(self, queue):
-        if queue in self.__queue_index:
-            for binding in self.__queue_index[queue]:
-                del self.__bindings[binding]
-            del self.__queue_index[queue]
 
 
 class QoS(object):

--- a/kombu/transport/virtual/__init__.py
+++ b/kombu/transport/virtual/__init__.py
@@ -96,10 +96,8 @@ class BrokerState(object):
     # }
     __queue_index = None
 
-    def __init__(self, exchanges=None, bindings=None):
+    def __init__(self, exchanges=None):
         self.exchanges = {} if exchanges is None else exchanges
-        self.bindings = {} if bindings is None else bindings  # TODO
-        #
         self.__bindings = dict()
         self.__queue_index = collections.defaultdict(set)
 
@@ -554,9 +552,9 @@ class Channel(AbstractChannel, base.StdChannel):
 
     def queue_unbind(self, queue, exchange=None, routing_key='',
                      arguments=None, **kwargs):
+        # Remove queue binding:
         self.state.binding_delete(queue, exchange, routing_key)
-        # TODO: the complexity of this operation is O(number of bindings).
-        # Should be optimized.
+        # Remove binding from exchange's routing table:
         try:
             table = self.get_table(exchange)
         except KeyError:
@@ -564,6 +562,8 @@ class Channel(AbstractChannel, base.StdChannel):
         binding_meta = self.typeof(exchange).prepare_bind(
             queue, exchange, routing_key, arguments,
         )
+        # TODO: the complexity of this operation is O(number of bindings).
+        # Should be optimized. Modifying table in place.
         table[:] = [meta for meta in table if meta != binding_meta]
 
     def list_bindings(self):


### PR DESCRIPTION
This PR adds the ability to define multiple bindings from a queue to the same exchange when using virtual transports (for native transports it is already supported by AMQP itself) as requested in #506 by @hochbergg.
Since defining a bind is almost _free_ in terms of resources, in situations where you want to subscribe (and unsubscribe) to different topics dynamically, adding and removing bindings is _much_ more efficient than adding and removing dedicated exchanges (I can provide benchmarks for the latest RabbitMQ if it makes sense). A simple usage example could be:
```python
queue.bind_to(exchange, routing_key=key) for key in ['key_a', 'key_b', 'key_c']
```
You can find a fairly complete test in [this gist](https://gist.github.com/nazavode/97926f916798729c8e4e).

In the current `master` code base, running the code above using a virtual transport will discard all bindings declarations that follow the first one.

Note: I'm working on a optimized rewrite of `BrokerState` class that reduces the complexity of queue deletion operations. Since it needs a new structure for exchanges' routing tables, I'm keeping it as a [branch](https://github.com/nazavode/kombu/tree/feature/multibind).