### PR TITLE
Add support for arbitrary json messages to SQS transport

### DIFF
--- a/kombu/tests/transport/test_SQS.py
+++ b/kombu/tests/transport/test_SQS.py
@@ -194,26 +194,39 @@ class test_Channel(Case):
             self.channel._get_bulk(self.queue_name)
 
     def test_messages_to_python(self):
-        message_count = 3
+        celery_message_count = 3
+        json_message_count = 3
         # Create several test messages and publish them
-        for i in range(message_count):
+        for i in range(celery_message_count):
             message = 'message: %s' % i
             self.producer.publish(message)
 
+        # JSON formatted message NOT created by celery
+        for i in range(json_message_count):
+            message = '{"foo":"bar"}'
+            self.channel._put(self.producer.routing_key, message)
+
         q = self.channel._new_queue(self.queue_name)
         # Get the messages now
-        messages = q.get_messages(num_messages=message_count)
+        celery_messages = q.get_messages(num_messages=celery_message_count)
+        json_messages = q.get_messages(num_messages=json_message_count)
 
         # Now convert them to payloads
-        payloads = self.channel._messages_to_python(
-            messages, self.queue_name,
+        celery_payloads = self.channel._messages_to_python(
+            celery_messages, self.queue_name,
+        )
+        json_payloads = self.channel._messages_to_python(
+            json_messages, self.queue_name,
         )
 
         # We got the same number of payloads back, right?
-        self.assertEquals(len(payloads), message_count)
+        self.assertEquals(len(celery_payloads), celery_message_count)
+        self.assertEquals(len(json_payloads), json_message_count)
 
         # Make sure they're payload-style objects
-        for p in payloads:
+        for p in celery_payloads:
+            self.assertTrue('properties' in p)
+        for p in json_payloads:
             self.assertTrue('properties' in p)
 
     def test_put_and_get(self):

--- a/kombu/tests/transport/test_SQS.py
+++ b/kombu/tests/transport/test_SQS.py
@@ -229,8 +229,6 @@ class test_Channel(Case):
 
         # Get the messages now
         messages = q.get_messages(num_messages=message_count)
-        for mess in messages:
-            print mess.get_body()
 
         # Now convert them to payloads
         payloads = self.channel._messages_to_python(

--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -225,7 +225,6 @@ class Channel(virtual.Channel):
                 payload.update({'properties': {'delivery_info': data,
                                 'delivery_tag': None}})
                 payload['properties']['delivery_tag'] = message.receipt_handle
-                return payload
         return payload
 
     def _messages_to_python(self, messages, queue):

--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -219,6 +219,7 @@ class Channel(virtual.Channel):
                 # set delivery tag to SQS receipt handle
                 payload['properties']['delivery_tag'] = message.receipt_handle
             except Exception, e:
+                # It's probably just a json message NOT created with celery
                 payload.update({'body': bytes_to_str(message.get_body())})
                 data = {'sqs_message': message, 'sqs_queue': queue}
                 payload.update({'properties': {'delivery_info': data,

--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -219,10 +219,7 @@ class Channel(virtual.Channel):
                 # set delivery tag to SQS receipt handle
                 payload['properties']['delivery_tag'] = message.receipt_handle
             except Exception, e:
-<<<<<<< HEAD
                 # It's probably just a json message NOT created with celery
-=======
->>>>>>> 166b057779fc979382b188f5e66edc40a843ac82
                 payload.update({'body': bytes_to_str(message.get_body())})
                 data = {'sqs_message': message, 'sqs_queue': queue}
                 payload.update({'properties': {'delivery_info': data,

--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -218,7 +218,7 @@ class Channel(virtual.Channel):
                 })
                 # set delivery tag to SQS receipt handle
                 payload['properties']['delivery_tag'] = message.receipt_handle
-            except Exception, e:
+            except KeyError as e:
                 # It's probably just a json message NOT created with celery
                 payload.update({'body': bytes_to_str(message.get_body())})
                 data = {'sqs_message': message, 'sqs_queue': queue}


### PR DESCRIPTION
I needed to be able to connect to an SQS queue and listen for json messages NOT created with kombu/celery
Random json messages created without the use the celery/kombu libraries do not include all the json keys that kombu was looking for when parsing the message, and it would fail.
Here's an update that should solve that issue.

I've added a new test that checks that the _message_to_python method can handle arbitrary json messages.