### PR TITLE
Fixed TypeError when conneting to redis via unix domain socket

### DIFF
--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -880,6 +880,11 @@ class Channel(virtual.Channel):
                 connparams.update({
                     'connection_class': redis.UnixDomainSocketConnection,
                     'path': '/' + path}, **query)
+
+                connparams.pop('socket_connect_timeout', None)
+                connparams.pop('socket_keepalive', None)
+                connparams.pop('socket_keepalive_options', None)
+
             connparams.pop('host', None)
             connparams.pop('port', None)
         connparams['db'] = self._prepare_virtual_host(


### PR DESCRIPTION
I have a bug similar to celery/celery#2903 when trying to connect to a redis broker via a unix domain socket:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.4/dist-packages/celery/worker/__init__.py", line 206, in start
    self.blueprint.start(self)
  File "/usr/local/lib/python3.4/dist-packages/celery/bootsteps.py", line 123, in start
    step.start(parent)
  File "/usr/local/lib/python3.4/dist-packages/celery/bootsteps.py", line 374, in start
    return self.obj.start()
  File "/usr/local/lib/python3.4/dist-packages/celery/worker/consumer.py", line 279, in start
    blueprint.start(self)
  File "/usr/local/lib/python3.4/dist-packages/celery/bootsteps.py", line 123, in start
    step.start(parent)
  File "/usr/local/lib/python3.4/dist-packages/celery/worker/consumer.py", line 479, in start
    c.connection = c.connect()
  File "/usr/local/lib/python3.4/dist-packages/celery/worker/consumer.py", line 376, in connect
    callback=maybe_shutdown,
  File "/usr/local/lib/python3.4/dist-packages/kombu/connection.py", line 369, in ensure_connection
    interval_start, interval_step, interval_max, callback)
  File "/usr/local/lib/python3.4/dist-packages/kombu/utils/__init__.py", line 246, in retry_over_time
    return fun(*args, **kwargs)
  File "/usr/local/lib/python3.4/dist-packages/kombu/connection.py", line 237, in connect
    return self.connection
  File "/usr/local/lib/python3.4/dist-packages/kombu/connection.py", line 742, in connection
    self._connection = self._establish_connection()
  File "/usr/local/lib/python3.4/dist-packages/kombu/connection.py", line 697, in _establish_connection
    conn = self.transport.establish_connection()
  File "/usr/local/lib/python3.4/dist-packages/kombu/transport/virtual/__init__.py", line 809, in establish_connection
    self._avail_channels.append(self.create_channel(self))
  File "/usr/local/lib/python3.4/dist-packages/kombu/transport/virtual/__init__.py", line 791, in create_channel
    channel = self.Channel(connection)
  File "/usr/local/lib/python3.4/dist-packages/kombu/transport/redis.py", line 464, in __init__
    self.client.info()
  File "/usr/local/lib/python3.4/dist-packages/kombu/utils/__init__.py", line 325, in __get__
    value = obj.__dict__[self.__name__] = self.__get(obj)
  File "/usr/local/lib/python3.4/dist-packages/kombu/transport/redis.py", line 908, in client
    return self._create_client(async=True)
  File "/usr/local/lib/python3.4/dist-packages/kombu/transport/redis.py", line 861, in _create_client
    return self.AsyncClient(connection_pool=self.async_pool)
  File "/usr/local/lib/python3.4/dist-packages/kombu/transport/redis.py", line 882, in __init__
    self.connection = self.connection_pool.get_connection('_')
  File "/usr/local/lib/python3.4/dist-packages/redis/connection.py", line 450, in get_connection
    connection = self.make_connection()
  File "/usr/local/lib/python3.4/dist-packages/redis/connection.py", line 459, in make_connection
    return self.connection_class(**self.connection_kwargs)
TypeError: __init__() got an unexpected keyword argument 'socket_keepalive_options'
```

I took this change from https://github.com/ridethepony/kombu/commit/d5e3da08b3f42c98271994cf9f407dfddf0a00c9, improved it and confirmed that it is working.