### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1923,7 +1923,7 @@ SQS: Now supports long polling (Issue #176).
           as a pure-python replacement in environments where rabbitmq-c cannot
           be compiled.
 
-    .. _`py-amqp`: http://amqp.readthedocs.org/
+    .. _`py-amqp`: https://amqp.readthedocs.io/
 
     If you start using use py-amqp instead of amqplib you can enjoy many
     advantages including:

--- a/README.rst
+++ b/README.rst
@@ -134,7 +134,7 @@ Documentation
 
 Kombu is using Sphinx, and the latest documentation can be found here:
 
-    http://kombu.readthedocs.org/
+    https://kombu.readthedocs.io/
 
 Quick overview
 --------------

--- a/docs/includes/introduction.txt
+++ b/docs/includes/introduction.txt
@@ -129,7 +129,7 @@ Documentation
 
 Kombu is using Sphinx, and the latest documentation can be found here:
 
-    http://kombu.readthedocs.org/
+    https://kombu.readthedocs.io/
 
 Quick overview
 --------------

--- a/kombu/__init__.py
+++ b/kombu/__init__.py
@@ -14,7 +14,7 @@ VERSION = version_info = version_info_t(4, 0, 0, 'a1', '')
 __version__ = '{0.major}.{0.minor}.{0.micro}{0.releaselevel}'.format(VERSION)
 __author__ = 'Ask Solem'
 __contact__ = 'ask@celeryproject.org'
-__homepage__ = 'http://kombu.readthedocs.org'
+__homepage__ = 'https://kombu.readthedocs.io'
 __docformat__ = 'restructuredtext en'
 
 # -eof meta-

--- a/kombu/transport/zookeeper.py
+++ b/kombu/transport/zookeeper.py
@@ -18,7 +18,7 @@ This uses the built-in kazoo recipe for queues
 **References**
 
 - https://zookeeper.apache.org/doc/trunk/recipes.html#sc_recipes_Queues
-- https://kazoo.readthedocs.org/en/latest/api/recipe/queue.html
+- https://kazoo.readthedocs.io/en/latest/api/recipe/queue.html
 
 **Limitations**
 This queue does not offer reliable consumption. An entry is removed from


### PR DESCRIPTION
As per their email ‘Changes to project subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.