### PR TITLE
Fix funtests for pyamqp and django

### DIFF
--- a/funtests/transport.py
+++ b/funtests/transport.py
@@ -21,6 +21,9 @@ if sys.version_info >= (2, 5):
 else:
     from sha import new as _digest  # noqa
 
+if not hasattr(string, 'letters'):
+    string.letters = string.ascii_letters
+
 
 def say(msg):
     print(msg, file=sys.stderr)

--- a/funtests/transport.py
+++ b/funtests/transport.py
@@ -168,6 +168,8 @@ class TransportCase(unittest.TestCase):
                 purged += self.purge_consumer(consumer)
 
     def _digest(self, data):
+        if isinstance(data, type(u'')):
+            data = data.encode()
         return _digest(data).hexdigest()
 
     @skip_if_quick

--- a/funtests/transport.py
+++ b/funtests/transport.py
@@ -30,7 +30,10 @@ def say(msg):
 
 
 def _nobuf(x):
-    return [str(i) if isinstance(i, buffer) else i for i in x]
+    if 'buffer' in locals():
+        return [str(i) if isinstance(i, buffer) else i for i in x]
+    else:
+        return [str(i) for i in x]
 
 
 def consumeN(conn, consumer, n=1, timeout=30):


### PR DESCRIPTION
The funtests are broken, at least for Python 3.4.

Tested on Python 2.7 and 3.4 on my machine