### PR TITLE
Fixed queue lookup in virtual transports with multiple overlapping bindings

### DIFF
--- a/kombu/tests/transport/test_redis.py
+++ b/kombu/tests/transport/test_redis.py
@@ -321,13 +321,13 @@ class test_Channel(Case):
         pl1 = {'body': 'BODY'}
         spl1 = dumps(pl1)
         lookup = self.channel._lookup = Mock(name='_lookup')
-        lookup.return_value = ['george', 'elaine']
+        lookup.return_value = {'george', 'elaine'}
         self.channel._do_restore_message(
             pl1, 'ex', 'rkey', client,
         )
         client.rpush.assert_has_calls([
             call('george', spl1), call('elaine', spl1),
-        ])
+        ], any_order=True)
 
         client = Mock(name='client')
         pl2 = {'body': 'BODY2', 'headers': {'x-funny': 1}}
@@ -338,7 +338,7 @@ class test_Channel(Case):
         )
         client.rpush.assert_has_calls([
             call('george', spl2), call('elaine', spl2),
-        ])
+        ], any_order=True)
 
         client.rpush.side_effect = KeyError()
         with patch('kombu.transport.redis.crit') as crit:

--- a/kombu/tests/transport/virtual/test_exchange.py
+++ b/kombu/tests/transport/virtual/test_exchange.py
@@ -23,17 +23,17 @@ class test_Direct(ExchangeCase):
              ('rBaz', None, 'qBaz')]
 
     def test_lookup(self):
-        self.assertListEqual(
+        self.assertSetEqual(
             self.e.lookup(self.table, 'eFoo', 'rFoo', None),
-            ['qFoo', 'qFox'],
+            {'qFoo', 'qFox'},
         )
-        self.assertListEqual(
+        self.assertSetEqual(
             self.e.lookup(self.table, 'eMoz', 'rMoz', 'DEFAULT'),
-            [],
+            set(),
         )
-        self.assertListEqual(
+        self.assertSetEqual(
             self.e.lookup(self.table, 'eBar', 'rBar', None),
-            ['qBar'],
+            {'qBar'},
         )
 
 
@@ -44,9 +44,9 @@ class test_Fanout(ExchangeCase):
              (None, None, 'qBar')]
 
     def test_lookup(self):
-        self.assertListEqual(
+        self.assertSetEqual(
             self.e.lookup(self.table, 'eFoo', 'rFoo', None),
-            ['qFoo', 'qFox', 'qBar'],
+            {'qFoo', 'qFox', 'qBar'},
         )
 
     def test_deliver_when_fanout_supported(self):
@@ -84,23 +84,23 @@ class test_Topic(ExchangeCase):
         self.assertTupleEqual(x, ('stock.#', r'^stock\..*?$', 'qFoo'))
 
     def test_lookup(self):
-        self.assertListEqual(
+        self.assertSetEqual(
             self.e.lookup(self.table, 'eFoo', 'stock.us.nasdaq', None),
-            ['rFoo', 'rBar'],
+            {'rFoo', 'rBar'},
         )
         self.assertTrue(self.e._compiled)
-        self.assertListEqual(
+        self.assertSetEqual(
             self.e.lookup(self.table, 'eFoo', 'stock.europe.OSE', None),
-            ['rFoo'],
+            {'rFoo'},
         )
-        self.assertListEqual(
+        self.assertSetEqual(
             self.e.lookup(self.table, 'eFoo', 'stockxeuropexOSE', None),
-            [],
+            set(),
         )
-        self.assertListEqual(
+        self.assertSetEqual(
             self.e.lookup(self.table, 'eFoo',
                           'candy.schleckpulver.snap_crackle', None),
-            [],
+            set(),
         )
 
     def test_deliver(self):
@@ -133,23 +133,23 @@ class test_TopicMultibind(ExchangeCase):
                       for rkey, _, queue in self.table]
 
     def test_lookup(self):
-        self.assertListEqual(
+        self.assertSetEqual(
             self.e.lookup(self.table, 'eFoo', 'stock.us.nasdaq', None),
-            ['rFoo'],
+            {'rFoo'},
         )
         self.assertTrue(self.e._compiled)
-        self.assertListEqual(
+        self.assertSetEqual(
             self.e.lookup(self.table, 'eFoo', 'stock.europe.OSE', None),
-            ['rFoo'],
+            {'rFoo'},
         )
-        self.assertListEqual(
+        self.assertSetEqual(
             self.e.lookup(self.table, 'eFoo', 'stockxeuropexOSE', None),
-            ['rFoo'],
+            {'rFoo'},
         )
-        self.assertListEqual(
+        self.assertSetEqual(
             self.e.lookup(self.table, 'eFoo',
                           'candy.schleckpulver.snap_crackle', None),
-            ['rFoo'],
+            {'rFoo'},
         )
 
 

--- a/kombu/transport/virtual/exchange.py
+++ b/kombu/transport/virtual/exchange.py
@@ -11,7 +11,6 @@ from __future__ import absolute_import, unicode_literals
 from kombu.utils import escape_regex
 
 import re
-import collections
 
 
 class ExchangeType(object):

--- a/kombu/transport/virtual/exchange.py
+++ b/kombu/transport/virtual/exchange.py
@@ -52,13 +52,9 @@ class DirectExchange(ExchangeType):
     type = 'direct'
 
     def lookup(self, table, exchange, routing_key, default):
-        # Using an OrderedDict to purge queue duplicates while
-        # keeping the same order in which they appear in the table
-        return list(
-            collections.OrderedDict.fromkeys(
-                queue for rkey, _, queue in table
-                if rkey == routing_key
-            )
+        return set(
+            queue for rkey, _, queue in table
+            if rkey == routing_key
         )
 
     def deliver(self, message, exchange, routing_key, **kwargs):
@@ -82,13 +78,9 @@ class TopicExchange(ExchangeType):
     _compiled = {}
 
     def lookup(self, table, exchange, routing_key, default):
-        # Using an OrderedDict to purge queue duplicates while
-        # keeping the same order in which they appear in the table
-        return list(
-            collections.OrderedDict.fromkeys(
-                queue for rkey, pattern, queue in table
-                if self._match(pattern, routing_key)
-            )
+        return set(
+            queue for rkey, pattern, queue in table
+            if self._match(pattern, routing_key)
         )
 
     def deliver(self, message, exchange, routing_key, **kwargs):
@@ -133,12 +125,8 @@ class FanoutExchange(ExchangeType):
     type = 'fanout'
 
     def lookup(self, table, exchange, routing_key, default):
-        # Using an OrderedDict to purge queue duplicates while
-        # keeping the same order in which they appear in the table
-        return list(
-            collections.OrderedDict.fromkeys(
-                queue for _, _, queue in table
-            )
+        return set(
+            queue for _, _, queue in table
         )
 
     def deliver(self, message, exchange, routing_key, **kwargs):


### PR DESCRIPTION
When a queue is bound to an exchange with multiple bindings whose patterns overlap, the AMQP standard says that a single message shall be delivered *once* to that queue. RabbitMQ behaves according to the standard. When using virtual transports in `kombu/master`, a message will be delivered *one time for each binding that matches the topic pattern*, even for overlapping ones.
For example, the correct (AMQP) behaviour is:
```
# Queue bindings: ['mytopic', 'mytopic.#', '#']
-> Sent 1 message with topic: 'mytopic'
-> Delivered 1 message to queue
```
`kombu/master` behaves like follows:
```
# Queue bindings: ['mytopic', 'mytopic.#', '#']
-> Sent 1 message with topic: 'mytopic'
-> Delivered same message 3 times to the same queue
```

A regression test has been added to the commit.