### PR TITLE
Connection deepcopy

### DIFF
--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -576,6 +576,7 @@ class Connection(object):
             ('login_method', self.login_method or D.get('login_method')),
             ('uri_prefix', self.uri_prefix),
             ('heartbeat', self.heartbeat),
+            ('failover_strategy', self.failover_strategy),
             ('alternates', self.alt),
         )
         return info

--- a/kombu/tests/test_connection.py
+++ b/kombu/tests/test_connection.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, unicode_literals
 import pickle
 import socket
 
-from copy import copy
+from copy import copy, deepcopy
 
 from kombu import Connection, Consumer, Producer, parse_url
 from kombu.connection import Resource
@@ -138,6 +138,11 @@ class test_connection_utils(Case):
             userid='guest', password='guest', hostname='[::1]',
             port=5672, virtual_host='/',
         )
+
+    def test_connection_copy(self):
+        conn = Connection(self.url, alternates=['amqp://host'])
+        clone = deepcopy(conn)
+        self.assertEqual(clone.alt, ['amqp://host'])
 
 
 class test_Connection(Case):


### PR DESCRIPTION
A Connection instance cannot be 'deepcopied' if it has alternates urls.