### PR TITLE
Mailbox constructor got queue and reply_queue TTL and Expires options (rebased over master)

### DIFF
--- a/kombu/utils/__init__.py
+++ b/kombu/utils/__init__.py
@@ -9,6 +9,7 @@ from .functional import (
 )
 from .imports import symbol_by_name
 from .objects import cached_property
+from .time import maybe_s_to_ms
 from .uuid import uuid
 
 __all__ = [
@@ -19,8 +20,4 @@ __all__ = [
     'symbol_by_name', 'nested', 'fileno', 'maybe_fileno',
     'maybe_s_to_ms',
 ]
-
-
-def maybe_s_to_ms(v):
-    return int(float(v) * 1000.0) if v is not None else v
 

--- a/kombu/utils/__init__.py
+++ b/kombu/utils/__init__.py
@@ -17,7 +17,7 @@ __all__ = [
     'emergency_dump_state', 'cached_property',
     'register_after_fork', 'reprkwargs', 'reprcall',
     'symbol_by_name', 'nested', 'fileno', 'maybe_fileno',
-    'maybe_s_to_ms']
+    'maybe_s_to_ms',
 ]
 
 

--- a/kombu/utils/__init__.py
+++ b/kombu/utils/__init__.py
@@ -23,3 +23,4 @@ __all__ = [
 
 def maybe_s_to_ms(v):
     return int(float(v) * 1000.0) if v is not None else v
+

--- a/kombu/utils/__init__.py
+++ b/kombu/utils/__init__.py
@@ -17,4 +17,9 @@ __all__ = [
     'emergency_dump_state', 'cached_property',
     'register_after_fork', 'reprkwargs', 'reprcall',
     'symbol_by_name', 'nested', 'fileno', 'maybe_fileno',
+    'maybe_s_to_ms']
 ]
+
+
+def maybe_s_to_ms(v):
+    return int(float(v) * 1000.0) if v is not None else v

--- a/kombu/utils/time.py
+++ b/kombu/utils/time.py
@@ -1,0 +1,7 @@
+from __future__ import absolute_import
+
+__all__ = ['maybe_s_to_ms']
+
+
+def maybe_s_to_ms(v):
+    return int(float(v) * 1000.0) if v is not None else v


### PR DESCRIPTION
(done right this time...)

New ``Mailbox.__init__()`` options: ``queue_ttl``, ``queue_expires``, ``reply_queue_ttl`` and ``reply_queue_expires``

``utils.maybe_s_to_ms`` was copied-over from Celery implementation (from actual master)