### PR TITLE
Fix Redis SSL support

### DIFF
--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -879,10 +879,11 @@ class Channel(virtual.Channel):
             'socket_keepalive_options': self.socket_keepalive_options,
         }
         if conninfo.ssl:
-            # Connection(ssl={}) can be a dict like in amqplib.
-            connparams['ssl'] = True
+            # Connection(ssl={}) must be a dict containing the keys:
+            # 'ssl_cert_reqs', 'ssl_ca_certs', 'ssl_certfile', 'ssl_keyfile'
             try:
                 connparams.update(conninfo.ssl)
+                connparams['connection_class'] = redis.SSLConnection
             except TypeError:
                 pass
         host = connparams['host']

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -783,16 +783,29 @@ class test_Channel:
 
     def test_ssl_argument__dict(self):
         with patch('kombu.transport.redis.Channel._create_client'):
-            with Connection('redis://', ssl={'ca_cert': '/foo'}) as conn:
+            # Expected format for redis-py's SSLConnection class
+            ssl_params = {
+                'ssl_cert_reqs': 2,
+                'ssl_ca_certs': '/foo/ca.pem',
+                'ssl_certfile': '/foo/cert.crt',
+                'ssl_keyfile': '/foo/pkey.key'
+            }
+            with Connection('redis://', ssl=ssl_params) as conn:
                 connparams = conn.default_channel._connparams()
-                assert connparams['ssl']
-                assert connparams['ca_cert'] == '/foo'
+                assert connparams['ssl_cert_reqs'] == ssl_params['ssl_cert_reqs']
+                assert connparams['ssl_ca_certs'] == ssl_params['ssl_ca_certs']
+                assert connparams['ssl_certfile'] == ssl_params['ssl_certfile']
+                assert connparams['ssl_keyfile'] == ssl_params['ssl_keyfile']
+                assert connparams.get('ssl') is None
 
-    def test_ssl_argument__bool(self):
+    def test_ssl_connection(self):
         with patch('kombu.transport.redis.Channel._create_client'):
-            with Connection('redis://', ssl=True) as conn:
+            with Connection('redis://', ssl={'ssl_cert_reqs': 2}) as conn:
                 connparams = conn.default_channel._connparams()
-                assert connparams['ssl']
+                assert issubclass(
+                    connparams['connection_class'],
+                    redis.redis.SSLConnection,
+                )
 
 
 @skip.unless_module('redis')

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -789,12 +789,12 @@ class test_Channel:
                 'ssl_keyfile': '/foo/pkey.key'
             }
             with Connection('redis://', ssl=ssl_params) as conn:
-                connparams = conn.default_channel._connparams()
-                assert connparams['ssl_cert_reqs'] == ssl_params['ssl_cert_reqs']
-                assert connparams['ssl_ca_certs'] == ssl_params['ssl_ca_certs']
-                assert connparams['ssl_certfile'] == ssl_params['ssl_certfile']
-                assert connparams['ssl_keyfile'] == ssl_params['ssl_keyfile']
-                assert connparams.get('ssl') is None
+                params = conn.default_channel._connparams()
+                assert params['ssl_cert_reqs'] == ssl_params['ssl_cert_reqs']
+                assert params['ssl_ca_certs'] == ssl_params['ssl_ca_certs']
+                assert params['ssl_certfile'] == ssl_params['ssl_certfile']
+                assert params['ssl_keyfile'] == ssl_params['ssl_keyfile']
+                assert params.get('ssl') is None
 
     def test_ssl_connection(self):
         with patch('kombu.transport.redis.Channel._create_client'):


### PR DESCRIPTION
Fixes celery/kombu#628

**Root cause:**
- setting `connparams[‘ssl’] = True` will cause an unexpected keyword
exception when initializing a redis `Connection` or `SSLConnection`
- connection_class must be `redis.SSLConnection`. The base `redis.Connection`
class does not support SSL parameters.

**Notes:**
- Updated the comment and tests to reflect the required format since it
is different than amqplib. Ideally the Celery documentation that talks about `BROKER_USE_SSL` should be updated to specify the keyname format for redis vs amqplib.
- If you attempt to use Redis-over-SSL as both a transport and results backend then Celery will fail since the `RedisBackend.connparams` are not patched to support SSL. These end up passed directly into `redis.ConnectionPool` which defaults to the base `redis.Connection` class if one isn't specified. I didn't dig deeply enough into the Celery plumbing to know the right way to patch that but this workaround enabled Redis-over-SSL end to end for both the broker and results backend:

```python
# force=True isn't required, but in my case I grab cert files from s3 if they're missing
# when setting `BROKER_USE_SSL` and need to ensure it runs now before querying for
# that property below.
from redis.connection import SSLConnection
app = Celery()
app.config_from_object('celeryconfig', force=True)

if app.conf.broker_use_ssl:
    app.backend.connparams.update(app.conf.broker_use_ssl)
    app.backend.connparams['connection_class'] = SSLConnection
```

@ask: Do you want me to open an issue over on the Celery side for the Results backend (at least to document the workaround)? I wasn't sure the relationship between the two projects and best practices for managing issues. 