### PR TITLE
remove natural sort

### DIFF
--- a/kombu/transport/mongodb.py
+++ b/kombu/transport/mongodb.py
@@ -137,8 +137,7 @@ class Channel(virtual.Channel):
         else:
             msg = self.messages.find_and_modify(
                 query={'queue': queue},
-                sort=[('priority', pymongo.ASCENDING),
-                      ('$natural', pymongo.ASCENDING)],
+                sort=[('priority', pymongo.ASCENDING)],
                 remove=True,
             )
 
@@ -381,13 +380,11 @@ class Channel(virtual.Channel):
         if pymongo.version_tuple >= (3, ):
             query = dict(
                 filter={'queue': exchange},
-                sort=[('$natural', pymongo.ASCENDING)],
                 cursor_type=CursorType.TAILABLE
             )
         else:
             query = dict(
                 query={'queue': exchange},
-                sort=[('$natural', pymongo.ASCENDING)],
                 tailable=True
             )
 


### PR DESCRIPTION
I am no mongodb specialist, but there is an explicit mentioning in MongoDb docs about natural sorting:
"Queries that include a sort by $natural order do not use indexes to fulfill the query predicate"
https://docs.mongodb.com/v3.2/reference/method/cursor.sort/#index-use

So as far as we have "query" index set in ensure_indexes, so this will not be used according to the docs.
