### PR TITLE
Fixed rpc example

### DIFF
--- a/examples/rpc-tut6/rpc_client.py
+++ b/examples/rpc-tut6/rpc_client.py
@@ -23,7 +23,7 @@ class FibonacciRpcClient(object):
                 exchange='',
                 routing_key='rpc_queue',
                 declare=[self.callback_queue],
-                reply_to=self.callback_queue,
+                reply_to=self.callback_queue.name,
                 correlation_id=self.correlation_id,
             )
         with Consumer(self.connection,


### PR DESCRIPTION
There is an error in the RPC example that is causing [this](https://github.com/celery/kombu/issues/639) issue.