### PR TITLE
Fixed wrong keyword argument `channel`

### DIFF
--- a/kombu/transport/librabbitmq.py
+++ b/kombu/transport/librabbitmq.py
@@ -35,7 +35,7 @@ class Message(base.Message):
 
     def __init__(self, channel, props, info, body):
         super(Message, self).__init__(
-            channel,
+            channel=channel,
             body=body,
             delivery_info=info,
             properties=props,


### PR DESCRIPTION
Error message:

```[2016-11-11 10:05:16,683: CRITICAL/MainProcess] Unrecoverable error: TypeError("__init__() got multiple values for keyword argument 'body'",)
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/celery/worker/worker.py", line 203, in start
    self.blueprint.start(self)
  File "/usr/local/lib/python2.7/dist-packages/celery/bootsteps.py", line 119, in start
    step.start(parent)
  File "/usr/local/lib/python2.7/dist-packages/celery/bootsteps.py", line 370, in start
    return self.obj.start()
  File "/usr/local/lib/python2.7/dist-packages/celery/worker/consumer/consumer.py", line 318, in start
    blueprint.start(self)
  File "/usr/local/lib/python2.7/dist-packages/celery/bootsteps.py", line 119, in start
    step.start(parent)
  File "/usr/local/lib/python2.7/dist-packages/celery/worker/consumer/consumer.py", line 584, in start
    c.loop(*c.loop_args())
  File "/usr/local/lib/python2.7/dist-packages/celery/worker/loops.py", line 88, in asynloop
    next(loop)
  File "/usr/local/lib/python2.7/dist-packages/kombu/async/hub.py", line 345, in create_loop
    cb(*cbargs)
  File "/usr/local/lib/python2.7/dist-packages/kombu/transport/base.py", line 236, in on_readable
    reader(loop)
  File "/usr/local/lib/python2.7/dist-packages/kombu/transport/base.py", line 218, in _read
    drain_events(timeout=0)
  File "/usr/local/lib/python2.7/dist-packages/librabbitmq/__init__.py", line 220, in drain_events
    self._basic_recv(timeout)
  File "/usr/local/lib/python2.7/dist-packages/kombu/transport/librabbitmq.py", line 45, in __init__
    headers=props.get('headers'))
TypeError: __init__() got multiple values for keyword argument 'body'
```