### PR TITLE
Fix UnicodeEncodeError for python2

### DIFF
--- a/kombu/utils/url.py
+++ b/kombu/utils/url.py
@@ -14,7 +14,7 @@ from kombu.five import string_t
 
 from .compat import NamedTuple
 
-safequote = partial(quote, safe='')
+safequote = partial(quote, safe=str(''))
 
 
 urlparts = NamedTuple('urlparts', [


### PR DESCRIPTION
Python 2 urllib.quote method requires the second argument to be a string
instead of unicode (see https://bugs.python.org/issue23885). Since
url.py imports unicode_literals, '' is actually u'' in python 2. Add a
str() to force it to ''.