### PR TITLE
Switch to using getattr in qpid.Transport.__del__

### DIFF
--- a/kombu/transport/qpid.py
+++ b/kombu/transport/qpid.py
@@ -1731,7 +1731,7 @@ class Transport(base.Transport):
 
     def __del__(self):
         """Ensure file descriptors opened in __init__() are closed."""
-        if self.use_async_interface:
+        if getattr(self, 'use_async_interface', False):
             for fd in (self.r, self._w):
                 try:
                     os.close(fd)


### PR DESCRIPTION
The \_\_init\_\_ function calls verify_runtime_environment before setting
the use_async_interface variable.  If it throws an exception in that
function, the \_\_del\_\_ method will be called, and raises an
AttributeError

using getattr in the __del__ method to guard against this