### PR TITLE
Added revive() method to kombo.simple.SimpleQueue

### DIFF
--- a/kombu/simple.py
+++ b/kombu/simple.py
@@ -122,7 +122,11 @@ class SimpleQueue(SimpleBase):
                                       compression=compression)
         super(SimpleQueue, self).__init__(channel, producer,
                                           consumer, no_ack, **kwargs)
-
+    def revive(self, new_channel):
+        self.channel = maybe_channel(new_channel) # reset from None
+        self.producer.revive(new_channel)
+        self.consumer.revive(new_channel)
+        self.consumer.consume() # create consumer connection
 
 class SimpleBuffer(SimpleQueue):
     """Simple API for ephemeral queues."""

--- a/kombu/simple.py
+++ b/kombu/simple.py
@@ -126,7 +126,7 @@ class SimpleQueue(SimpleBase):
         self.channel = maybe_channel(new_channel) # reset from None
         self.producer.revive(new_channel)
         self.consumer.revive(new_channel)
-        self.consumer.consume() # create consumer connection
+        self.consumer.consume(no_ack=self.no_ack) # create consumer connection
 
 class SimpleBuffer(SimpleQueue):
     """Simple API for ephemeral queues."""


### PR DESCRIPTION
kombu.connection.Connection.ensure() calls revive on the object after a connection is re-established. 
This method is needed to allow SimpleQueue to withstand re-connections. kombu.entity.Queue can withstand re-connections because it has the same method revive(). 

**Consumer Test Results**
For testing the consumer, the consumer connection was removed from RabbitMQ UI while the consumer was receiving messages. Below shows that the SimpleQueue.consumer object continues to receive messages after re-connection.
```
<kombu.transport.pyamqp.Message object at 0x7faae634f218>
<kombu.transport.pyamqp.Message object at 0x7faae634f2b0>
2016-11-17 13:54:53,609 events.py:32302:140372112471968:24 INFO Kombu failure [Errno 32] Broken pipe, retry in 0 seconds
2016-11-17 13:54:53,665 connection.py:32302:140372112471968:755 DEBUG Start from server, version: 0.9, properties: {u'information': u'Licensed under the MPL. See http://www.rabbitmq.com/', u'product': u'RabbitMQ', u'copyright': u'Copyright (C) 2007-2015 Pivotal Software, Inc.', u'capabilities': {u'exchange_exchange_bindings': True, u'connection.blocked': True, u'authentication_failure_close': True, u'basic.nack': True, u'per_consumer_qos': True, u'consumer_priorities': True, u'consumer_cancel_notify': True, u'publisher_confirms': True}, u'cluster_name': u'sys-rabbit@dtllnjddalap01', u'platform': u'Erlang/OTP', u'version': u'3.5.4'}, mechanisms: [u'AMQPLAIN', u'PLAIN'], locales: [u'en_US']
2016-11-17 13:54:53,667 connection.py:32302:140372112471968:641 DEBUG Open OK!
2016-11-17 13:54:53,667 channel.py:32302:140372112471968:82 DEBUG using channel_id: 1
2016-11-17 13:54:53,669 channel.py:32302:140372112471968:440 DEBUG Channel open
<kombu.transport.pyamqp.Message object at 0x7faae634f218>
<kombu.transport.pyamqp.Message object at 0x7faae634f2b0>
<kombu.transport.pyamqp.Message object at 0x7faae634f218>
```

**Producer Test Results**
For testing the producer, the RabbitMQ broker where the publisher was running was stopped. This shows that the SimpleQueue.producer object continues to publishes messages after re-connection.
```
2016-11-17 13:57:47,197 test2.py:47601:140437586212768:33 DEBUG putting 1
2016-11-17 13:57:57,220 test2.py:47601:140437586212768:33 DEBUG putting 2
2016-11-17 13:58:07,693 test2.py:47601:140437586212768:33 DEBUG putting 3

Stopping node 'sys-rabbit@dtllnjddalap01' ...
2016-11-17 13:58:17,714 test2.py:47601:140437586212768:33 DEBUG putting 4
2016-11-17 13:58:17,715 events.py:47601:140437586212768:24 INFO Kombu failure [Errno 32] Broken pipe, retry in 0 seconds
2016-11-17 13:58:17,754 connection.py:47601:140437586212768:755 DEBUG Start from server, version: 0.9, properties: {u'information': u'Licensed under the MPL. See http://www.rabbitmq.com/', u'product': u'RabbitMQ', u'copyright': u'Copyright (C) 2007-2015 Pivotal Software, Inc.', u'capabilities': {u'exchange_exchange_bindings': True, u'connection.blocked': True, u'authentication_failure_close': True, u'basic.nack': True, u'per_consumer_qos': True, u'consumer_priorities': True, u'consumer_cancel_notify': True, u'publisher_confirms': True}, u'cluster_name': u'sys-rabbit@dtllnjddalap01', u'platform': u'Erlang/OTP', u'version': u'3.5.4'}, mechanisms: [u'AMQPLAIN', u'PLAIN'], locales: [u'en_US']
2016-11-17 13:58:17,761 connection.py:47601:140437586212768:641 DEBUG Open OK!
2016-11-17 13:58:17,761 channel.py:47601:140437586212768:82 DEBUG using channel_id: 1
2016-11-17 13:58:17,764 channel.py:47601:140437586212768:440 DEBUG Channel open
2016-11-17 13:58:27,813 test2.py:47601:140437586212768:33 DEBUG putting 5
```