### PR TITLE
Fix byte string for kazoo.Queue in Python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ dump.rdb
 htmlcov/
 test.db
 coverage.xml
+venv/

--- a/AUTHORS
+++ b/AUTHORS
@@ -37,6 +37,7 @@ David Gelvin <david.gelvin@gmail.com>
 David Strauss <david@davidstrauss.net>
 David Ziegler <david.ziegler@gmail.com>
 Dhananjay Nene <dhananjay.nene@gmail.com>
+Dima Kurguzov <koorgoo@gmail.com>
 Dmitry Malinovsky <dmalinovsky@thumbtack.net>
 Dustin J. Mitchell <dustin@mozilla.com>
 Emmanuel Cazenave <contact@emcaz.fr>

--- a/kombu/transport/zookeeper.py
+++ b/kombu/transport/zookeeper.py
@@ -27,7 +27,7 @@ import os
 import socket
 
 from kombu.five import Empty
-from kombu.utils.encoding import bytes_to_str
+from kombu.utils.encoding import bytes_to_str, ensure_bytes
 from kombu.utils.json import loads, dumps
 
 from . import virtual
@@ -98,7 +98,7 @@ class Channel(virtual.Channel):
 
     def _put(self, queue, message, **kwargs):
         return self._get_queue(queue).put(
-            dumps(message),
+            ensure_bytes(dumps(message)),
             priority=self._get_message_priority(message, reverse=True),
         )
 

--- a/setup.py
+++ b/setup.py
@@ -155,6 +155,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: Implementation :: CPython',

--- a/t/unit/transport/test_zookeeper.py
+++ b/t/unit/transport/test_zookeeper.py
@@ -1,0 +1,27 @@
+from __future__ import absolute_import, unicode_literals
+
+from case import skip
+
+from kombu import Connection
+from kombu.transport import zookeeper
+
+
+@skip.unless_module('kazoo')
+class test_Channel:
+    def setup(self):
+        self.connection = self.create_connection()
+        self.channel = self.connection.default_channel
+
+    def create_connection(self, **kwargs):
+        return Connection(transport=zookeeper.Transport, **kwargs)
+
+    def teardown(self):
+        self.connection.close()
+
+    def test_put_puts_bytes_to_queue(self):
+        class AssertQueue:
+            def put(self, value, priority):
+                assert isinstance(value, bytes)
+
+        self.channel._queues['foo'] = AssertQueue()
+        self.channel._put(queue='foo', message='bar')

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     pypy
     3.4
     3.5
+    3.6
     flake8
     flakeplus
     apicheck
@@ -24,13 +25,14 @@ deps=
     flake8,flakeplus,pydocstyle: -r{toxinidir}/requirements/pkgutils.txt
 
 commands = pip install -U -r{toxinidir}/requirements/dev.txt
-           py.test -xv
+           py.test -xv {posargs}
 
 basepython =
     2.7,flakeplus,flake8,apicheck,linkcheck,cov,pydocstyle: python2.7
     3.3: python3.3
     3.4: python3.4
     3.5: python3.5
+    3.6: python3.6
     pypy: pypy
     jython: jython
 


### PR DESCRIPTION
Using Python 3 delaying a task with ZooKeeper as a broker fails with `TypeError: value must be a byte string` because [kazoo.Queue.put()](https://github.com/python-zk/kazoo/blob/8f6bf35d/kazoo/recipe/queue.py#L111) requires `value` argument to be a byte string .

I just add forced message conversion to bytes.

Will be thankful if anybody helps me with writing a test for it.