### PR TITLE
Allow endpoint URL to be specified for SQS transport

### DIFF
--- a/requirements/funtest.txt
+++ b/requirements/funtest.txt
@@ -8,7 +8,6 @@ pymongo
 kazoo
 
 # SQS transport
-boto
 boto3
 
 # Qpid transport

--- a/t/unit/transport/test_SQS.py
+++ b/t/unit/transport/test_SQS.py
@@ -11,7 +11,7 @@ import pytest
 import random
 import string
 
-from case import Mock, skip, patch
+from case import Mock, skip
 
 from kombu import messaging
 from kombu import Connection, Exchange, Queue


### PR DESCRIPTION
- [x] Add a `endpoint_url` property in SQS channel class.
- [x] Initialization SQS connection using endpoint URL, if defined.
- [x] Re-enable test cases by removing skip due to missing dependency (`boto`).

Related Pull Requests:
- #693 
- #714