### PR TITLE
Fix invalid escape sequence

### DIFF
--- a/kombu/transport/virtual/exchange.py
+++ b/kombu/transport/virtual/exchange.py
@@ -107,7 +107,7 @@ class TopicExchange(ExchangeType):
 
     def key_to_pattern(self, rkey):
         """Get the corresponding regex for any routing key."""
-        return '^%s$' % ('\.'.join(
+        return '^%s$' % (r'\.'.join(
             self.wildcards.get(word, word)
             for word in escape_regex(rkey, '.#*').split('.')
         ))


### PR DESCRIPTION
Fixes the following warning when running tests on Python 3.6:

DeprecationWarning: invalid escape sequence \.