### PR TITLE
Remove deprecated use of StopIteration in generators

### DIFF
--- a/kombu/compat.py
+++ b/kombu/compat.py
@@ -20,7 +20,7 @@ def _iterconsume(connection, consumer, no_ack=False, limit=None):
     consumer.consume(no_ack=no_ack)
     for iteration in count(0):  # for infinity
         if limit and iteration >= limit:
-            raise StopIteration
+            break
         yield connection.drain_events()
 
 
@@ -166,7 +166,7 @@ class Consumer(messaging.Consumer):
             item = self.fetch()
             if (not infinite and item is None) or \
                     (limit and items_since_start >= limit):
-                raise StopIteration
+                break
             yield item
 
 


### PR DESCRIPTION
Removes warning during tests:

DeprecationWarning: generator '...' raised StopIteration

For additional information, see:

- https://docs.python.org/3/whatsnew/3.5.html#pep-479-change-stopiteration-handling-inside-generators
- https://www.python.org/dev/peps/pep-0479/