### PR TITLE
Fix  Closed connection and with statement blows up

### DIFF
--- a/kombu/messaging.py
+++ b/kombu/messaging.py
@@ -435,7 +435,7 @@ class Consumer(object):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if self.channel:
+        if self.channel and self.channel.connection:
             conn_errors = self.channel.connection.client.connection_errors
             if not isinstance(exc_val, conn_errors):
                 try:


### PR DESCRIPTION
https://github.com/celery/kombu/issues/690
Add self.channel.connection check to prevent AttributeError.

Tested with this gist
https://gist.github.com/eavictor/ee7856581619ac60643b57987b7ed580