### PR TITLE
Use ensure_connection to allow broker failover

### DIFF
--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -816,7 +816,7 @@ class Connection(object):
             require a channel.
         """
         # make sure we're still connected, and if not refresh.
-        self.connection
+        self.ensure_connection()
         if self._default_channel is None:
             self._default_channel = self.channel()
         return self._default_channel

--- a/requirements/pkgutils.txt
+++ b/requirements/pkgutils.txt
@@ -5,4 +5,4 @@ flakeplus>=1.1
 tox>=2.3.1
 sphinx2rst>=1.0
 bumpversion
-pydocstyle
+pydocstyle==1.1.1


### PR DESCRIPTION
- [x] Use `Connection.ensure_connection` in `default_channel` property to properly account for broker connection errors and failover.

Fixes https://github.com/celery/celery/issues/3921 .