### PR TITLE
Process todos first before polling

### DIFF
--- a/kombu/async/hub.py
+++ b/kombu/async/hub.py
@@ -276,10 +276,11 @@ class Hub(object):
             for tick_callback in on_tick:
                 tick_callback()
 
-            while todo:
-                item = todo.pop()
-                if item:
+            if todo:
+                while todo:
+                    item = todo.pop()
                     item()
+                continue
 
             poll_timeout = fire_timers(propagate=propagate) if scheduled else 1
             #  print('[[[HUB]]]: %s' % (self.repr_active(),))

--- a/kombu/async/hub.py
+++ b/kombu/async/hub.py
@@ -279,7 +279,8 @@ class Hub(object):
             if todo:
                 while todo:
                     item = todo.pop()
-                    item()
+                    if item:
+                        item()
                 continue
 
             poll_timeout = fire_timers(propagate=propagate) if scheduled else 1


### PR DESCRIPTION
As todos can be chained like amqp frame 1-2-3 and as a result may affect what we are polling for, we can end up with unfinished frame and poll that times out after 0-2s. Which results in a delayed task execution.

Fixes https://github.com/celery/celery/issues/3978 and a few related issues that make tasks run very slowly with amqp and celery 4.x. Didn't encounter any issues so far as todos at least for amqp are simply reads with 0 timeout.