### PR TITLE
Fix librabbitmq queue handling

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -109,6 +109,7 @@ Ralf Nyren <ralf-github@nyren.net>
 Randy Barlow <rbarlow@redhat.com>
 Raphael Michel <mail@raphaelmichel.de>
 Rob Ottaway <robottaway@gmail.com>
+Robert Kopaczewski <rk@23doors.com>
 Roger Hu <rhu@hearsaycorp.com>
 Rumyana Neykova <rumi.neykova@gmail.com>
 Rune Halvorsen <runeh@opera.com>

--- a/kombu/transport/librabbitmq.py
+++ b/kombu/transport/librabbitmq.py
@@ -62,7 +62,8 @@ class Channel(amqp.Channel, base.StdChannel):
         return body, properties
 
     def prepare_queue_arguments(self, arguments, **kwargs):
-        return to_rabbitmq_queue_arguments(arguments, **kwargs)
+        arguments = to_rabbitmq_queue_arguments(arguments, **kwargs)
+        return {k.encode('utf8'): v for k, v in items(arguments)}
 
 
 class Connection(amqp.Connection):


### PR DESCRIPTION
I know that librabbitmq support in 4.x is spotty and that it is kind of no longer supported. But it works just fine (at least with python 2.7) with task_protocol=1 except for one thing - transient queues mess rabbitmq up.

librabbitmq doesn't really handle utf8 very well and creating queues with unicode arguments result in getting 500 error when listing queues in rabbitmq:
http://localhost:15672/#/queues in management plugin
and same for API.

Relevant issues I found:
https://github.com/mher/flower/issues/661
https://github.com/rabbitmq/rabbitmq-management/issues/332

Converting keys to bytestring fixes it.