### PR TITLE
Fix last chroot character trimming for ZooKeeper

### DIFF
--- a/kombu/transport/zookeeper.py
+++ b/kombu/transport/zookeeper.py
@@ -28,8 +28,7 @@ import socket
 
 from kombu.five import Empty
 from kombu.utils.encoding import bytes_to_str, ensure_bytes
-from kombu.utils.json import loads, dumps
-
+from kombu.utils.json import dumps, loads
 from . import virtual
 
 try:
@@ -141,7 +140,7 @@ class Channel(virtual.Channel):
 
     def _open(self):
         conninfo = self.connection.client
-        self.vhost = os.path.join('/', conninfo.virtual_host[0:-1])
+        self.vhost = self._normalize_chroot(conninfo.virtual_host)
         hosts = []
         if conninfo.alt:
             for host_port in conninfo.alt:
@@ -165,6 +164,13 @@ class Channel(virtual.Channel):
         conn = KazooClient(conn_str)
         conn.start()
         return conn
+
+    @staticmethod
+    def _normalize_chroot(chroot):
+        chroot = chroot.rstrip('/')
+        if not len(chroot) or chroot[0] != '/':
+            chroot = '/' + chroot
+        return chroot
 
     @property
     def client(self):

--- a/t/unit/transport/test_zookeeper.py
+++ b/t/unit/transport/test_zookeeper.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
+import pytest
 from case import skip
 
 from kombu import Connection
@@ -25,3 +26,12 @@ class test_Channel:
 
         self.channel._queues['foo'] = AssertQueue()
         self.channel._put(queue='foo', message='bar')
+
+
+@pytest.mark.parametrize('input,expected', (
+    ('/', '/'),
+    ('/root', '/root'),
+    ('/root/', '/root'),
+))
+def test_normalize_chroot(input, expected):
+    assert zookeeper.Channel._normalize_chroot(input) == expected

--- a/t/unit/transport/test_zookeeper.py
+++ b/t/unit/transport/test_zookeeper.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, unicode_literals
 
 import pytest
 from case import skip
-
 from kombu import Connection
 from kombu.transport import zookeeper
 
@@ -27,11 +26,11 @@ class test_Channel:
         self.channel._queues['foo'] = AssertQueue()
         self.channel._put(queue='foo', message='bar')
 
-
-@pytest.mark.parametrize('input,expected', (
-    ('/', '/'),
-    ('/root', '/root'),
-    ('/root/', '/root'),
-))
-def test_normalize_chroot(input, expected):
-    assert zookeeper.Channel._normalize_chroot(input) == expected
+    @pytest.mark.parametrize('input,expected', (
+        ('', '/'),
+        ('/root', '/root'),
+        ('/root/', '/root'),
+    ))
+    def test_virtual_host_normalization(self, input, expected):
+        with self.create_connection(virtual_host=input) as conn:
+            assert conn.default_channel._vhost == expected


### PR DESCRIPTION
Noticed that kombu removes last chroot character.

For example, you connect to ZooKeeper with chroot `/project` but celery produces/consumes tasks with chroot `/projec`.