### PR TITLE
Prevent SQS from defaulting to localhost hostname

### DIFF
--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -516,3 +516,7 @@ class Transport(virtual.Transport):
         async=True,
         exchange_type=frozenset(['direct']),
     )
+
+    @property
+    def default_connection_params(self):
+        return {'port': self.default_port}

--- a/t/unit/transport/test_SQS.py
+++ b/t/unit/transport/test_SQS.py
@@ -182,6 +182,10 @@ class test_Channel:
         boto3_sqs = SQS_Channel_sqs.__get__(self.channel, SQS.Channel)
         assert boto3_sqs._endpoint.host == expected_endpoint_url
 
+    def test_none_hostname_persists(self):
+        conn = Connection(hostname=None, transport=SQS.Transport)
+        assert conn.hostname == conn.clone().hostname
+
     def test_new_queue(self):
         queue_name = 'new_unittest_queue'
         self.channel._new_queue(queue_name)


### PR DESCRIPTION
Commit [`cdbfe9a64e1884dc99fc9806a834f23cf8398a3b`](https://github.com/celery/kombu/commit/cdbfe9a64e1884dc99fc9806a834f23cf8398a3b#diff-3cc1ff6df0f488077057a603b8f5e5d4R487) added tooling to retrieve the `hostname` from the SQS Transport.  If no hostname is provided (for example, if you only configure an app with `broker_transport = 'sqs'`), the hostname is [set to a default value](https://github.com/alukach/kombu/blob/0c20e84c63489b6efb2dd93f607e00fcec6f0597/kombu/connection.py#L585-L599) from the Transport baseclass' [`default_connection_params` property](https://github.com/alukach/kombu/blob/0c20e84c63489b6efb2dd93f607e00fcec6f0597/kombu/transport/virtual/base.py#L1002-L1003).  This is problematic, as the default is `'localhost'`, which is likely not correct for an SQS queue and results in failed message retrieval.  Interestingly, a Celery worker is still able to successfully start, retrieve the list of queues, and retrieve messages being that Celery [provides the Transport a default `url` value of `None`](https://github.com/celery/celery/blob/master/celery/app/base.py#L746-L760).

This PR omits `hostname` from the SQS Transport's `default_connection_params` property, thereby letting Boto3 use its default logic if no `hostname` is manually provided to the SQS Transport.