### PR TITLE
Use ensure_connection to allow broker failover

### DIFF
--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -753,7 +753,7 @@ class Connection(object):
 
         """
         # make sure we're still connected, and if not refresh.
-        self.connection
+        self.ensure_connection()
         if self._default_channel is None:
             self._default_channel = self.channel()
         return self._default_channel


### PR DESCRIPTION
Just cherry picking a commit from kombu's current master to ensure workers would re-connect if broker nodes failed.