### PR TITLE
add connection kwargs for sentinel

### DIFF
--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -1066,7 +1066,8 @@ class SentinelChannel(Channel):
     from_transport_options = Channel.from_transport_options + (
         'master_name',
         'min_other_sentinels',
-        'sentinel_kwargs')
+        'sentinel_kwargs',
+        'connection_kwargs')
 
     connection_class = sentinel.SentinelManagedConnection if sentinel else None
 
@@ -1074,6 +1075,7 @@ class SentinelChannel(Channel):
         connparams = self._connparams(async)
 
         additional_params = connparams.copy()
+        additional_params = getattr(self, 'connection_kwargs', additional_params)
 
         additional_params.pop('host', None)
         additional_params.pop('port', None)

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -1075,7 +1075,9 @@ class SentinelChannel(Channel):
         connparams = self._connparams(async)
 
         additional_params = connparams.copy()
-        additional_params = getattr(self, 'connection_kwargs', additional_params)
+        additional_params = getattr(self,
+                                    'connection_kwargs',
+                                    additional_params)
 
         additional_params.pop('host', None)
         additional_params.pop('port', None)

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -1074,10 +1074,9 @@ class SentinelChannel(Channel):
     def _sentinel_managed_pool(self, async=False):
         connparams = self._connparams(async)
 
-        additional_params = connparams.copy()
         additional_params = getattr(self,
                                     'connection_kwargs',
-                                    additional_params)
+                                    connparams.copy())
 
         additional_params.pop('host', None)
         additional_params.pop('port', None)


### PR DESCRIPTION
........
class Sentinel(object):
"""
........
connection_kwargs are keyword arguments that will be used when
establishing a connection to a Redis server.
"""
........

#example config
BROKER_URL = 'sentinel://host1:26379;sentinel://host2:26379;sentinel://host3:26379'
RESULT_BACKEND = 'sentinel://host1:26379;sentinel://host2:26379;sentinel://host3:26379'
BROKER_TRANSPORT_OPTIONS = {
                                                             'master_name': 'mymaster',
                                                             'connection_kwargs': {'db': 10, 'password': 'secret'}
                                                            }