### PR TITLE
Fixed broken link to AMQP documentation

### DIFF
--- a/kombu/entity.py
+++ b/kombu/entity.py
@@ -98,7 +98,7 @@ class Exchange(MaybeChannelBound):
 
 
                 .. _`AMQP in 10 minutes: Part 4`:
-                    http://bit.ly/amqp-exchange-types
+                    https://bit.ly/2rcICv5
 
         channel (ChannelT): The channel the exchange is bound to (if bound).
 


### PR DESCRIPTION
The linked document was the first result on Google for the title of the link.

I'm not sure how the nice title for the replaced link was created (there's another bit.ly link with a hashed string pointing to Wikipedia).