### PR TITLE
[amqp][ssl] Add ability to validate a server host

### DIFF
--- a/kombu/transport/pyamqp.py
+++ b/kombu/transport/pyamqp.py
@@ -114,6 +114,8 @@ class Transport(base.Transport):
                 setattr(conninfo, name, default_value)
         if conninfo.hostname == 'localhost':
             conninfo.hostname = '127.0.0.1'
+        if conninfo.ssl and 'server_hostname' not in conninfo.ssl:
+            conninfo.ssl['server_hostname'] = conninfo.hostname
         opts = dict({
             'host': conninfo.host,
             'userid': conninfo.userid,


### PR DESCRIPTION

To validate a servers hostname during ssl handshake according with SAN/SNI,  the next ssl option must be provided explicitly:

* ssl opt: 
    - `server_hostname=my-rabbitmq-host`

For example: 

```
Connection('amqp://myrabbit', ssl={server_hostname="myrabbit"})
```
In case then you are passing as kombu connection URI  the list of rabbitmq brokers runned under TLS:

```
Connection('amqp://guest:guest@host-a:5671,guest:guest@host-b:5671', ssl={server_hostname="??????"})
```

there are no any possibility to set the new `server_hostname` into the ssl options each time when kombu under the hood selects a new host and do reconnection according with failover strategy.

To make it possible, we can add `server_hostname` explicitly (if user is not set it) in the ssl options dict.