### PR TITLE
fix bytes_to_str bug

### DIFF
--- a/kombu/utils/encoding.py
+++ b/kombu/utils/encoding.py
@@ -54,7 +54,7 @@ if is_py3k:  # pragma: no cover
     def bytes_to_str(s):
         """Convert bytes to str."""
         if isinstance(s, bytes):
-            return s.decode()
+            return s.decode(errors='replace')
         return s
 
     def from_utf8(s, *args, **kwargs):


### PR DESCRIPTION
When we were using celery , and using `pickle` format to transfer a bytes variable like a file content, for example a picture file, then we will get an exception here. 
```
Traceback (most recent call last):
  File "/Users/daiyue/git/hxtsaas/env/lib/python3.6/site-packages/celery/app/trace.py", line 436, in trace_task
    Rstr = saferepr(R, resultrepr_maxsize)
  File "/Users/daiyue/git/hxtsaas/env/lib/python3.6/site-packages/celery/utils/saferepr.py", line 74, in saferepr
    o, maxlen=maxlen, maxlevels=maxlevels, seen=seen
  File "/Users/daiyue/git/hxtsaas/env/lib/python3.6/site-packages/celery/utils/saferepr.py", line 118, in _saferepr
    val = "b'%s'" % (bytes_to_str(truncate_bytes(val, maxlen)),)
  File "/Users/daiyue/git/hxtsaas/env/lib/python3.6/site-packages/kombu/utils/encoding.py", line 58, in bytes_to_str
    return s.decode()
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 0: invalid start byte
```
So add `errors='replace'` to avoid the encoding error here.