### PR TITLE
Fix readpreference option parsing in MongoDB transport

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -4,6 +4,17 @@
  Change history
 ================
 
+.. _version-4.0.3:
+
+4.0.3
+=====
+:release-date: TBA
+:release-by: Ask Solem
+
+- MongoDB: Fixed problem with using readPreference option at pymongo 3.x.
+
+    Contributed by **Mikhail Elovskikh**.
+
 .. _version-4.0.2:
 
 4.0.2

--- a/kombu/transport/mongodb.py
+++ b/kombu/transport/mongodb.py
@@ -274,18 +274,21 @@ class Channel(virtual.Channel):
                                  if self.connect_timeout else None),
         }
         options.update(parsed['options'])
+        options = self._prepare_client_options(options)
 
         return hostname, dbname, options
 
     def _prepare_client_options(self, options):
         if pymongo.version_tuple >= (3,):
             options.pop('auto_start_request', None)
+            if isinstance(options.get('readpreference'), int):
+                modes = pymongo.read_preferences._MONGOS_MODES
+                options['readpreference'] = modes[options['readpreference']]
         return options
 
     def _open(self, scheme='mongodb://'):
-        hostname, dbname, options = self._parse_uri(scheme=scheme)
+        hostname, dbname, conf = self._parse_uri(scheme=scheme)
 
-        conf = self._prepare_client_options(options)
         conf['host'] = hostname
 
         env = _detect_environment()

--- a/t/unit/transport/test_mongodb.py
+++ b/t/unit/transport/test_mongodb.py
@@ -81,6 +81,12 @@ class test_mongodb_uri_parsing:
         assert hostname == 'mongodb://foo:bar@localhost/dbname'
         assert dbname == 'dbname'
 
+    def test_correct_readpreference(self):
+        url = 'mongodb://localhost/dbname?readpreference=nearest'
+        channel = _create_mock_connection(url).default_channel
+        hostname, dbname, options = channel._parse_uri()
+        assert options['readpreference'] == 'nearest'
+
 
 class BaseMongoDBChannelCase:
 


### PR DESCRIPTION
Since pymongo v3.0 it changed the way it parses readpreference uri option. There is kind of bug in that option validator, as it returns result that is not valid for same validator (It returns the index of mongos mode in the [_MONGOS_MODES](https://github.com/mongodb/mongo-python-driver/blob/master/pymongo/read_preferences.py#L33) tuple. If you try to use the returned value as a keyword argument for `MongoClient`, it will fail with an exception:

```
  File "/usr/local/lib/python2.7/dist-packages/kombu/transport/virtual/base.py", line 923, in create_channel
    channel = self.Channel(connection)
  File "/usr/local/lib/python2.7/dist-packages/kombu/transport/mongodb.py", line 118, in __init__
    self.client
  File "/usr/local/lib/python2.7/dist-packages/kombu/utils/objects.py", line 44, in __get__
    value = obj.__dict__[self.__name__] = self.__get(obj)
  File "/usr/local/lib/python2.7/dist-packages/kombu/transport/mongodb.py", line 350, in client
    return self._create_client()
  File "/usr/local/lib/python2.7/dist-packages/kombu/transport/mongodb.py", line 342, in _create_client
    database = self._open()
  File "/usr/local/lib/python2.7/dist-packages/kombu/transport/mongodb.py", line 299, in _open
    mongoconn = MongoClient(**conf)
  File "/usr/local/lib/python2.7/dist-packages/pymongo/mongo_client.py", line 422, in __init__
    for k, v in keyword_opts.items())
  File "/usr/local/lib/python2.7/dist-packages/pymongo/mongo_client.py", line 422, in <genexpr>
    for k, v in keyword_opts.items())
  File "/usr/local/lib/python2.7/dist-packages/pymongo/common.py", line 539, in validate
    value = validator(option, value)
  File "/usr/local/lib/python2.7/dist-packages/pymongo/common.py", line 311, in validate_read_preference_mode
    raise ValueError("%s is not a valid read preference" % (name,))
ValueError: 4 is not a valid read preference
```

This pr fixes that bug on the kombu side. I've also provided the PR to pymongo to fix that behaviour (https://github.com/mongodb/mongo-python-driver/pull/325) , but it's not approved/merged yet and it would be useful for users that don't update there pymongo driver for some reason.