### PR TITLE
Fix SQS requests and response handling

### DIFF
--- a/t/unit/transport/test_SQS.py
+++ b/t/unit/transport/test_SQS.py
@@ -90,7 +90,8 @@ class SQSClientMock(object):
                                    'ReceiptHandle': handle})
                 break
 
-    def receive_message(self, QueueUrl=None, MaxNumberOfMessages=1):
+    def receive_message(self, QueueUrl=None, MaxNumberOfMessages=1,
+                        WaitTimeSeconds=10):
         self._receive_messages_calls += 1
         for q in self._queues.values():
             if q.url == QueueUrl:

--- a/t/unit/transport/test_SQS.py
+++ b/t/unit/transport/test_SQS.py
@@ -97,7 +97,7 @@ class SQSClientMock(object):
             if q.url == QueueUrl:
                 msgs = q.messages[:MaxNumberOfMessages]
                 q.messages = q.messages[MaxNumberOfMessages:]
-                return {'Messages': msgs}
+                return {'Messages': msgs} if msgs else {}
 
     def get_queue_attributes(self, QueueUrl=None, AttributeNames=None):
         if 'ApproximateNumberOfMessages' in AttributeNames:


### PR DESCRIPTION
This PR contains three bugfixes for the SQS transport:

* The `_get_bulk` and `_get` methods should take advantage of long-polling.
* I was running into an error where `resp['Messages']` would throw a `KeyError`. Admittedly, I don't recall exactly what situation this occurred during, I believe that it was when using a Kombu Consumer to read off of a queue with non-celery messages.  Nonetheless, I believe using `resp.get('Messages')` should have no negative effect to current operation but grant more flexibility to SQS message format.  If someone feels like this flexibility is a bad idea, let me know and I can attempt to recreate how I was running into the `KeyError`.
* The `_get` method fails as `receive_message` on the `Boto3` session expects only keyword arguments.