### PR TITLE
Adds `multiple` kwarg to Qpid `Channel.basic_ack`

### DIFF
--- a/kombu/transport/qpid.py
+++ b/kombu/transport/qpid.py
@@ -850,7 +850,7 @@ class Channel(base.StdChannel):
         except Empty:
             pass
 
-    def basic_ack(self, delivery_tag):
+    def basic_ack(self, delivery_tag, multiple=False):
         """Acknowledge a message by delivery_tag.
 
         Acknowledges a message referenced by delivery_tag. Messages can
@@ -864,8 +864,12 @@ class Channel(base.StdChannel):
         :param delivery_tag: The delivery tag associated with the message
             to be acknowledged.
         :type delivery_tag: uuid.UUID
+        :param multiple: not implemented. If set to True an AssertionError
+            is raised.
+        :type multiple: bool
 
         """
+        assert multiple is False
         self.qos.ack(delivery_tag)
 
     def basic_reject(self, delivery_tag, requeue=False):


### PR DESCRIPTION
Celery 4.0.2 passes the `multiple` keyword argument to `basic_ack`.
This did not used to occur with 3.1.20- so this change is only being
merged into the 4.0 branch. The desired functionality of this param is
documented here [0], but the Qpid transport uses UUIDs as the
delivery_tags so we don't have a record of the sequential messages
required to implement this. We use UUIDs as the deliver_tag to avoid
Issue #563.

With the functionality for the `multiple` parameter not implemented, an
AssertionError is raised if Celery attempts to meaningfully use the
`multiple` parameter with the Qpid transport. A developer or user who
encounters this AssertionError should file a bug with Kombu.

[0] http://amqp.readthedocs.io/en/latest/reference/amqp.connection.html#amqp.connection.Connection.Channel.basic_ack

closes #699