### PR TITLE
Fix infinite loop in create_loop

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -15,6 +15,9 @@
 
     Contributed by **Mikhail Elovskikh**.
 
+- Async hub: Fixed potential infinite loop while performing todo tasks
+  (Issue celery/celery#3712).
+
 .. _version-4.0.2:
 
 4.0.2

--- a/kombu/async/hub.py
+++ b/kombu/async/hub.py
@@ -283,7 +283,7 @@ class Hub(object):
             # we will break early and allow execution of readers and writers.
             current_todos = len(todo)
             for _ in itertools.repeat(None, current_todos):
-                if not todos:
+                if not todo:
                     break
 
                 item = todo.pop()

--- a/kombu/async/hub.py
+++ b/kombu/async/hub.py
@@ -269,13 +269,18 @@ class Hub(object):
         consolidate = self.consolidate
         consolidate_callback = self.consolidate_callback
         on_tick = self.on_tick
-        todo = self._ready
         propagate = self.propagate_errors
 
         while 1:
             for tick_callback in on_tick:
                 tick_callback()
-
+            
+            # To avoid infinite loop where one of the callables adds items to self._ready
+            # (via call_soon or otherwise), we copy the todo list aside and clear the _ready
+            # so items added don't affect this loop and instead they'll be taken care of on the
+            # next itermation of the parent-loop
+            todo = self._ready.copy()
+            self._ready.clear()
             while todo:
                 item = todo.pop()
                 if item:

--- a/kombu/async/hub.py
+++ b/kombu/async/hub.py
@@ -274,10 +274,11 @@ class Hub(object):
         while 1:
             for tick_callback in on_tick:
                 tick_callback()
-            
-            # To avoid infinite loop where one of the callables adds items to self._ready
-            # (via call_soon or otherwise), we copy the todo list aside and clear the _ready
-            # so items added don't affect this loop and instead they'll be taken care of on the
+
+            # To avoid infinite loop where one of the callables adds items
+            # to self._ready (via call_soon or otherwise), we copy the todo
+            # list aside and clear the _ready so items added don't affect
+            # this loop and instead they'll be taken care of on the
             # next iteration of the parent-loop
             todo = self._ready.copy()
             self._ready.clear()

--- a/kombu/async/hub.py
+++ b/kombu/async/hub.py
@@ -278,7 +278,7 @@ class Hub(object):
             # To avoid infinite loop where one of the callables adds items to self._ready
             # (via call_soon or otherwise), we copy the todo list aside and clear the _ready
             # so items added don't affect this loop and instead they'll be taken care of on the
-            # next itermation of the parent-loop
+            # next iteration of the parent-loop
             todo = self._ready.copy()
             self._ready.clear()
             while todo:

--- a/t/unit/async/test_hub.py
+++ b/t/unit/async/test_hub.py
@@ -501,7 +501,7 @@ class test_Hub:
 
     def test_loop__tick_callbacks(self):
         self.hub._ready = Mock(name='_ready')
-        self.hub._ready.pop.side_effect = RuntimeError()
+        self.hub._ready.copy.side_effect = RuntimeError()
         ticks = [Mock(name='cb1'), Mock(name='cb2')]
         self.hub.on_tick = list(ticks)
 

--- a/t/unit/async/test_hub.py
+++ b/t/unit/async/test_hub.py
@@ -5,7 +5,6 @@ import pytest
 
 from case import Mock, call, patch
 from vine import promise
-from unittest.mock import MagicMock
 
 from kombu.async import hub as _hub
 from kombu.async import Hub, READ, WRITE, ERR
@@ -501,7 +500,8 @@ class test_Hub:
         assert list(hub.scheduler), [1, 2 == 3]
 
     def test_loop__tick_callbacks(self):
-        self.hub._ready = MagicMock(name='_ready')
+        self.hub._ready = Mock(name='_ready')
+        self.hub._ready.__len__ = Mock(name="_ready.__len__")
         self.hub._ready.__len__.side_effect = RuntimeError()
         ticks = [Mock(name='cb1'), Mock(name='cb2')]
         self.hub.on_tick = list(ticks)

--- a/t/unit/async/test_hub.py
+++ b/t/unit/async/test_hub.py
@@ -5,6 +5,7 @@ import pytest
 
 from case import Mock, call, patch
 from vine import promise
+from unittest.mock import MagicMock
 
 from kombu.async import hub as _hub
 from kombu.async import Hub, READ, WRITE, ERR
@@ -500,8 +501,8 @@ class test_Hub:
         assert list(hub.scheduler), [1, 2 == 3]
 
     def test_loop__tick_callbacks(self):
-        self.hub._ready = Mock(name='_ready')
-        self.hub._ready.copy.side_effect = RuntimeError()
+        self.hub._ready = MagicMock(name='_ready')
+        self.hub._ready.__len__.side_effect = RuntimeError()
         ticks = [Mock(name='cb1'), Mock(name='cb2')]
         self.hub.on_tick = list(ticks)
 


### PR DESCRIPTION
fixes https://github.com/celery/celery/issues/3712 

Before handling the todo items we "freeze" them by copying them aside and clearing the list.
This way if an item in the todo list appends a new callable to the list itself it will be taken care of in the next iteration of the parent loop instead of producing an infinite loop by adding it to the list we're running on.