### PR TITLE
fix(doc): updating pydoc for redis sentinel

### DIFF
--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -1060,7 +1060,7 @@ class SentinelChannel(Channel):
     `Connection` object).
 
     You must provide at least one option in Transport options:
-     * `service_name` - name of the redis group to poll
+     * `master_name` - name of the redis group to poll
     """
 
     from_transport_options = Channel.from_transport_options + (


### PR DESCRIPTION
service_name is not used anymore, and was changed in this commit: a46dba8f2e3490e6c30ca24cf6ee4a96b7f4124a