### PR TITLE
Pass connection options from broker_options to default_channel 

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -11,6 +11,13 @@
 :release-date: 2017-07-17 04:45 P.M MST
 :release-by: Anthony Lukach
 
+- Now passing ``max_retries``, ``interval_start``, ``interval_step``,
+  ``interval_max`` parameters from broker ``transport_options`` to
+  :meth:`~kombu.Connection.ensure_connection` when returning
+  :meth:`~kombu.Connection.default_connection` (Issue #765).
+
+    Contributed by **Anthony Lukach**.
+
 - SQS: Added support for long-polling on all supported queries. Fixed bug
   causing error on parsing responses with no retrieved messages from SQS.
 

--- a/Changelog
+++ b/Changelog
@@ -4,12 +4,12 @@
  Change history
 ================
 
-.. _version-4.1.0:
+.. _version-4.1.1:
 
-4.1.0
+4.1.1
 =====
-:release-date: 2017-07-17 04:45 P.M MST
-:release-by: Anthony Lukach
+:release-date: TBD
+:release-by: TBD
 
 - Now passing ``max_retries``, ``interval_start``, ``interval_step``,
   ``interval_max`` parameters from broker ``transport_options`` to
@@ -17,6 +17,13 @@
   :meth:`~kombu.Connection.default_connection` (Issue #765).
 
     Contributed by **Anthony Lukach**.
+
+.. _version-4.1.0:
+
+4.1.0
+=====
+:release-date: 2017-07-17 04:45 P.M MST
+:release-by: Anthony Lukach
 
 - SQS: Added support for long-polling on all supported queries. Fixed bug
   causing error on parsing responses with no retrieved messages from SQS.

--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -815,18 +815,20 @@ class Connection(object):
             a connection is passed instead of a channel, to functions that
             require a channel.
         """
-        ensure_connection_options = {}
-        if self.transport_options:
-            options_keys = [
-                'max_retries',
-                'interval_start', 'interval_step', 'interval_max',
-            ]
-            for k in options_keys:
-                if k in self.transport_options:
-                    ensure_connection_options[k] = self.transport_options[k]
+        conn_opts = {}
+        transport_opts = self.transport_options
+        if transport_opts:
+            if 'max_retries' in transport_opts:
+                conn_opts['max_retries'] = transport_opts['max_retries']
+            if 'interval_start' in transport_opts:
+                conn_opts['interval_start'] = transport_opts['interval_start']
+            if 'interval_step' in transport_opts:
+                conn_opts['interval_step'] = transport_opts['interval_step']
+            if 'interval_max' in transport_opts:
+                conn_opts['interval_max'] = transport_opts['interval_max']
 
         # make sure we're still connected, and if not refresh.
-        self.ensure_connection(**ensure_connection_options)
+        self.ensure_connection(**conn_opts)
         if self._default_channel is None:
             self._default_channel = self.channel()
         return self._default_channel

--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -815,14 +815,18 @@ class Connection(object):
             a connection is passed instead of a channel, to functions that
             require a channel.
         """
-        options = {
-            k: v for k, v in (self.transport_options or {}).items()
-            if k in [
-                'max_retries', 'interval_start',
-                'interval_step', 'interval_max']
-        }
+        ensure_connection_options = {}
+        if self.transport_options:
+            options_keys = [
+                'max_retries',
+                'interval_start', 'interval_step', 'interval_max',
+            ]
+            for k in options_keys:
+                if k in self.transport_options:
+                    ensure_connection_options[k] = self.transport_options[k]
+
         # make sure we're still connected, and if not refresh.
-        self.ensure_connection(**options)
+        self.ensure_connection(**ensure_connection_options)
         if self._default_channel is None:
             self._default_channel = self.channel()
         return self._default_channel

--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -815,8 +815,14 @@ class Connection(object):
             a connection is passed instead of a channel, to functions that
             require a channel.
         """
+        options = {
+            k: v for k, v in (self.transport_options or {}).items()
+            if k in [
+                'max_retries', 'interval_start',
+                'interval_step', 'interval_max']
+        }
         # make sure we're still connected, and if not refresh.
-        self.ensure_connection()
+        self.ensure_connection(**options)
         if self._default_channel is None:
             self._default_channel = self.channel()
         return self._default_channel

--- a/t/unit/test_connection.py
+++ b/t/unit/test_connection.py
@@ -380,6 +380,32 @@ class test_Connection:
         defchan.close.assert_called_with()
         assert conn._default_channel is None
 
+    def test_default_channel_no_transport_options(self):
+        conn = self.conn
+        conn.ensure_connection = Mock()
+
+        assert conn.default_channel
+        conn.ensure_connection.assert_called_with()
+
+    def test_default_channel_transport_options(self):
+        conn = self.conn
+        conn.transport_options = options = {
+            'max_retries': 1,
+            'interval_start': 2,
+            'interval_step': 3,
+            'interval_max': 4,
+            'ignore_this': True
+        }
+        conn.ensure_connection = Mock()
+
+        assert conn.default_channel
+        conn.ensure_connection.assert_called_with(**{
+            k: v for k, v in options.items()
+            if k in ['max_retries',
+                     'interval_start',
+                     'interval_step',
+                     'interval_max']})
+
     def test_ensure_connection(self):
         assert self.conn.ensure_connection()
 


### PR DESCRIPTION
Not sure if this is the best implementation, however it gets the job done for my needs. My goal is to be able to start my application when the message broker is offline. Upon startup, the application attempts to establish queues, which requires the `Channel.default_connection` to be generated. When generating the `default_channel`, `Channel.ensure_connection` with no `max_retry` (or other options) provided. This caused the application to hang while infinitely attempting to connect to the broker.

Fixes #765 