### PR TITLE
Removed some unnecessary variable assignments

### DIFF
--- a/docs/userguide/producers.rst
+++ b/docs/userguide/producers.rst
@@ -35,7 +35,7 @@ Having a producer instance you can publish messages:
     ...      {'hello': 'world'},  # message to send
     ...      exchange=exchange,   # destination exchange
     ...      routing_key='rk',    # destination routing key,
-    ...      decare=[exchange],   # make sure exchange is declared,
+    ...      declare=[exchange],  # make sure exchange is declared,
     ... )
 
 

--- a/kombu/compat.py
+++ b/kombu/compat.py
@@ -85,7 +85,6 @@ class Consumer(messaging.Consumer):
     durable = True
     exclusive = False
     auto_delete = False
-    exchange_type = 'direct'
     _closed = False
 
     def __init__(self, connection, queue=None, exchange=None,

--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -173,7 +173,7 @@ class Connection(object):
                 # e.g. sqla+mysql://root:masterkey@localhost/
                 params['transport'], params['hostname'] = \
                     hostname.split('+', 1)
-                transport = self.uri_prefix = params['transport']
+                self.uri_prefix = params['transport']
             else:
                 transport = transport or urlparse(hostname).scheme
                 if not get_transport_cls(transport).can_parse_url:

--- a/kombu/simple.py
+++ b/kombu/simple.py
@@ -128,7 +128,6 @@ class SimpleQueue(SimpleBase):
             queue = entity.Queue(name, exchange, name, **queue_opts)
             routing_key = name
         else:
-            name = queue.name
             exchange = queue.exchange
             routing_key = queue.routing_key
         consumer = messaging.Consumer(channel, queue)

--- a/kombu/utils/functional.py
+++ b/kombu/utils/functional.py
@@ -324,7 +324,6 @@ def retry_over_time(fun, catch, args=[], kwargs={}, errback=None,
         interval_max (float): Maximum number of seconds to sleep
             between retries.
     """
-    retries = 0
     interval_range = fxrange(interval_start,
                              interval_max + interval_start,
                              interval_step, repeatlast=True)


### PR DESCRIPTION
I added a comment in `kombu/connection.py`. I noticed a lot of unused parameters in functions and methods, and in a few cases the index-variable `i` in for-loops could be replaced with `_`. 