### PR TITLE
Make messages durable by default in qpid

### DIFF
--- a/kombu/transport/qpid.py
+++ b/kombu/transport/qpid.py
@@ -427,7 +427,8 @@ class Channel(base.StdChannel):
             rx.close()
         return message
 
-    def _put(self, routing_key, message, exchange=None, **kwargs):
+    def _put(self, routing_key, message, exchange=None, durable=True,
+             **kwargs):
         """Synchronously send a single message onto a queue or exchange.
 
         An internal method which synchronously sends a single message onto
@@ -460,6 +461,9 @@ class Channel(base.StdChannel):
             should be sent on. If no exchange is specified, the message is
             sent directly to a queue specified by routing_key.
         :type exchange: str
+        :keyword durable: whether or not the message should persist or be
+            durable.
+        :type durable: bool
 
         """
         if not exchange:
@@ -472,6 +476,7 @@ class Channel(base.StdChannel):
             msg_subject = str(routing_key)
         sender = self.transport.session.sender(address)
         qpid_message = qpid.messaging.Message(content=message,
+                                              durable=durable,
                                               subject=msg_subject)
         try:
             sender.send(qpid_message, sync=True)

--- a/t/unit/transport/test_qpid.py
+++ b/t/unit/transport/test_qpid.py
@@ -521,7 +521,7 @@ class test_Channel_put(ChannelTestBase):
         )
         self.transport.session.sender.assert_called_with(address_str)
         mock_Message_cls.assert_called_with(
-            content=mock_message, subject=None,
+            content=mock_message, subject=None, durable=True
         )
         mock_sender = self.transport.session.sender.return_value
         mock_sender.send.assert_called_with(
@@ -543,7 +543,7 @@ class test_Channel_put(ChannelTestBase):
         )
         self.transport.session.sender.assert_called_with(addrstr)
         mock_Message_cls.assert_called_with(
-            content=mock_message, subject=mock_routing_key,
+            content=mock_message, subject=mock_routing_key, durable=True
         )
         mock_sender = self.transport.session.sender.return_value
         mock_sender.send.assert_called_with(


### PR DESCRIPTION
We are seeing messages disappear in durable queues when restarting
qpid. This coincides with the rabbitmq code (e.g. https://git.io/v7jNV).