### PR TITLE
Update links in documentation to either https or to new locations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@
 
 :Version: 4.1.0
 :Web: http://kombu.me/
-:Download: http://pypi.python.org/pypi/kombu/
+:Download: https://pypi.python.org/pypi/kombu/
 :Source: https://github.com/celery/kombu/
 :Keywords: messaging, amqp, rabbitmq, redis, mongodb, python, queue
 

--- a/docs/reference/kombu.serialization.rst
+++ b/docs/reference/kombu.serialization.rst
@@ -43,9 +43,9 @@
 
     .. autodata:: registry
 
-.. _`cjson`: http://pypi.python.org/pypi/python-cjson/
-.. _`simplejson`: http://code.google.com/p/simplejson/
-.. _`Python 2.6+`: http://docs.python.org/library/json.html
-.. _`PyYAML`: http://pyyaml.org/
-.. _`msgpack`: http://msgpack.sourceforge.net/
-.. _`msgpack-python`: http://pypi.python.org/pypi/msgpack-python/
+.. _`cjson`: https://pypi.python.org/pypi/python-cjson/
+.. _`simplejson`: https://github.com/simplejson/simplejson
+.. _`Python 2.7+`: https://docs.python.org/library/json.html
+.. _`PyYAML`: https://pyyaml.org/
+.. _`msgpack`: https://msgpack.org/
+.. _`msgpack-python`: https://pypi.python.org/pypi/msgpack-python/

--- a/docs/userguide/serialization.rst
+++ b/docs/userguide/serialization.rst
@@ -28,7 +28,7 @@ The accept argument can also include MIME-types.
 
 .. _`JSON`: http://www.json.org/
 .. _`YAML`: http://yaml.org/
-.. _`msgpack`: http://msgpack.sourceforge.net/
+.. _`msgpack`: https://msgpack.org/
 
 Each option has its advantages and disadvantages.
 


### PR DESCRIPTION
This forwards automatically to the newest Python source, i.e., 3.6. 2.6 is not supported anymore (although it was introduced in 2.6, I've noticed), so I replaced it with 2.7.

`Python 2.7+`: https://docs.python.org/library/json.html

`apicheck` fails both locally, and remote. I'm not sure how to fix that.