### PR TITLE
Fixes #791: SQS Queue names getting mangles

### DIFF
--- a/kombu/async/http/curl.py
+++ b/kombu/async/http/curl.py
@@ -218,9 +218,6 @@ class CurlClient(BaseClient):
             if request.proxy_username:
                 setopt(_pycurl.PROXYUSERPWD, '{0}:{1}'.format(
                     request.proxy_username, request.proxy_password or ''))
-        else:
-            setopt(_pycurl.PROXY, '')
-            curl.unsetopt(_pycurl.PROXYUSERPWD)
 
         setopt(_pycurl.SSL_VERIFYPEER, 1 if request.validate_cert else 0)
         setopt(_pycurl.SSL_VERIFYHOST, 2 if request.validate_cert else 0)

--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -154,10 +154,10 @@ class Channel(virtual.Channel):
         """Format AMQP queue name into a legal SQS queue name."""
         if name.endswith('.fifo'):
             partial = name.rstrip('.fifo')
-            partial = text_t(safe_str(partial)).translate(table)
+            partial = text_t(safe_str(partial.translate(table)))
             return partial + '.fifo'
         else:
-            return text_t(safe_str(name)).translate(table)
+            return text_t(safe_str(name.translate(table)))
 
     def canonical_queue_name(self, queue_name):
         return self.entity_name(self.queue_name_prefix + queue_name)


### PR DESCRIPTION
Fixes #791 by slightly changing the order of when the queue name is translated to SQS valid name and when the unicode to str encoding happens. Basically doing the translate() on the original string instead of doing it after we have translated the string into an encoded unicode string.