### PR TITLE
Fixes #791 - SQS queue name gets mangled in Python 2.7 environment

### DIFF
--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -154,10 +154,10 @@ class Channel(virtual.Channel):
         """Format AMQP queue name into a legal SQS queue name."""
         if name.endswith('.fifo'):
             partial = name.rstrip('.fifo')
-            partial = text_t(safe_str(partial.translate(table)))
+            partial = text_t(safe_str(partial)).translate(table)
             return partial + '.fifo'
         else:
-            return text_t(safe_str(name.translate(table)))
+            return text_t(safe_str(name)).translate(table)
 
     def canonical_queue_name(self, queue_name):
         return self.entity_name(self.queue_name_prefix + queue_name)

--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -154,10 +154,10 @@ class Channel(virtual.Channel):
         """Format AMQP queue name into a legal SQS queue name."""
         if name.endswith('.fifo'):
             partial = name.rstrip('.fifo')
-            partial = text_t(safe_str(partial)).translate(table)
+            partial = text_t(safe_str(partial.translate(table)))
             return partial + '.fifo'
         else:
-            return text_t(safe_str(name)).translate(table)
+            return text_t(safe_str(name.translate(table)))
 
     def canonical_queue_name(self, queue_name):
         return self.entity_name(self.queue_name_prefix + queue_name)

--- a/kombu/utils/encoding.py
+++ b/kombu/utils/encoding.py
@@ -132,7 +132,8 @@ else:
         encoding = default_encoding(file)
         try:
             if isinstance(s, unicode):
-                return _ensure_str(s.encode(encoding, errors), encoding, errors)
+                return _ensure_str(s.encode(encoding, errors),
+                                   encoding, errors)
             return unicode(s, encoding, errors)
         except Exception as exc:
             return '<Unrepresentable {0!r}: {1!r} {2!r}>'.format(

--- a/kombu/utils/encoding.py
+++ b/kombu/utils/encoding.py
@@ -122,11 +122,17 @@ if is_py3k:  # pragma: no cover
             return '<Unrepresentable {0!r}: {1!r} {2!r}>'.format(
                 type(s), exc, '\n'.join(traceback.format_stack()))
 else:
+    def ensure_str(s):
+        if isinstance(s, bytes):
+            return s.decode()
+        return s
+
+
     def _safe_str(s, errors='replace', file=None):  # noqa
         encoding = default_encoding(file)
         try:
             if isinstance(s, unicode):
-                return s.encode(encoding, errors)
+                return ensure_str(s.encode(encoding, errors))
             return unicode(s, encoding, errors)
         except Exception as exc:
             return '<Unrepresentable {0!r}: {1!r} {2!r}>'.format(

--- a/kombu/utils/encoding.py
+++ b/kombu/utils/encoding.py
@@ -122,7 +122,7 @@ if is_py3k:  # pragma: no cover
             return '<Unrepresentable {0!r}: {1!r} {2!r}>'.format(
                 type(s), exc, '\n'.join(traceback.format_stack()))
 else:
-    def ensure_str(s, encoding, errors):
+    def _ensure_str(s, encoding, errors):
         if isinstance(s, bytes):
             return s.decode(encoding, errors)
         return s
@@ -132,7 +132,7 @@ else:
         encoding = default_encoding(file)
         try:
             if isinstance(s, unicode):
-                return ensure_str(s.encode(encoding, errors), encoding, errors)
+                return _ensure_str(s.encode(encoding, errors), encoding, errors)
             return unicode(s, encoding, errors)
         except Exception as exc:
             return '<Unrepresentable {0!r}: {1!r} {2!r}>'.format(

--- a/kombu/utils/encoding.py
+++ b/kombu/utils/encoding.py
@@ -122,9 +122,9 @@ if is_py3k:  # pragma: no cover
             return '<Unrepresentable {0!r}: {1!r} {2!r}>'.format(
                 type(s), exc, '\n'.join(traceback.format_stack()))
 else:
-    def ensure_str(s):
+    def ensure_str(s, encoding, errors):
         if isinstance(s, bytes):
-            return s.decode()
+            return s.decode(encoding, errors)
         return s
 
 
@@ -132,7 +132,7 @@ else:
         encoding = default_encoding(file)
         try:
             if isinstance(s, unicode):
-                return ensure_str(s.encode(encoding, errors))
+                return ensure_str(s.encode(encoding, errors), encoding, errors)
             return unicode(s, encoding, errors)
         except Exception as exc:
             return '<Unrepresentable {0!r}: {1!r} {2!r}>'.format(

--- a/t/unit/utils/test_encoding.py
+++ b/t/unit/utils/test_encoding.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 
 from case import patch, skip
 
-from kombu.five import bytes_t, string_t
+from kombu.five import bytes_t, string_t, string
 from kombu.utils.encoding import (
     get_default_encoding_file, safe_str,
     set_default_encoding_file, default_encoding,
@@ -65,6 +65,22 @@ def test_default_encode():
         assert e.default_encode(b'foo')
 
 
+class newbytes(bytes):
+    """Mock class to simulate python-future newbytes class"""
+    def __repr__(self):
+        return 'b' + super(newbytes, self).__repr__()
+
+    def __str__(self):
+        return 'b' + "'{0}'".format(super(newbytes, self).__str__())
+
+
+class newstr(string):
+    """Mock class to simulate python-future newstr class"""
+
+    def encode(self, encoding=None, errors=None):
+        return newbytes(super(newstr, self).encode(encoding, errors))
+
+
 class test_safe_str:
 
     def setup(self):
@@ -73,6 +89,10 @@ class test_safe_str:
 
     def test_when_bytes(self):
         assert safe_str('foo') == 'foo'
+
+    def test_when_newstr(self):
+        """Simulates using python-future package under 2.7"""
+        assert str(safe_str(newstr('foo'))) == 'foo'
 
     def test_when_unicode(self):
         assert isinstance(safe_str('foo'), string_t)

--- a/t/unit/utils/test_encoding.py
+++ b/t/unit/utils/test_encoding.py
@@ -82,13 +82,13 @@ class test_safe_str:
         assert default_encoding() == 'utf-8'
         s = 'The quiæk fåx jømps øver the lazy dåg'
         res = safe_str(s)
-        assert isinstance(res, str)
+        assert isinstance(res, string_t)
 
     def test_when_containing_high_chars(self):
         self._encoding.return_value = 'ascii'
         s = 'The quiæk fåx jømps øver the lazy dåg'
         res = safe_str(s)
-        assert isinstance(res, str)
+        assert isinstance(res, string_t)
         assert len(s) == len(res)
 
     def test_when_not_string(self):


### PR DESCRIPTION
This change alters the safe_str() function to handle the case when a python-future package "newstr" and "newbytes" are being used in Python 2.7