### PR TITLE
Fix Pyro link

### DIFF
--- a/docs/includes/introduction.txt
+++ b/docs/includes/introduction.txt
@@ -68,7 +68,7 @@ and the `Wikipedia article about AMQP`_.
 .. _`Wikipedia article about AMQP`: http://en.wikipedia.org/wiki/AMQP
 .. _`carrot`: http://pypi.python.org/pypi/carrot/
 .. _`librabbitmq`: http://pypi.python.org/pypi/librabbitmq
-.. _`Pyro`: http://pythonhosting.org/Pyro
+.. _`Pyro`: https://pythonhosted.org/Pyro
 .. _`SoftLayer MQ`: http://www.softlayer.com/services/additional/message-queue
 
 .. _transport-comparison:


### PR DESCRIPTION
it's pythonhosted.org not pythonhosting.org