### PR TITLE
Include license file in the generated wheel packages

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,3 +20,6 @@ requires = amqp >= 2.
 
 [bdist_wheel]
 universal = 1
+
+[metadata]
+license_file = LICENSE


### PR DESCRIPTION
The wheel package format supports including the license file. This is
done using the [metadata] section in the setup.cfg file. For additional
information on this feature, see:

https://wheel.readthedocs.io/en/stable/index.html#including-the-license-in-the-generated-wheel-file