### PR TITLE
 Moving the handling of Sentinel failures to the redis library itself. 

### DIFF
--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -1075,7 +1075,7 @@ class SentinelChannel(Channel):
 
         additional_params.pop('host', None)
         additional_params.pop('port', None)
-        connection_list = list()
+        connection_list = []
         for url in self.connection.client.alt:
             if url and 'sentinel://' in url:
                 connection_list.append(url.split('/')[2].split(':'))

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -1051,9 +1051,7 @@ class SentinelChannel(Channel):
 
     sentinel://0.0.0.0:26379;sentinel://0.0.0.0:26380/...
 
-    where each sentinel is separated by a `;`.  Multiple sentinels are handled
-    by :class:`kombu.Connection` constructor, and placed in the alternative
-    list of servers to connect to in case of connection failure.
+    where each sentinel is separated by a `;`.
 
     Other arguments for the sentinel should come from the transport options
     (see :method:`Celery.connection` which is in charge of creating the
@@ -1077,11 +1075,14 @@ class SentinelChannel(Channel):
 
         additional_params.pop('host', None)
         additional_params.pop('port', None)
-
+        connection_list = list()
+        for url in self.connection.client.alt:
+            if url and 'sentinel://' in url:
+                connection_list.append(url.split('/')[2].split(':'))
         sentinel_inst = sentinel.Sentinel(
-            [(connparams['host'], connparams['port'])],
+            connection_list,
             min_other_sentinels=getattr(self, 'min_other_sentinels', 0),
-            sentinel_kwargs=getattr(self, 'sentinel_kwargs', {}),
+            sentinel_kwargs=getattr(self, 'sentinel_kwargs',None),
             **additional_params)
 
         master_name = getattr(self, 'master_name', None)

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 import pytest
 import socket
 import types
+import unittest
 
 from collections import defaultdict
 from itertools import count
@@ -1276,7 +1277,7 @@ class test_Mutex:
 
 
 @skip.unless_module('redis.sentinel')
-class test_RedisSentinel:
+class test_RedisSentinel(unittest.TestCase):
 
     def test_method_called(self):
         from kombu.transport.redis import SentinelChannel
@@ -1295,14 +1296,19 @@ class test_RedisSentinel:
     def test_getting_master_from_sentinel(self):
         with patch('redis.sentinel.Sentinel') as patched:
             connection = Connection(
-                'sentinel://localhost:65534/',
+                'sentinel://localhost:65534/;sentinel://localhost:65535/;sentinel://localhost:65536/;',
                 transport_options={
                     'master_name': 'not_important',
                 },
             )
 
             connection.channel()
-            assert patched
+            patched.assert_called_once_with(
+                [[u'localhost', u'65534'], [u'localhost', u'65535'], [u'localhost', u'65536']],
+                connection_class=mock.ANY, db=0, max_connections=10,
+                min_other_sentinels=0, password=None, sentinel_kwargs=None,
+                socket_connect_timeout=None, socket_keepalive=None,
+                socket_keepalive_options=None, socket_timeout=None)
 
             master_for = patched.return_value.master_for
             master_for.assert_called()

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, unicode_literals
 import pytest
 import socket
 import types
-import unittest
 
 from collections import defaultdict
 from itertools import count
@@ -1277,7 +1276,7 @@ class test_Mutex:
 
 
 @skip.unless_module('redis.sentinel')
-class test_RedisSentinel(unittest.TestCase):
+class test_RedisSentinel:
 
     def test_method_called(self):
         from kombu.transport.redis import SentinelChannel


### PR DESCRIPTION
These were the exceptions seen. Redis Sentinel worked only if the first node's sentinel service in the URI was up. A server outage would have caused downtime.

```
[2017-11-14 16:47:57,860: INFO/Beat] beat: Starting...
[2017-11-14 16:47:57,865: ERROR/MainProcess] consumer: Cannot connect to sentinel://10.0.0.10:26379/0: No master found for 'mymaster'.
Will retry using next failover.

[2017-11-14 16:47:57,883: INFO/MainProcess] Connected to sentinel://10.0.0.11:26379/0
[2017-11-14 16:47:57,896: ERROR/MainProcess] consumer: Cannot connect to sentinel://10.0.0.10:26379/0: No master found for 'mymaster'.
Will retry using next failover.

[2017-11-14 16:47:57,918: INFO/MainProcess] mingle: searching for neighbors
[2017-11-14 16:47:57,942: WARNING/MainProcess] consumer: Connection to broker lost. Trying to re-establish the connection...
Traceback (most recent call last):
  File "/opt/project/lib/python2.7/site-packages/celery/worker/consumer/consumer.py", line 318, in start
    blueprint.start(self)                                                                                                                                                                                                            [25/1985]
  File "/opt/project/lib/python2.7/site-packages/celery/bootsteps.py", line 119, in start   
    step.start(parent)
  File "/opt/project/lib/python2.7/site-packages/celery/worker/consumer/mingle.py", line 38, in start   
    self.sync(c)
  File "/opt/project/lib/python2.7/site-packages/celery/worker/consumer/mingle.py", line 42, in sync   
    replies = self.send_hello(c)
  File "/opt/project/lib/python2.7/site-packages/celery/worker/consumer/mingle.py", line 55, in send_hello   
    replies = inspect.hello(c.hostname, our_revoked._data) or {}
  File "/opt/project/lib/python2.7/site-packages/celery/app/control.py", line 129, in hello   
    return self._request('hello', from_node=from_node, revoked=revoked)
  File "/opt/project/lib/python2.7/site-packages/celery/app/control.py", line 81, in _request   
    timeout=self.timeout, reply=True,
  File "/opt/project/lib/python2.7/site-packages/celery/app/control.py", line 436, in broadcast   
    limit, callback, channel=channel,
  File "/opt/project/lib/python2.7/site-packages/kombu/pidbox.py", line 315, in _broadcast   
    serializer=serializer)
  File "/opt/project/lib/python2.7/site-packages/kombu/pidbox.py", line 290, in _publish   
    serializer=serializer,
  File "/opt/project/lib/python2.7/site-packages/kombu/messaging.py", line 181, in publish   
    exchange_name, declare,
  File "/opt/project/lib/python2.7/site-packages/kombu/messaging.py", line 187, in _publish   
    channel = self.channel
  File "/opt/project/lib/python2.7/site-packages/kombu/messaging.py", line 209, in _get_channel   
    channel = self._channel = channel()
  File "/opt/project/lib/python2.7/site-packages/kombu/utils/functional.py", line 38, in __call__   
    value = self.__value__ = self.__contract__()
  File "/opt/project/lib/python2.7/site-packages/kombu/messaging.py", line 224, in <lambda>   
    channel = ChannelPromise(lambda: connection.default_channel)
  File "/opt/project/lib/python2.7/site-packages/kombu/connection.py", line 819, in default_channel   
    self.connection
  File "/opt/project/lib/python2.7/site-packages/kombu/connection.py", line 802, in connection   
    self._connection = self._establish_connection()
  File "/opt/project/lib/python2.7/site-packages/kombu/connection.py", line 757, in _establish_connection   
    conn = self.transport.establish_connection()
  File "/opt/project/lib/python2.7/site-packages/kombu/transport/virtual/base.py", line 941, in establish_connection
    self._avail_channels.append(self.create_channel(self))
  File "/opt/project/lib/python2.7/site-packages/kombu/transport/virtual/base.py", line 923, in create_channel   
    channel = self.Channel(connection)
  File "/opt/project/lib/python2.7/site-packages/kombu/transport/redis.py", line 501, in __init__   
    self.client.ping()
  File "/opt/project/lib/python2.7/site-packages/redis/client.py", line 682, in ping   
    return self.execute_command('PING')
  File "/opt/project/lib/python2.7/site-packages/redis/client.py", line 578, in execute_command   
    connection.send_command(*args)
  File "/opt/project/lib/python2.7/site-packages/redis/connection.py", line 563, in send_command   
    self.send_packed_command(self.pack_command(*args))
  File "/opt/project/lib/python2.7/site-packages/redis/connection.py", line 538, in send_packed_command   
    self.connect()
  File "/opt/project/lib/python2.7/site-packages/redis/sentinel.py", line 44, in connect   
    self.connect_to(self.connection_pool.get_master_address())
  File "/opt/project/lib/python2.7/site-packages/redis/sentinel.py", line 100, in get_master_address   
    self.service_name)
  File "/opt/project/lib/python2.7/site-packages/redis/sentinel.py", line 222, in discover_master   
    raise MasterNotFoundError("No master found for %r" % (service_name,))
MasterNotFoundError: No master found for 'mymaster'
[2017-11-14 16:47:57,993: ERROR/MainProcess] consumer: Cannot connect to sentinel://10.0.0.10:26379/0: No master found for 'mymaster'.
Will retry using next failover.

[2017-11-14 16:47:57,997: ERROR/Beat] beat: Connection error: No master found for 'mymaster'. Trying again in 0 seconds...
```