### PR TITLE
Fixed ValueError caused by mongodb rc version: invalid literal for in…

### DIFF
--- a/kombu/transport/mongodb.py
+++ b/kombu/transport/mongodb.py
@@ -303,6 +303,7 @@ class Channel(virtual.Channel):
         database = mongoconn[dbname]
 
         version_str = mongoconn.server_info()['version']
+        version_str = version_str.split('-')[0]
         version = tuple(map(int, version_str.split('.')))
 
         if version < (1, 3):

--- a/t/unit/transport/test_mongodb.py
+++ b/t/unit/transport/test_mongodb.py
@@ -359,6 +359,15 @@ class test_mongodb_channel(BaseMongoDBChannelCase):
                 filter={'queue': 'fanout_exchange1'},
             )
 
+    def test_open_rc_version(self):
+        import pymongo
+
+        def server_info(self):
+            return {'version': '3.6.0-rc'}
+
+        with patch.object(pymongo.MongoClient, 'server_info', server_info):
+            self.channel._open()
+
 
 @skip.unless_module('pymongo')
 class test_mongodb_channel_ttl(BaseMongoDBChannelCase):


### PR DESCRIPTION
when mongodb version is like '3.6.0-rc1-45-gdb64381', will raise ValueError: invalid literal for int() with base 10.