### PR TITLE
Proposed fix for SQS transport acks and deletes

### DIFF
--- a/kombu/async/http/__init__.py
+++ b/kombu/async/http/__init__.py
@@ -25,14 +25,8 @@ def get_client(hub=None, **kwargs):
 
         return hub._current_http_client
     except AttributeError:
-        
-        # What should happen on error?
-        # It appears to impact the message.ack() going
-        # back to SQS for issues like:
-        # https://github.com/celery/kombu/issues/746
         if not hub:
             hub = Hub()
-            set_event_loop(hub)
 
         client = hub._current_http_client = Client(hub, **kwargs)
         set_event_loop(hub)

--- a/kombu/async/http/__init__.py
+++ b/kombu/async/http/__init__.py
@@ -20,10 +20,10 @@ def get_client(hub=None, **kwargs):
     try:
         if not hub:
             hub = Hub()
+            client = hub._current_http_client = Client(hub, **kwargs)
             set_event_loop(hub)
 
-        client = Client(hub, **kwargs)
-        return client
+        return hub._current_http_client
     except AttributeError:
         
         # What should happen on error?
@@ -34,5 +34,6 @@ def get_client(hub=None, **kwargs):
             hub = Hub()
             set_event_loop(hub)
 
-        client = Client(hub, **kwargs)
-        return client
+        client = hub._current_http_client = Client(hub, **kwargs)
+        set_event_loop(hub)
+        return hub._current_http_client

--- a/kombu/async/http/__init__.py
+++ b/kombu/async/http/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
-from kombu.async import get_event_loop
+from kombu.async import get_event_loop, set_event_loop
+from kombu.async.hub import Hub
 
 from .base import Request, Headers, Response
 
@@ -17,7 +18,21 @@ def get_client(hub=None, **kwargs):
     """Get or create HTTP client bound to the current event loop."""
     hub = hub or get_event_loop()
     try:
-        return hub._current_http_client
+        if not hub:
+            hub = Hub()
+            set_event_loop(hub)
+
+        client = Client(hub, **kwargs)
+        return client
     except AttributeError:
-        client = hub._current_http_client = Client(hub, **kwargs)
+        
+        # What should happen on error?
+        # It appears to impact the message.ack() going
+        # back to SQS for issues like:
+        # https://github.com/celery/kombu/issues/746
+        if not hub:
+            hub = Hub()
+            set_event_loop(hub)
+
+        client = Client(hub, **kwargs)
         return client

--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -371,14 +371,16 @@ class Channel(virtual.Channel):
         return super(Channel, self)._restore(message)
 
     def basic_ack(self, delivery_tag, multiple=False):
+        message = {}
+        sqs_message = {}
         try:
             message = self.qos.get(delivery_tag).delivery_info
             sqs_message = message['sqs_message']
         except KeyError:
             pass
         else:
-            self.asynsqs.delete_message(message['sqs_queue'],
-                                        sqs_message['ReceiptHandle'])
+            self._sqs.delete_message(QueueUrl=message['sqs_queue'],
+                                     ReceiptHandle=sqs_message['ReceiptHandle'])
         super(Channel, self).basic_ack(delivery_tag)
 
     def _size(self, queue):


### PR DESCRIPTION
Thanks for putting together such a great project. Kombu is awesome!

I hit this issue and believe this PR can help:
https://github.com/celery/kombu/issues/746

I noticed ``hub._current_http_client`` was not defined on master and the async SQS client was never deleting messages in my SQS test queue. When I called ``message.ack()`` it would respond (after fixing ``get_client()``) but messages would go to **In Flight** instead of being deleted. 

The changes below seem to work, but I do not know the internals of the ``kombu.async.hub`` or how this could impact other SQS actions.

Thanks again!

