### PR TITLE
fix of version recon  - ValueError: invalid literal for int() with ba…

### DIFF
--- a/kombu/transport/mongodb.py
+++ b/kombu/transport/mongodb.py
@@ -303,7 +303,7 @@ class Channel(virtual.Channel):
         database = mongoconn[dbname]
 
         version_str = mongoconn.server_info()['version']
-        version = tuple(map(int, version_str.split('.')))
+        version = tuple(map(int, version_str.split("-")[0].split('.')))
 
         if version < (1, 3):
             raise VersionMismatch(E_SERVER_VERSION.format(version_str))


### PR DESCRIPTION
…se 10: '6-1'

```
version = tuple(map(int, version_str.split('.')))
ValueError: invalid literal for int() with base 10: '6-1'

3.4.6-1.7
```