### PR TITLE
Prevent spurious exception on Resource.resize(0)

### DIFF
--- a/t/unit/test_pools.py
+++ b/t/unit/test_pools.py
@@ -208,6 +208,13 @@ class test_PoolGroup:
 
         pools.set_limit(pools.get_limit())
 
+    def test_remove_limit(self):
+        conn = Connection('memory://')
+        pool = pools.connections[conn]
+        pool.limit = 10
+        with pool.acquire():
+            pool.limit = 0
+
 
 class test_fun_PoolGroup:
 


### PR DESCRIPTION
`Resource.resize()` raises an exception if the pool is in use and the new size is smaller than the old size. However, it also raises this exception when the new size is zero, which should correspond to disabling the pool. Instead of shrinking the pool to zero and releasing all resources, we can simply dequeue all resources and forget about them.

Refs #781 