### PR TITLE
"Reentrant" version, that allows a `celery.bin.celery.main` worker to run multiple times

### DIFF
--- a/kombu/asynchronous/hub.py
+++ b/kombu/asynchronous/hub.py
@@ -99,19 +99,25 @@ class Hub(object):
 
         self._create_poller()
 
+    @property
+    def poller(self):
+        if not self._poller:
+            self._create_poller()
+        return self._poller
+
     def reset(self):
         self.close()
         self._create_poller()
 
     def _create_poller(self):
-        self.poller = poll()
-        self._register_fd = self.poller.register
-        self._unregister_fd = self.poller.unregister
+        self._poller = poll()
+        self._register_fd = self._poller.register
+        self._unregister_fd = self._poller.unregister
 
     def _close_poller(self):
-        if self.poller is not None:
-            self.poller.close()
-            self.poller = None
+        if self._poller is not None:
+            self._poller.close()
+            self._poller = None
             self._register_fd = None
             self._unregister_fd = None
 
@@ -261,8 +267,6 @@ class Hub(object):
                     Empty=Empty, StopIteration=StopIteration,
                     KeyError=KeyError, READ=READ, WRITE=WRITE, ERR=ERR):
         readers, writers = self.readers, self.writers
-        if not self.poller:
-            self._create_poller()
         poll = self.poller.poll
         fire_timers = self.fire_timers
         hub_remove = self.remove

--- a/kombu/asynchronous/hub.py
+++ b/kombu/asynchronous/hub.py
@@ -105,6 +105,10 @@ class Hub(object):
             self._create_poller()
         return self._poller
 
+    @poller.setter
+    def poller(self, value):
+        self._poller = value
+
     def reset(self):
         self.close()
         self._create_poller()

--- a/kombu/asynchronous/hub.py
+++ b/kombu/asynchronous/hub.py
@@ -261,6 +261,8 @@ class Hub(object):
                     Empty=Empty, StopIteration=StopIteration,
                     KeyError=KeyError, READ=READ, WRITE=WRITE, ERR=ERR):
         readers, writers = self.readers, self.writers
+        if not self.poller:
+            self._create_poller()
         poll = self.poller.poll
         fire_timers = self.fire_timers
         hub_remove = self.remove

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -280,8 +280,6 @@ class MultiChannelPoller(object):
         sock = client.connection._sock
         self._fd_to_chan[sock.fileno()] = (channel, type)
         self._chan_to_sock[(channel, client, type)] = sock
-        if not self.poller:
-            self.poller = poll()
         self.poller.register(sock, self.eventflags)
 
     def _unregister(self, channel, client, type):

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -280,6 +280,8 @@ class MultiChannelPoller(object):
         sock = client.connection._sock
         self._fd_to_chan[sock.fileno()] = (channel, type)
         self._chan_to_sock[(channel, client, type)] = sock
+        if not self.poller:
+            self.poller = poll()
         self.poller.register(sock, self.eventflags)
 
     def _unregister(self, channel, client, type):

--- a/t/unit/asynchronous/test_hub.py
+++ b/t/unit/asynchronous/test_hub.py
@@ -239,6 +239,14 @@ class test_Hub:
         self.hub.close()
         poller.close.assert_called_with()
 
+    def test_poller_regeneration_on_access(self):
+        self.hub = Hub()
+        assert self.hub.poller
+        self.hub.stop()
+        self.hub.close()
+        assert self.hub._poller is None
+        assert self.hub.poller, 'It should be regenerated automatically!'
+
     def test_fire_timers(self):
         self.hub.timer = Mock()
         self.hub.timer._queue = []

--- a/t/unit/asynchronous/test_hub.py
+++ b/t/unit/asynchronous/test_hub.py
@@ -176,7 +176,7 @@ class test_Hub:
         poller = self.hub.poller = Mock(name='poller')
         self.hub._close_poller()
         poller.close.assert_called_with()
-        assert self.hub.poller is None
+        assert self.hub._poller is None
 
     def test_stop(self):
         self.hub.call_soon = Mock(name='call_soon')


### PR DESCRIPTION
The actual version does not allow `celery.bin.celery.main` to run, raise a SystemExit, catch it and then run again. (See: https://github.com/alanjds/celery-serverless/commit/a23f79d3cfe17ed8a91003707af4a5dd1e2aa542#diff-b4826aeb276ca699cf1adda1903fe3eaR55)

To allow it, the `kombu.async.hub.Hub.poller` became a @property that regenerates on access. And the Redis backend tries to recreate it before acessing, if needed.

Indeed, `celery.worker.state.should_{stop,terminate}` should be reset after every SystemExit for it to work, but this part is a patch not for Kombu repo ;) .
(See: https://github.com/alanjds/celery-serverless/commit/a23f79d3cfe17ed8a91003707af4a5dd1e2aa542#diff-b4826aeb276ca699cf1adda1903fe3eaR57)