### PR TITLE
Handle librabbitmq fileno socket not connected raising ValueError

### DIFF
--- a/kombu/transport/librabbitmq.py
+++ b/kombu/transport/librabbitmq.py
@@ -146,7 +146,7 @@ class Transport(base.Transport):
                 channel.connection = None
             try:
                 os.close(connection.fileno())
-            except OSError:
+            except (OSError, ValueError):
                 pass
             connection.channels.clear()
             connection.callbacks.clear()

--- a/t/unit/transport/test_librabbitmq.py
+++ b/t/unit/transport/test_librabbitmq.py
@@ -125,6 +125,15 @@ class test_Transport(lrmqCase):
             self.T._collect(conn)
             close.assert_called_with(conn.fileno())
 
+    def test_collect__with_fileno_raising_value_error(self):
+        conn = Mock(name='connection')
+        conn.channels = {1: Mock(name='chan1'), 2: Mock(name='chan2')}
+        with patch('os.close') as close:
+            self.T.client = self.client
+            conn.fileno.side_effect = ValueError("Socket not connected")
+            self.T._collect(conn)
+            close.assert_not_called()
+
     def test_register_with_event_loop(self):
         conn = Mock(name='conn')
         loop = Mock(name='loop')

--- a/t/unit/transport/test_librabbitmq.py
+++ b/t/unit/transport/test_librabbitmq.py
@@ -133,6 +133,7 @@ class test_Transport(lrmqCase):
             conn.fileno.side_effect = ValueError("Socket not connected")
             self.T._collect(conn)
             close.assert_not_called()
+        conn.fileno.assert_called_with()
         assert self.client.drain_events is None
         assert self.T.client is None
 

--- a/t/unit/transport/test_librabbitmq.py
+++ b/t/unit/transport/test_librabbitmq.py
@@ -133,6 +133,8 @@ class test_Transport(lrmqCase):
             conn.fileno.side_effect = ValueError("Socket not connected")
             self.T._collect(conn)
             close.assert_not_called()
+        assert self.client.drain_events is None
+        assert self.T.client is None
 
     def test_register_with_event_loop(self):
         conn = Mock(name='conn')


### PR DESCRIPTION
Hi, I believe this will solve #860. Because librabbitmq connection's fileno method will raise `ValueError` (https://github.com/celery/librabbitmq/issues/39) if the socket has unexpected been closed, this was escaping being caught when running `os.close`, preventing publish connection retries if the socket disappeared.

Closes #860.