### PR TITLE
don't cache declaration of expiring queues

### DIFF
--- a/kombu/entity.py
+++ b/kombu/entity.py
@@ -804,7 +804,11 @@ class Queue(MaybeChannelBound):
 
     @property
     def can_cache_declaration(self):
-        return not self.auto_delete
+        if self.queue_arguments:
+            expiring_queue = "x-expires" in self.queue_arguments
+        else:
+            expiring_queue = False
+        return not expiring_queue and not self.auto_delete
 
     @classmethod
     def from_dict(cls, queue, **options):

--- a/t/unit/test_entity.py
+++ b/t/unit/test_entity.py
@@ -319,6 +319,9 @@ class test_Queue:
     def test_can_cache_declaration(self):
         assert Queue('a', durable=True).can_cache_declaration
         assert Queue('a', durable=False).can_cache_declaration
+        assert not Queue(
+            'a', queue_arguments={'x-expires': 100}
+        ).can_cache_declaration
 
     def test_eq(self):
         q1 = Queue('xxx', Exchange('xxx', 'direct'), 'xxx')


### PR DESCRIPTION
Queues that are declared with a TTL should also be excluded from the cache in case they expire between publishes on the same channel.