### PR TITLE
Update all pypi.python.org URLs to pypi.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@
 
 :Version: 4.2.1
 :Web: http://kombu.me/
-:Download: https://pypi.python.org/pypi/kombu/
+:Download: https://pypi.org/project/kombu/
 :Source: https://github.com/celery/kombu/
 :Keywords: messaging, amqp, rabbitmq, redis, mongodb, python, queue
 
@@ -64,16 +64,16 @@ and the `Wikipedia article about AMQP`_.
 
 .. _`RabbitMQ`: https://www.rabbitmq.com/
 .. _`AMQP`: https://amqp.org
-.. _`py-amqp`: https://pypi.python.org/pypi/amqp/
-.. _`qpid-python`: https://pypi.python.org/pypi/qpid-python/
+.. _`py-amqp`: https://pypi.org/project/amqp/
+.. _`qpid-python`: https://pypi.org/project/qpid-python/
 .. _`Redis`: https://redis.io
 .. _`Amazon SQS`: https://aws.amazon.com/sqs/
 .. _`Zookeeper`: https://zookeeper.apache.org/
 .. _`Rabbits and warrens`: http://web.archive.org/web/20160323134044/http://blogs.digitar.com/jjww/2009/01/rabbits-and-warrens/
 .. _`amqplib`: https://barryp.org/software/py-amqplib/
 .. _`Wikipedia article about AMQP`: https://en.wikipedia.org/wiki/AMQP
-.. _`carrot`: https://pypi.python.org/pypi/carrot/
-.. _`librabbitmq`: https://pypi.python.org/pypi/librabbitmq
+.. _`carrot`: https://pypi.org/project/carrot/
+.. _`librabbitmq`: https://pypi.org/project/librabbitmq/
 .. _`Pyro`: https://pythonhosting.org/Pyro4
 .. _`SoftLayer MQ`: https://sldn.softlayer.com/reference/messagequeueapi
 
@@ -346,14 +346,14 @@ file in the top distribution directory for the full license text.
 
 .. |wheel| image:: https://img.shields.io/pypi/wheel/kombu.svg
     :alt: Kombu can be installed via wheel
-    :target: https://pypi.python.org/pypi/kombu/
+    :target: https://pypi.org/project/kombu/
 
 .. |pyversion| image:: https://img.shields.io/pypi/pyversions/kombu.svg
     :alt: Supported Python versions.
-    :target: https://pypi.python.org/pypi/kombu/
+    :target: https://pypi.org/project/kombu/
 
 .. |pyimp| image:: https://img.shields.io/pypi/implementation/kombu.svg
     :alt: Support Python implementations.
-    :target: https://pypi.python.org/pypi/kombu/
+    :target: https://pypi.org/project/kombu/
 --
 

--- a/docs/includes/introduction.txt
+++ b/docs/includes/introduction.txt
@@ -1,6 +1,6 @@
 :Version: 4.2.1
 :Web: http://kombu.me/
-:Download: http://pypi.python.org/pypi/kombu/
+:Download: https://pypi.org/project/kombu/
 :Source: https://github.com/celery/kombu/
 :Keywords: messaging, amqp, rabbitmq, redis, mongodb, python, queue
 
@@ -58,16 +58,16 @@ and the `Wikipedia article about AMQP`_.
 
 .. _`RabbitMQ`: https://www.rabbitmq.com/
 .. _`AMQP`: https://amqp.org
-.. _`py-amqp`: https://pypi.python.org/pypi/amqp/
-.. _`qpid-python`: https://pypi.python.org/pypi/qpid-python/
+.. _`py-amqp`: https://pypi.org/project/amqp/
+.. _`qpid-python`: https://pypi.org/project/qpid-python/
 .. _`Redis`: https://redis.io/
 .. _`Amazon SQS`: https://aws.amazon.com/sqs/
 .. _`Zookeeper`: https://zookeeper.apache.org/
 .. _`Rabbits and warrens`: http://web.archive.org/web/20160323134044/http://blogs.digitar.com/jjww/2009/01/rabbits-and-warrens/
 .. _`amqplib`: http://barryp.org/software/py-amqplib/
 .. _`Wikipedia article about AMQP`: http://en.wikipedia.org/wiki/AMQP
-.. _`carrot`: http://pypi.python.org/pypi/carrot/
-.. _`librabbitmq`: http://pypi.python.org/pypi/librabbitmq
+.. _`carrot`: https://pypi.org/project/carrot/
+.. _`librabbitmq`: https://pypi.org/project/librabbitmq/
 .. _`Pyro`: http://pythonhosted.org/Pyro4/
 .. _`SoftLayer MQ`: http://www.softlayer.com/services/additional/message-queue
 

--- a/docs/reference/kombu.serialization.rst
+++ b/docs/reference/kombu.serialization.rst
@@ -43,9 +43,9 @@
 
     .. autodata:: registry
 
-.. _`cjson`: https://pypi.python.org/pypi/python-cjson/
+.. _`cjson`: https://pypi.org/project/python-cjson/
 .. _`simplejson`: https://github.com/simplejson/simplejson
 .. _`Python 2.7+`: https://docs.python.org/library/json.html
 .. _`PyYAML`: https://pyyaml.org/
 .. _`msgpack`: https://msgpack.org/
-.. _`msgpack-python`: https://pypi.python.org/pypi/msgpack-python/
+.. _`msgpack-python`: https://pypi.org/project/msgpack-python/

--- a/docs/templates/readme.txt
+++ b/docs/templates/readme.txt
@@ -23,13 +23,13 @@
 
 .. |wheel| image:: https://img.shields.io/pypi/wheel/kombu.svg
     :alt: Kombu can be installed via wheel
-    :target: http://pypi.python.org/pypi/kombu/
+    :target: https://pypi.org/project/kombu/
 
 .. |pyversion| image:: https://img.shields.io/pypi/pyversions/kombu.svg
     :alt: Supported Python versions.
-    :target: http://pypi.python.org/pypi/kombu/
+    :target: https://pypi.org/project/kombu/
 
 .. |pyimp| image:: https://img.shields.io/pypi/implementation/kombu.svg
     :alt: Support Python implementations.
-    :target: http://pypi.python.org/pypi/kombu/
+    :target: https://pypi.org/project/kombu/
 --

--- a/kombu/compat.py
+++ b/kombu/compat.py
@@ -1,6 +1,6 @@
 """Carrot compatibility interface.
 
-See https://pypi.python.org/pypi/carrot for documentation.
+See https://pypi.org/project/carrot/ for documentation.
 """
 from __future__ import absolute_import, unicode_literals
 

--- a/kombu/transport/qpid.py
+++ b/kombu/transport/qpid.py
@@ -24,8 +24,8 @@ or to install the requirements manually:
     tested and works with with Python 2.7.
 
 .. _`Qpid`: https://qpid.apache.org/
-.. _`qpid-python`: https://pypi.python.org/pypi/qpid-python/
-.. _`qpid-tools`: https://pypi.python.org/pypi/qpid-tools/
+.. _`qpid-python`: https://pypi.org/project/qpid-python/
+.. _`qpid-tools`: https://pypi.org/project/qpid-tools/
 
 Authentication
 ==============

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ for scheme in list(INSTALL_SCHEMES.values()):
 if os.path.exists('README.rst'):
     long_description = codecs.open('README.rst', 'r', 'utf-8').read()
 else:
-    long_description = 'See https://pypi.python.org/pypi/kombu'
+    long_description = 'See https://pypi.org/project/kombu/'
 
 # -*- Installation Requires -*-
 py_version = sys.version_info


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html