### PR TITLE
Fixed SQS queue name parsing for queue names ending with an "f"

### DIFF
--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -153,7 +153,9 @@ class Channel(virtual.Channel):
     def entity_name(self, name, table=CHARS_REPLACE_TABLE):
         """Format AMQP queue name into a legal SQS queue name."""
         if name.endswith('.fifo'):
-            partial = name.rstrip('.fifo')
+            # SQS allows no dots in queue names with one exception being FIFO queues
+            # For FIFO queues only one dot is allowed in '.fifo' suffix
+            partial = name.split('.')[:1][0]
             partial = text_t(safe_str(partial)).translate(table)
             return partial + '.fifo'
         else:


### PR DESCRIPTION
Due to improper use of 'rstrip' queue names ending with an 'f' will not be parsed properly

```
>>> queue_name_ending_with_an_f = 'queue_name_ending_with_an_f.fifo'
>>> queue_name_ending_with_an_f.rstrip('.fifo')
'queue_name_ending_with_an_'
>>> queue_name_ending_with_an_f.split('.')[:1][0]
'queue_name_ending_with_an_f'
>>>
```