### PR TITLE
fix librabbitmq link error

### DIFF
--- a/kombu/transport/librabbitmq.py
+++ b/kombu/transport/librabbitmq.py
@@ -1,6 +1,6 @@
 """`librabbitmq`_ transport.
 
-.. _`librabbitmq`: https://pypi.python.org/librabbitmq/
+.. _`librabbitmq`: https://pypi.python.org/pypi/librabbitmq/
 """
 from __future__ import absolute_import, unicode_literals
 


### PR DESCRIPTION
we couldn't find `https://pypi.python.org/librabbitmq/`  on pypi, and i modify it to `https://pypi.python.org/pypi/librabbitmq/`