### PR TITLE
Add transports based on Azure PaaS

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -25,6 +25,7 @@ omit =
     *kombu/transport/zmq.py
     *kombu/transport/django.py
     *kombu/transport/pyro.py
+    *kombu/transport/azure*
     *kombu/transport/qpid*
 exclude_lines =
     pragma: no cover

--- a/docs/includes/introduction.txt
+++ b/docs/includes/introduction.txt
@@ -35,7 +35,8 @@ Features
 
     * Virtual transports makes it really easy to add support for non-AMQP
       transports. There is already built-in support for `Redis`_,
-      `Amazon SQS`_, `ZooKeeper`_, `SoftLayer MQ`_ and `Pyro`_.
+      `Amazon SQS`_, `Azure Storage Queues`_, `Azure Service Bus`_,
+      `ZooKeeper`_, `SoftLayer MQ`_ and `Pyro`_.
 
     * In-memory transport for unit testing.
 
@@ -62,6 +63,8 @@ and the `Wikipedia article about AMQP`_.
 .. _`qpid-python`: https://pypi.org/project/qpid-python/
 .. _`Redis`: https://redis.io/
 .. _`Amazon SQS`: https://aws.amazon.com/sqs/
+.. _`Azure Storage Queues`: https://azure.microsoft.com/en-us/services/storage/queues/
+.. _`Azure Service Bus`: https://azure.microsoft.com/en-us/services/service-bus/
 .. _`Zookeeper`: https://zookeeper.apache.org/
 .. _`Rabbits and warrens`: http://web.archive.org/web/20160323134044/http://blogs.digitar.com/jjww/2009/01/rabbits-and-warrens/
 .. _`amqplib`: http://barryp.org/software/py-amqplib/

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -38,6 +38,8 @@
     kombu.asynchronous.aws.sqs.message
     kombu.asynchronous.aws.sqs.queue
     kombu.transport
+    kombu.transport.azurestoragequeues
+    kombu.transport.azureservicebus
     kombu.transport.pyamqp
     kombu.transport.librabbitmq
     kombu.transport.qpid

--- a/docs/reference/kombu.transport.azureservicebus.rst
+++ b/docs/reference/kombu.transport.azureservicebus.rst
@@ -1,0 +1,24 @@
+==================================================================
+ Azure Service Bus Transport - ``kombu.transport.azureservicebus``
+==================================================================
+
+.. currentmodule:: kombu.transport.azureservicebus
+
+.. automodule:: kombu.transport.azureservicebus
+
+    .. contents::
+        :local:
+
+    Transport
+    ---------
+
+    .. autoclass:: Transport
+        :members:
+        :undoc-members:
+
+    Channel
+    -------
+
+    .. autoclass:: Channel
+        :members:
+        :undoc-members:

--- a/docs/reference/kombu.transport.azurestoragequeues.rst
+++ b/docs/reference/kombu.transport.azurestoragequeues.rst
@@ -1,0 +1,24 @@
+========================================================================
+ Azure Storage Queues Transport - ``kombu.transport.azurestoragequeues``
+========================================================================
+
+.. currentmodule:: kombu.transport.azurestoragequeues
+
+.. automodule:: kombu.transport.azurestoragequeues
+
+    .. contents::
+        :local:
+
+    Transport
+    ---------
+
+    .. autoclass:: Transport
+        :members:
+        :undoc-members:
+
+    Channel
+    -------
+
+    .. autoclass:: Channel
+        :members:
+        :undoc-members:

--- a/kombu/transport/__init__.py
+++ b/kombu/transport/__init__.py
@@ -38,6 +38,8 @@ TRANSPORT_ALIASES = {
     'sentinel': 'kombu.transport.redis:SentinelTransport',
     'consul': 'kombu.transport.consul:Transport',
     'etcd': 'kombu.transport.etcd:Transport',
+    'azurestoragequeues': 'kombu.transport.azurestoragequeues:Transport',
+    'azureservicebus': 'kombu.transport.azureservicebus:Transport'
 }
 
 _transport_cache = {}

--- a/kombu/transport/azureservicebus.py
+++ b/kombu/transport/azureservicebus.py
@@ -19,7 +19,6 @@ https://azure.microsoft.com/en-us/services/service-bus/
 """
 from __future__ import absolute_import, unicode_literals
 
-from os import getenv
 import string
 
 from kombu.five import Empty, text_t
@@ -118,12 +117,9 @@ class Channel(virtual.Channel):
     def sbq(self):
         if self._sbq is None:
             self._sbq = ServiceBusService(
-                service_namespace=getenv('AZURE_SERVICEBUS_ACCOUNT',
-                                         self.conninfo.hostname),
-                shared_access_key_name=getenv('AZURE_SERVICEBUS_KEY_NAME',
-                                              self.conninfo.userid),
-                shared_access_key_value=getenv('AZURE_SERVICEBUS_KEY_VALUE',
-                                               self.conninfo.password))
+                service_namespace=self.conninfo.hostname,
+                shared_access_key_name=self.conninfo.userid,
+                shared_access_key_value=self.conninfo.password)
 
         return self._sbq
 

--- a/kombu/transport/azureservicebus.py
+++ b/kombu/transport/azureservicebus.py
@@ -1,0 +1,154 @@
+"""Azure Service Bus Message Queue transport.
+
+The transport can be enabled by setting the CELERY_BROKER_URL to:
+
+```
+azureservicebus://{SAS policy name}:{SAS key}@{Service Bus Namespace}
+```
+
+Note that the Shared Access Policy used to connect to Azure Service Bus
+requires Manage, Send and Listen claims since the broker will create new
+queues and delete old queues as required.
+
+Note that if the SAS key for the Service Bus account contains a slash, it will
+have to be regenerated before it can be used in the connection URL.
+
+More information about Azure Service Bus:
+https://azure.microsoft.com/en-us/services/service-bus/
+
+"""
+from __future__ import absolute_import, unicode_literals
+
+from os import getenv
+import string
+
+from kombu.five import Empty, text_t
+from kombu.utils.encoding import bytes_to_str, safe_str
+from kombu.utils.json import loads, dumps
+from kombu.utils.objects import cached_property
+
+from . import virtual
+
+try:
+    from azure.servicebus import ServiceBusService, Message, Queue
+except ImportError:
+    ServiceBusService = Message = Queue = None
+
+# dots are replaced by dash, all other punctuation replaced by underscore.
+CHARS_REPLACE_TABLE = {
+    ord(c): 0x5f for c in string.punctuation if c not in '_'
+}
+
+
+class Channel(virtual.Channel):
+    """Azure Service Bus channel."""
+
+    default_visibility_timeout = 1800  # 30 minutes.
+    domain_format = 'kombu%(vhost)s'
+    _sbq = None
+    _queue_cache = {}
+
+    def __init__(self, *args, **kwargs):
+        if ServiceBusService is None:
+            raise ImportError('Azure Service Bus transport requires the '
+                              'azure-servicebus library')
+
+        super(Channel, self).__init__(*args, **kwargs)
+
+        for queue in self.sbq.list_queues():
+            self._queue_cache[queue] = queue
+
+    def entity_name(self, name, table=CHARS_REPLACE_TABLE):
+        """Format AMQP queue name into a valid ServiceBus queue name."""
+        return text_t(safe_str(name)).translate(table)
+
+    def _new_queue(self, queue, **kwargs):
+        """Ensure a queue exists in ServiceBus."""
+        queue = self.entity_name(self.queue_name_prefix + queue)
+        try:
+            return self._queue_cache[queue]
+        except KeyError:
+            self.sbq.create_queue(queue, fail_on_exist=False)
+            q = self._queue_cache[queue] = self.sbq.get_queue(queue)
+            return q
+
+    def _delete(self, queue, *args, **kwargs):
+        """Delete queue by name."""
+        queue_name = self.entity_name(queue)
+        self._queue_cache.pop(queue_name, None)
+        self.sbq.delete_queue(queue_name)
+        super(Channel, self)._delete(queue_name)
+
+    def _put(self, queue, message, **kwargs):
+        """Put message onto queue."""
+        msg = Message(dumps(message))
+        self.sbq.send_queue_message(self.entity_name(queue), msg)
+
+    def _get(self, queue, timeout=None):
+        """Try to retrieve a single message off ``queue``."""
+        message = self.sbq.receive_queue_message(self.entity_name(queue),
+                                                 timeout=timeout,
+                                                 peek_lock=False)
+
+        if message.body is None:
+            raise Empty()
+
+        return loads(bytes_to_str(message.body))
+
+    def _size(self, queue):
+        """Return the number of messages in a queue."""
+        return self._new_queue(queue).message_count
+
+    def _purge(self, queue):
+        """Delete all current messages in a queue."""
+        n = 0
+
+        while True:
+            message = self.sbq.read_delete_queue_message(
+                self.entity_name(queue), timeout=0.1)
+
+            if not message.body:
+                break
+            else:
+                n += 1
+
+        return n
+
+    @property
+    def sbq(self):
+        if self._sbq is None:
+            self._sbq = ServiceBusService(
+                service_namespace=getenv('AZURE_SERVICEBUS_ACCOUNT',
+                                         self.conninfo.hostname),
+                shared_access_key_name=getenv('AZURE_SERVICEBUS_KEY_NAME',
+                                              self.conninfo.userid),
+                shared_access_key_value=getenv('AZURE_SERVICEBUS_KEY_VALUE',
+                                               self.conninfo.password))
+
+        return self._sbq
+
+    @property
+    def conninfo(self):
+        return self.connection.client
+
+    @property
+    def transport_options(self):
+        return self.connection.client.transport_options
+
+    @cached_property
+    def visibility_timeout(self):
+        return (self.transport_options.get('visibility_timeout') or
+                self.default_visibility_timeout)
+
+    @cached_property
+    def queue_name_prefix(self):
+        return self.transport_options.get('queue_name_prefix', '')
+
+
+class Transport(virtual.Transport):
+    """Azure Service Bus transport."""
+
+    Channel = Channel
+
+    polling_interval = 1
+    default_port = None

--- a/kombu/transport/azurestoragequeues.py
+++ b/kombu/transport/azurestoragequeues.py
@@ -1,0 +1,152 @@
+"""Azure Storage Queues transport.
+
+The transport can be enabled by setting the CELERY_BROKER_URL to:
+
+```
+azurestoragequeues://:{Storage Account Access Key}@{Storage Account Name}
+```
+
+Note that if the access key for the storage account contains a slash, it will
+have to be regenerated before it can be used in the connection URL.
+
+More information about Azure Storage Queues:
+https://azure.microsoft.com/en-us/services/storage/queues/
+
+"""
+from __future__ import absolute_import, unicode_literals
+
+from os import getenv
+import string
+
+from kombu.five import Empty, text_t
+from kombu.utils.encoding import safe_str
+from kombu.utils.json import loads, dumps
+from kombu.utils.objects import cached_property
+
+from . import virtual
+
+try:
+    from azure.storage.queue import QueueService
+except ImportError:  # pragma: no cover
+    QueueService = None  # noqa
+
+# Azure storage queues allow only alphanumeric and dashes
+# so, replace everything with a dash
+CHARS_REPLACE_TABLE = {
+    ord(c): 0x2d for c in string.punctuation
+}
+
+
+class Channel(virtual.Channel):
+    """Azure Storage Queues channel."""
+
+    domain_format = 'kombu%(vhost)s'
+    _azq = None
+    _queue_name_cache = {}
+    no_ack = True
+    _noack_queues = set()
+
+    def __init__(self, *args, **kwargs):
+        if QueueService is None:
+            raise ImportError('Azure Storage Queues transport requires the '
+                              'azure-storage-queue library')
+
+        super(Channel, self).__init__(*args, **kwargs)
+
+        for queue_name in self.azq.list_queues():
+            self._queue_name_cache[queue_name] = queue_name
+
+    def basic_consume(self, queue, no_ack, *args, **kwargs):
+        if no_ack:
+            self._noack_queues.add(queue)
+
+        return super(Channel, self).basic_consume(queue, no_ack,
+                                                  *args, **kwargs)
+
+    def entity_name(self, name, table=CHARS_REPLACE_TABLE):
+        """Format AMQP queue name into a valid Azure Storage Queue name."""
+        return text_t(safe_str(name)).translate(table)
+
+    def _ensure_queue(self, queue):
+        """Ensure a queue exists."""
+        queue = self.entity_name(self.queue_name_prefix + queue)
+        try:
+            return self._queue_name_cache[queue]
+        except KeyError:
+            self.azq.create_queue(queue, fail_on_exist=False)
+            q = self._queue_name_cache[queue] = queue
+            return q
+
+    def _delete(self, queue, *args, **kwargs):
+        """Delete queue by name."""
+        queue_name = self.entity_name(queue)
+        self._queue_name_cache.pop(queue_name, None)
+        self.azq.delete_queue(queue_name)
+        super(Channel, self)._delete(queue_name)
+
+    def _put(self, queue, message, **kwargs):
+        """Put message onto queue."""
+        q = self._ensure_queue(queue)
+        encoded_message = dumps(message)
+        self.azq.put_message(q, encoded_message)
+
+    def _get(self, queue, timeout=None):
+        """Try to retrieve a single message off ``queue``."""
+        q = self._ensure_queue(queue)
+
+        messages = self.azq.get_messages(q, num_messages=1, timeout=timeout)
+        if not messages:
+            raise Empty()
+
+        message = messages[0]
+        raw_content = self.azq.decode_function(message.content)
+        content = loads(raw_content)
+
+        self.azq.delete_message(q, message.id, message.pop_receipt)
+
+        return content
+
+    def _size(self, queue):
+        """Return the number of messages in a queue."""
+        q = self._ensure_queue(queue)
+        metadata = self.azq.get_queue_metadata(q)
+        return metadata.approximate_message_count
+
+    def _purge(self, queue):
+        """Delete all current messages in a queue."""
+        q = self._ensure_queue(queue)
+        n = self._size(q)
+        self.azq.clear_messages(q)
+        return n
+
+    @property
+    def azq(self):
+        if self._azq is None:
+            self._azq = QueueService(
+                account_name=getenv('AZURE_STORAGE_ACCOUNT',
+                                    self.conninfo.hostname),
+                account_key=getenv('AZURE_STORAGE_ACCESS_KEY',
+                                   self.conninfo.password))
+
+        return self._azq
+
+    @property
+    def conninfo(self):
+        return self.connection.client
+
+    @property
+    def transport_options(self):
+        return self.connection.client.transport_options
+
+    @cached_property
+    def queue_name_prefix(self):
+        return self.transport_options.get('queue_name_prefix', '')
+
+
+class Transport(virtual.Transport):
+    """Azure Storage Queues transport."""
+
+    Channel = Channel
+
+    polling_interval = 1
+    default_port = None

--- a/kombu/transport/azurestoragequeues.py
+++ b/kombu/transport/azurestoragequeues.py
@@ -15,7 +15,6 @@ https://azure.microsoft.com/en-us/services/storage/queues/
 """
 from __future__ import absolute_import, unicode_literals
 
-from os import getenv
 import string
 
 from kombu.five import Empty, text_t
@@ -123,10 +122,8 @@ class Channel(virtual.Channel):
     def azq(self):
         if self._azq is None:
             self._azq = QueueService(
-                account_name=getenv('AZURE_STORAGE_ACCOUNT',
-                                    self.conninfo.hostname),
-                account_key=getenv('AZURE_STORAGE_ACCESS_KEY',
-                                   self.conninfo.password))
+                account_name=self.conninfo.hostname,
+                account_key=self.conninfo.password)
 
         return self._azq
 

--- a/requirements/extras/azureservicebus.txt
+++ b/requirements/extras/azureservicebus.txt
@@ -1,0 +1,1 @@
+azure-servicebus>=0.21.1

--- a/requirements/extras/azurestoragequeues.txt
+++ b/requirements/extras/azurestoragequeues.txt
@@ -1,0 +1,1 @@
+azure-storage-queue

--- a/requirements/test-ci.txt
+++ b/requirements/test-ci.txt
@@ -3,6 +3,8 @@ codecov
 redis
 PyYAML
 msgpack-python>0.2.0
+-r extras/azureservicebus.txt
+-r extras/azurestoragequeues.txt
 -r extras/sqs.txt
 -r extras/consul.txt
 -r extras/librabbitmq.txt

--- a/setup.py
+++ b/setup.py
@@ -130,6 +130,8 @@ setup(
         'librabbitmq': extras('librabbitmq.txt'),
         'pyro': extras('pyro.txt'),
         'slmq': extras('slmq.txt'),
+        'azurestoragequeues': extras('azurestoragequeues.txt'),
+        'azureservicebus': extras('azureservicebus.txt'),
         'qpid': extras('qpid.txt'),
         'consul': extras('consul.txt'),
     },

--- a/t/integration/tests/test_azureservicebus.py
+++ b/t/integration/tests/test_azureservicebus.py
@@ -5,9 +5,7 @@ from t.integration import transport
 from case import skip
 
 
-@skip.unless_environ('AZURE_SERVICEBUS_ACCOUNT')
-@skip.unless_environ('AZURE_SERVICEBUS_KEY_NAME')
-@skip.unless_environ('AZURE_SERVICEBUS_KEY_VALUE')
+@skip.unless_module('azure.servicebus')
 class test_azureservicebus(transport.TransportCase):
     transport = 'azureservicebus'
     prefix = 'azureservicebus'

--- a/t/integration/tests/test_azureservicebus.py
+++ b/t/integration/tests/test_azureservicebus.py
@@ -1,0 +1,14 @@
+from __future__ import absolute_import, unicode_literals
+
+from t.integration import transport
+
+from case import skip
+
+
+@skip.unless_environ('AZURE_SERVICEBUS_ACCOUNT')
+@skip.unless_environ('AZURE_SERVICEBUS_KEY_NAME')
+@skip.unless_environ('AZURE_SERVICEBUS_KEY_VALUE')
+class test_azureservicebus(transport.TransportCase):
+    transport = 'azureservicebus'
+    prefix = 'azureservicebus'
+    message_size_limit = 32000

--- a/t/integration/tests/test_azurestoragequeues.py
+++ b/t/integration/tests/test_azurestoragequeues.py
@@ -1,0 +1,17 @@
+from __future__ import absolute_import, unicode_literals
+
+from t.integration import transport
+
+from case import skip
+
+
+@skip.unless_environ('AZURE_STORAGE_ACCOUNT')
+@skip.unless_environ('AZURE_STORAGE_ACCESS_KEY')
+class test_azurestoragequeues(transport.TransportCase):
+    transport = 'azurestoragequeues'
+    prefix = 'azurestoragequeues'
+    event_loop_max = 100
+    message_size_limit = 32000
+    reliable_purge = False
+    #: does not guarantee FIFO order, even in simple cases.
+    suppress_disorder_warning = True

--- a/t/integration/tests/test_azurestoragequeues.py
+++ b/t/integration/tests/test_azurestoragequeues.py
@@ -5,8 +5,7 @@ from t.integration import transport
 from case import skip
 
 
-@skip.unless_environ('AZURE_STORAGE_ACCOUNT')
-@skip.unless_environ('AZURE_STORAGE_ACCESS_KEY')
+@skip.unless_module('azure.storage.queue')
 class test_azurestoragequeues(transport.TransportCase):
     transport = 'azurestoragequeues'
     prefix = 'azurestoragequeues'


### PR DESCRIPTION
This pull request adds two new transport implementations:

- `azurestoragequeues` is implemented on top of [Azure Storage Queues](https://azure.microsoft.com/en-us/services/storage/queues/). This offers a simple but scalable and low-cost PaaS transport for Celery users in Azure. The transport is intended to be used in conjunction with the [Azure Block Blob Storage backend](https://github.com/celery/celery/pull/4685).

- `azureservicebus` is implemented on top of [Azure Service Bus](https://azure.microsoft.com/en-us/services/service-bus/) and offers PaaS support for more demanding Celery workloads in Azure. The transport is intended to be used in conjunction with the [Azure CosmosDB backend](https://github.com/celery/celery/pull/4720).

This pull request was created together with @ankurokok, @dkisselev, @evandropaula, @martinpeck and @michaelperel.