### PR TITLE
Making the pyro transport available, fix it for recent Pyro4 versions, add broker daemon

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -4,6 +4,13 @@
  Change history
 ================
 
+- the `Pyro`_ transport (:mod:`kombu.transport.pyro`) now works with
+  recent Pyro versions. Also added a Pyro Kombu Broker that this transport
+  needs for its queues.
+
+  Contributed by **Irmen de Jong**
+
+
 .. _version-4.2.1:
 
 4.2.1

--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ and the `Wikipedia article about AMQP`_.
 .. _`Wikipedia article about AMQP`: https://en.wikipedia.org/wiki/AMQP
 .. _`carrot`: https://pypi.org/project/carrot/
 .. _`librabbitmq`: https://pypi.org/project/librabbitmq/
-.. _`Pyro`: https://pythonhosting.org/Pyro4
+.. _`Pyro`: https://pyro4.readthedocs.io/
 .. _`SoftLayer MQ`: https://sldn.softlayer.com/reference/messagequeueapi
 
 .. _transport-comparison:
@@ -100,6 +100,8 @@ Transport Comparison
 | *in-memory*   | Virtual  | Yes        | Yes [#f1]_ | No            | No           | No                    |
 +---------------+----------+------------+------------+---------------+--------------+-----------------------+
 | *SLMQ*        | Virtual  | Yes        | Yes [#f1]_ | No            | No           | No                    |
++---------------+----------+------------+------------+---------------+--------------+-----------------------+
+| *Pyro*        | Virtual  | Yes        | Yes [#f1]_ | No            | No           | No                    |
 +---------------+----------+------------+------------+---------------+--------------+-----------------------+
 
 

--- a/docs/includes/introduction.txt
+++ b/docs/includes/introduction.txt
@@ -71,7 +71,7 @@ and the `Wikipedia article about AMQP`_.
 .. _`Wikipedia article about AMQP`: http://en.wikipedia.org/wiki/AMQP
 .. _`carrot`: https://pypi.org/project/carrot/
 .. _`librabbitmq`: https://pypi.org/project/librabbitmq/
-.. _`Pyro`: http://pythonhosted.org/Pyro4/
+.. _`Pyro`: https://pyro4.readthedocs.io/
 .. _`SoftLayer MQ`: http://www.softlayer.com/services/additional/message-queue
 
 .. _transport-comparison:
@@ -97,6 +97,8 @@ Transport Comparison
 | *in-memory*   | Virtual  | Yes        | Yes [#f1]_ | No            | No           | No                    |
 +---------------+----------+------------+------------+---------------+--------------+-----------------------+
 | *SLMQ*        | Virtual  | Yes        | Yes [#f1]_ | No            | No           | No                    |
++---------------+----------+------------+------------+---------------+--------------+-----------------------+
+| *Pyro*        | Virtual  | Yes        | Yes [#f1]_ | No            | No           | No                    |
 +---------------+----------+------------+------------+---------------+--------------+-----------------------+
 
 

--- a/docs/reference/kombu.transport.pyro.rst
+++ b/docs/reference/kombu.transport.pyro.rst
@@ -22,3 +22,10 @@
     .. autoclass:: Channel
         :members:
         :undoc-members:
+
+
+    KombuBroker
+    -----------
+
+    .. autoclass:: KombuBroker
+        :members:

--- a/docs/userguide/connections.rst
+++ b/docs/userguide/connections.rst
@@ -98,6 +98,10 @@ All of these are valid URLs:
     # Using virtual host 'foo'
     amqp://localhost/foo
 
+    # Using Pyro with name server running on 'localhost'
+    pyro://localhost/kombu.broker
+
+
 The query part of the URL can also be used to set options, e.g.:
 
 .. code-block:: text

--- a/kombu/transport/__init__.py
+++ b/kombu/transport/__init__.py
@@ -39,7 +39,8 @@ TRANSPORT_ALIASES = {
     'consul': 'kombu.transport.consul:Transport',
     'etcd': 'kombu.transport.etcd:Transport',
     'azurestoragequeues': 'kombu.transport.azurestoragequeues:Transport',
-    'azureservicebus': 'kombu.transport.azureservicebus:Transport'
+    'azureservicebus': 'kombu.transport.azureservicebus:Transport',
+    'pyro': 'kombu.transport.pyro:Transport'
 }
 
 _transport_cache = {}

--- a/kombu/transport/pyro.py
+++ b/kombu/transport/pyro.py
@@ -1,30 +1,50 @@
-"""Pyro transport.
+"""Pyro transport, and Kombu Broker daemon.
 
 Requires the :mod:`Pyro4` library to be installed.
+
+To use the Pyro transport with Kombu, use an url of the form:
+``pyro://localhost/kombu.broker``
+
+The hostname is where the transport will be looking for a Pyro name server,
+which is used in turn to locate the kombu.broker Pyro service.
+This broker can be launched by simply executing this transport module directly,
+with the command: ``python -m kombu.transport.pyro``
 """
+
 from __future__ import absolute_import, unicode_literals
 
 import sys
 
-from kombu.five import reraise
-from kombu.utils.objects import cached_property
-
+from ..five import reraise, Queue, Empty
+from ..utils.objects import cached_property
+from ..log import get_logger
 from . import virtual
 
 try:
     import Pyro4 as pyro
     from Pyro4.errors import NamingError
+    from Pyro4.util import SerializerBase
 except ImportError:          # pragma: no cover
-    pyro = NamingError = None  # noqa
+    pyro = NamingError = SerializerBase = None  # noqa
 
 DEFAULT_PORT = 9090
-E_LOOKUP = """\
-Unable to locate pyro nameserver {0.virtual_host} on host {0.hostname}\
+E_NAMESERVER = """\
+Unable to locate pyro nameserver on host {0.hostname}\
 """
+E_LOOKUP = """\
+Unable to lookup '{0.virtual_host}' in pyro nameserver on host {0.hostname}\
+"""
+
+logger = get_logger(__name__)
 
 
 class Channel(virtual.Channel):
     """Pyro Channel."""
+
+    def close(self):
+        super(Channel, self).close()
+        if self.shared_queues:
+            self.shared_queues._pyroRelease()
 
     def queues(self):
         return self.shared_queues.get_queue_names()
@@ -33,10 +53,12 @@ class Channel(virtual.Channel):
         if queue not in self.queues():
             self.shared_queues.new_queue(queue)
 
+    def _has_queue(self, queue, **kwargs):
+        return self.shared_queues.has_queue(queue)
+
     def _get(self, queue, timeout=None):
         queue = self._queue_for(queue)
-        msg = self.shared_queues._get(queue)
-        return msg
+        return self.shared_queues.get(queue)
 
     def _queue_for(self, queue):
         if queue not in self.queues():
@@ -45,16 +67,16 @@ class Channel(virtual.Channel):
 
     def _put(self, queue, message, **kwargs):
         queue = self._queue_for(queue)
-        self.shared_queues._put(queue, message)
+        self.shared_queues.put(queue, message)
 
     def _size(self, queue):
-        return self.shared_queues._size(queue)
+        return self.shared_queues.size(queue)
 
     def _delete(self, queue, *args, **kwargs):
-        self.shared_queues._delete(queue)
+        self.shared_queues.delete(queue)
 
     def _purge(self, queue):
-        return self.shared_queues._purge(queue)
+        return self.shared_queues.purge(queue)
 
     def after_reply_message_received(self, queue):
         pass
@@ -77,11 +99,15 @@ class Transport(virtual.Transport):
     driver_type = driver_name = 'pyro'
 
     def _open(self):
+        logger.debug("trying Pyro nameserver to find the broker daemon")
         conninfo = self.client
-        pyro.config.HMAC_KEY = conninfo.virtual_host
         try:
             nameserver = pyro.locateNS(host=conninfo.hostname,
                                        port=self.default_port)
+        except NamingError:
+            reraise(NamingError, NamingError(E_NAMESERVER.format(conninfo)),
+                    sys.exc_info()[2])
+        try:
             # name of registered pyro object
             uri = nameserver.lookup(conninfo.virtual_host)
             return pyro.Proxy(uri)
@@ -95,3 +121,64 @@ class Transport(virtual.Transport):
     @cached_property
     def shared_queues(self):
         return self._open()
+
+
+if pyro is not None:
+    SerializerBase.register_dict_to_class("queue.Empty",
+                                          lambda cls, data: Empty())
+
+    @pyro.expose
+    @pyro.behavior(instance_mode="single")
+    class KombuBroker(object):
+        """Kombu Broker used by the Pyro transport.
+
+        You have to run this as a separate (Pyro) service.
+        """
+
+        def __init__(self):
+            self.queues = {}
+
+        def get_queue_names(self):
+            return list(self.queues)
+
+        def new_queue(self, queue):
+            if queue in self.queues:
+                return   # silently ignore the fact that queue already exists
+            self.queues[queue] = Queue()
+
+        def has_queue(self, queue):
+            return queue in self.queues
+
+        def get(self, queue):
+            return self.queues[queue].get(block=False)
+
+        def put(self, queue, message):
+            self.queues[queue].put(message)
+
+        def size(self, queue):
+            return self.queues[queue].qsize()
+
+        def delete(self, queue):
+            del self.queues[queue]
+
+        def purge(self, queue):
+            while True:
+                try:
+                    self.queues[queue].get(blocking=False)
+                except Empty:
+                    break
+
+
+# launch a Kombu Broker daemon with the command:
+# ``python -m kombu.transport.pyro``
+if __name__ == "__main__":
+    print("Launching Broker for Kombu's Pyro transport.")
+    with pyro.Daemon() as daemon:
+        print("(Expecting a Pyro name server at {0}:{1})"
+              .format(pyro.config.NS_HOST, pyro.config.NS_PORT))
+        with pyro.locateNS() as ns:
+            print("You can connect with Kombu using the url "
+                  "'pyro://{0}/kombu.broker'".format(pyro.config.NS_HOST))
+            uri = daemon.register(KombuBroker)
+            ns.register("kombu.broker", uri)
+        daemon.requestLoop()

--- a/kombu/transport/pyro.py
+++ b/kombu/transport/pyro.py
@@ -15,9 +15,9 @@ from __future__ import absolute_import, unicode_literals
 
 import sys
 
-from ..five import reraise, Queue, Empty
-from ..utils.objects import cached_property
-from ..log import get_logger
+from kombu.five import reraise, Queue, Empty
+from kombu.utils.objects import cached_property
+from kombu.log import get_logger
 from . import virtual
 
 try:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,3 +2,4 @@ pytz>dev
 case>=1.5.2
 pytest
 pytest-sugar
+Pyro4

--- a/t/unit/transport/test_pyro.py
+++ b/t/unit/transport/test_pyro.py
@@ -1,0 +1,93 @@
+from __future__ import absolute_import, unicode_literals
+
+import pytest
+import socket
+
+from kombu import Connection, Exchange, Queue, Consumer, Producer
+
+
+class test_PyroTransport:
+
+    def setup(self):
+        self.c = Connection(transport='pyro', virtual_host="kombu.broker")
+        self.e = Exchange('test_transport_pyro')
+        self.q = Queue('test_transport_pyro',
+                       exchange=self.e,
+                       routing_key='test_transport_pyro')
+        self.q2 = Queue('test_transport_pyro2',
+                        exchange=self.e,
+                        routing_key='test_transport_pyro2')
+        self.fanout = Exchange('test_transport_pyro_fanout', type='fanout')
+        self.q3 = Queue('test_transport_pyro_fanout1',
+                        exchange=self.fanout)
+        self.q4 = Queue('test_transport_pyro_fanout2',
+                        exchange=self.fanout)
+
+    def test_driver_version(self):
+        assert self.c.transport.driver_version()
+
+    @pytest.mark.skip("requires running Pyro nameserver and Kombu Broker")
+    def test_produce_consume_noack(self):
+        channel = self.c.channel()
+        producer = Producer(channel, self.e)
+        consumer = Consumer(channel, self.q, no_ack=True)
+
+        for i in range(10):
+            producer.publish({'foo': i}, routing_key='test_transport_pyro')
+
+        _received = []
+
+        def callback(message_data, message):
+            _received.append(message)
+
+        consumer.register_callback(callback)
+        consumer.consume()
+
+        while 1:
+            if len(_received) == 10:
+                break
+            self.c.drain_events()
+
+        assert len(_received) == 10
+
+    def test_drain_events(self):
+        with pytest.raises(socket.timeout):
+            self.c.drain_events(timeout=0.1)
+
+        c1 = self.c.channel()
+        c2 = self.c.channel()
+
+        with pytest.raises(socket.timeout):
+            self.c.drain_events(timeout=0.1)
+
+        del(c1)  # so pyflakes doesn't complain.
+        del(c2)
+
+    @pytest.mark.skip("requires running Pyro nameserver and Kombu Broker")
+    def test_drain_events_unregistered_queue(self):
+        c1 = self.c.channel()
+        producer = self.c.Producer()
+        consumer = self.c.Consumer([self.q2])
+
+        producer.publish(
+            {'hello': 'world'},
+            declare=consumer.queues,
+            routing_key=self.q2.routing_key,
+            exchange=self.q2.exchange,
+        )
+        message = consumer.queues[0].get()._raw
+
+        class Cycle(object):
+
+            def get(self, callback, timeout=None):
+                return (message, 'foo'), c1
+
+        self.c.transport.cycle = Cycle()
+        self.c.drain_events()
+
+    @pytest.mark.skip("requires running Pyro nameserver and Kombu Broker")
+    def test_queue_for(self):
+        chan = self.c.channel()
+        x = chan._queue_for('foo')
+        assert x
+        assert chan._queue_for('foo') is x


### PR DESCRIPTION
I'm trying to get the Pyro transport working for Kombu.

A few minor changes were needed in the transport itself to be compatible with recent Pyro versions again, but I struggle with understanding the following:

Where is the pyro broker component that should  provide the actual queueing methods that are remotely accessed from the Pyro transport? I see nothing in the kombu repo doing this, and can't find anything via google.  Is there such a thing or should I write it myself?