### PR TITLE
Allow SimpleQueue to pass 'queue_arguments' to Queue object.

### DIFF
--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -710,6 +710,7 @@ class Connection(object):
         return Consumer(channel or self, queues, *args, **kwargs)
 
     def SimpleQueue(self, name, no_ack=None, queue_opts=None,
+                    queue_args=None,
                     exchange_opts=None, channel=None, **kwargs):
         """Simple persistent queue API.
 
@@ -725,6 +726,9 @@ class Connection(object):
             no_ack (bool): Disable acknowledgments. Default is false.
             queue_opts (Dict): Additional keyword arguments passed to the
                 constructor of the automatically created :class:`~kombu.Queue`.
+            queue_args (Dict): Additional keyword arguments passed to the
+                constructor of the automatically created :class:`~kombu.Queue`
+                for setting implementation extensions (e.g., in RabbitMQ).
             exchange_opts (Dict): Additional keyword arguments passed to the
                 constructor of the automatically created
                 :class:`~kombu.Exchange`.
@@ -733,6 +737,7 @@ class Connection(object):
         """
         from .simple import SimpleQueue
         return SimpleQueue(channel or self, name, no_ack, queue_opts,
+                           queue_args,
                            exchange_opts, **kwargs)
 
     def SimpleBuffer(self, name, no_ack=None, queue_opts=None,

--- a/kombu/simple.py
+++ b/kombu/simple.py
@@ -129,7 +129,7 @@ class SimpleQueue(SimpleBase):
             exchange = entity.Exchange(name, **exchange_opts)
             queue = entity.Queue(name, exchange, name, 
                                  queue_arguments=queue_args,
-                                **queue_opts)
+                                 **queue_opts)
             routing_key = name
         else:
             exchange = queue.exchange

--- a/kombu/simple.py
+++ b/kombu/simple.py
@@ -127,7 +127,7 @@ class SimpleQueue(SimpleBase):
             no_ack = self.no_ack
         if not isinstance(queue, entity.Queue):
             exchange = entity.Exchange(name, **exchange_opts)
-            queue = entity.Queue(name, exchange, name, 
+            queue = entity.Queue(name, exchange, name,
                                  queue_arguments=queue_args,
                                  **queue_opts)
             routing_key = name

--- a/t/unit/test_simple.py
+++ b/t/unit/test_simple.py
@@ -107,6 +107,11 @@ class test_SimpleQueue(SimpleBase):
         q = self.Queue('test_is_no_ack')
         assert not q.no_ack
 
+    def test_queue_args(self):
+        q = self.connection.SimpleQueue('test_queue_args',
+                                        queue_args={'x-queue-mode': 'lazy'})
+        assert q.queue.queue_arguments['x-queue-mode'] == 'lazy'
+
 
 class test_SimpleBuffer(SimpleBase):
 


### PR DESCRIPTION
Update simple.py so SimpleQueue can pass queue_arguments to the created Queue object.

This will allow SimpleQueue to connect to RabbitMQ's  lazy queues (afaik), i.e., 'x-queue-mode' is set to 'lazy'.