### PR TITLE
Queue: add handling of Exchange as str to constructor

### DIFF
--- a/kombu/entity.py
+++ b/kombu/entity.py
@@ -568,7 +568,10 @@ class Queue(MaybeChannelBound):
                  **kwargs):
         super(Queue, self).__init__(**kwargs)
         self.name = name or self.name
-        self.exchange = exchange or self.exchange
+        if isinstance(exchange, str):
+            self.exchange = Exchange(exchange)
+        elif isinstance(exchange, Exchange):
+            self.exchange = exchange
         self.routing_key = routing_key or self.routing_key
         self.bindings = set(bindings or [])
         self.on_declared = on_declared

--- a/t/unit/test_entity.py
+++ b/t/unit/test_entity.py
@@ -214,6 +214,20 @@ class test_Queue:
     def setup(self):
         self.exchange = Exchange('foo', 'direct')
 
+    def test_constructor_with_actual_exchange(self):
+        exchange = Exchange('exchange_name', 'direct')
+        queue = Queue(name='queue_name', exchange=exchange)
+        assert queue.exchange == exchange
+
+    def test_constructor_with_string_exchange(self):
+        exchange_name = str('exchange_name')
+        queue = Queue(name='queue_name', exchange=exchange_name)
+        assert queue.exchange == Exchange(exchange_name)
+
+    def test_constructor_with_default_exchange(self):
+        queue = Queue(name='queue_name')
+        assert queue.exchange == Exchange('')
+
     def test_hash(self):
         assert hash(Queue('a')) == hash(Queue('a'))
         assert hash(Queue('a')) != hash(Queue('b'))


### PR DESCRIPTION
To fit with the documentation, Queue can now handle a str argument for
the exchange parameter in the constructor, as well as an actual Exchange
object.
Added relevant unit tests to avoid regressions.

Fixes: https://github.com/celery/kombu/issues/903

Signed-off-by: Antonio Gutierrez <chibby0ne@gmail.com>