### PR TITLE
on worker restart - restore visible regardless to time

### DIFF
--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -22,6 +22,7 @@ from kombu.utils.objects import cached_property
 from kombu.utils.scheduling import cycle_by_name
 from kombu.utils.url import _parse_url
 from kombu.utils.uuid import uuid
+from kombu.utils.compat import _detect_environment
 
 from . import virtual
 
@@ -189,6 +190,9 @@ class QoS(virtual.QoS):
             try:
                 with Mutex(client, self.unacked_mutex_key,
                            self.unacked_mutex_expire):
+                    env = _detect_environment()
+                    if env == 'gevent':
+                        ceil = time()
                     visible = client.zrevrangebyscore(
                         self.unacked_index_key, ceil, 0,
                         start=num and start, num=num, withscores=True)

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, unicode_literals
 
-import sys
-
 import pytest
 import socket
 import types
@@ -1045,7 +1043,7 @@ class test_MultiChannelPoller:
                 qos.restore_visible()
                 redis_client_mock.zrevrangebyscore\
                     .assert_called_with(chan1.unacked_index_key, timeout, 0,
-                                        start=0,num=10, withscores=True)
+                                        start=0, num=10, withscores=True)
 
     def test_handle_event(self):
         p = self.Poller()

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -1028,7 +1028,7 @@ class test_MultiChannelPoller:
             num=chan1.unacked_restore_limit,
         )
 
-    def test_on_poll_init_with_gevent(self):
+    def test_visibility_timeout_with_gevent(self):
         with patch('kombu.transport.redis.time') as time:
             with patch('kombu.transport.redis._detect_environment') as env:
                 timeout = 3600

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -1028,7 +1028,7 @@ class test_MultiChannelPoller:
             num=chan1.unacked_restore_limit,
         )
 
-    def test_visibility_timeout_with_gevent(self):
+    def test_restore_visible_with_gevent(self):
         with patch('kombu.transport.redis.time') as time:
             with patch('kombu.transport.redis._detect_environment') as env:
                 timeout = 3600

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
+import sys
+
 import pytest
 import socket
 import types
@@ -1025,6 +1027,26 @@ class test_MultiChannelPoller:
         chan1.qos.restore_visible.assert_called_with(
             num=chan1.unacked_restore_limit,
         )
+
+    def test_on_poll_init_with_gevent(self):
+        with patch('kombu.transport.redis.time') as time:
+            with patch('kombu.transport.redis._detect_environment') as env:
+                timeout = 3600
+                time.return_value = timeout
+                env.return_value = 'gevent'
+                chan1 = Mock(name='chan1')
+                redis_ctx_mock = Mock()
+                redis_client_mock = Mock(name='redis_client_mock')
+                redis_ctx_mock.__exit__ = Mock()
+                redis_ctx_mock.__enter__ = Mock(return_value=redis_client_mock)
+                chan1.conn_or_acquire.return_value = redis_ctx_mock
+                qos = redis.QoS(chan1)
+                qos.visibility_timeout = timeout
+                qos.restore_visible()
+                redis_client_mock.zrevrangebyscore.assert_called_with(chan1.unacked_index_key,
+                                                                      timeout,
+                                                                      0, start=0, num=10,
+                                                                      withscores=True)
 
     def test_handle_event(self):
         p = self.Poller()

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -1043,10 +1043,9 @@ class test_MultiChannelPoller:
                 qos = redis.QoS(chan1)
                 qos.visibility_timeout = timeout
                 qos.restore_visible()
-                redis_client_mock.zrevrangebyscore.assert_called_with(chan1.unacked_index_key,
-                                                                      timeout,
-                                                                      0, start=0, num=10,
-                                                                      withscores=True)
+                redis_client_mock.zrevrangebyscore\
+                    .assert_called_with(chan1.unacked_index_key, timeout, 0,
+                                        start=0,num=10, withscores=True)
 
     def test_handle_event(self):
         p = self.Poller()


### PR DESCRIPTION
**Problem**
1. Create new job with acks_late flag as True
2. Use gevent and patch it using monkey.patch_all()
3. Execute the task
4. While task is executed (and visibility_timeout is far from expiry) kill the worker
5. Task is not re-executed after new worker is initiated

**What was done**
When worker start (patched with gevent) restore all unacked messages 

issue:

https://github.com/celery/celery/issues/4976