### PR TITLE
fix/Broadcast-fail-by-give-queue-kwargs

### DIFF
--- a/kombu/common.py
+++ b/kombu/common.py
@@ -87,7 +87,7 @@ class Broadcast(Queue):
 
     def __init__(self, name=None, queue=None, auto_delete=True,
                  exchange=None, alias=None, **kwargs):
-        queue = queue or 'bcast.{0}'.format(uuid())
+        queue = '{0}.{1}'.format(queue or 'bcast', uuid())
         return super(Broadcast, self).__init__(
             alias=alias or name,
             queue=queue,

--- a/t/unit/test_common.py
+++ b/t/unit/test_common.py
@@ -80,11 +80,11 @@ class test_Broadcast:
         assert q.exchange.type == 'fanout'
 
         q = Broadcast('test_Broadcast', 'explicit_queue_name')
-        assert q.name == 'explicit_queue_name'
+        assert q.name.startswith('explicit_queue_name.')
         assert q.exchange.name == 'test_Broadcast'
 
         q2 = q(Mock())
-        assert q2.name == q.name
+        assert q2.name.split('.')[0] == q.name.split('.')[0]
 
 
 class test_maybe_declare:


### PR DESCRIPTION
Because give Broadcast(name='xxx', queue='xxx'),
it will create one specific name for queue,
and if launch more worker for consuming this queue,
this specific name queue already exist then it will not create new queue to
binding fanout exchange.
So all worker will consuming same queue, and exchange only binding this
queue then lose the effect of broadcasting.