### PR TITLE
Added Python 3.7 to the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,10 @@ matrix:
       env: TOXENV=3.5
     - python: 3.6
       env: TOXENV=3.6
+    - python: 3.7
+      env: TOXENV=3.7
+      sudo: true
+      dist: xenial
     - python: pypy
       env: TOXENV=pypy
     - env: TOXENV=flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ matrix:
       env: TOXENV=3.7
       sudo: true
       dist: xenial
+      before_install: sudo apt-get update && sudo apt-get install libgnutls-dev
     - python: pypy
       env: TOXENV=pypy
     - env: TOXENV=flake8

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,3 +1,2 @@
 git+https://github.com/celery/sphinx_celery.git
-librabbitmq
 -r extras/mongodb.txt

--- a/requirements/test-ci.txt
+++ b/requirements/test-ci.txt
@@ -4,4 +4,7 @@ redis
 PyYAML
 msgpack-python>0.2.0
 -r extras/sqs.txt
+-r extras/consul.txt
+-r extras/librabbitmq.txt
+-r extras/zookeeper.txt
 sqlalchemy

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ deps=
     flake8,flakeplus,pydocstyle: -r{toxinidir}/requirements/pkgutils.txt
 
 commands = pip install -U -r{toxinidir}/requirements/dev.txt
-           pytest -xv --cov=kombu --cov-report=xml --no-cov-on-fail {posargs}
+           pytest -rxs -xv --cov=kombu --cov-report=xml --no-cov-on-fail {posargs}
 
 basepython =
     2.7,flakeplus,flake8,apicheck,linkcheck,cov,pydocstyle: python2.7


### PR DESCRIPTION
I also installed more of our dependencies so we'll skip less tests.
Currently the pymongo and etcd tests are broken.
We should fix them but in the meanwhile, we'll continue to skip them.