### PR TITLE
Add support for 'rediss' scheme for secure redis connections.

### DIFF
--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -10,6 +10,14 @@ from contextlib import contextmanager
 from itertools import count, cycle
 from operator import itemgetter
 
+
+try:
+    from ssl import CERT_NONE
+    ssl_available = True
+except ImportError:  # pragma: no cover
+    CERT_NONE = None
+    ssl_available = False
+
 # jython breaks on relative import for .exceptions for some reason
 # (Issue #112)
 from kombu import exceptions
@@ -234,6 +242,10 @@ class Connection(object):
         transport = transport or 'amqp'
         if transport == 'amqp' and supports_librabbitmq():
             transport = 'librabbitmq'
+        if transport == 'rediss' and ssl_available and not ssl:
+            logger.warn('Secure redis scheme specified (rediss) with no ssl '
+                        'options, defaulting to insecure SSL behaviour.')
+            ssl = {'ssl_cert_reqs': CERT_NONE}
         self.hostname = hostname
         self.userid = userid
         self.password = password

--- a/kombu/transport/__init__.py
+++ b/kombu/transport/__init__.py
@@ -24,6 +24,7 @@ TRANSPORT_ALIASES = {
     'librabbitmq': 'kombu.transport.librabbitmq:Transport',
     'memory': 'kombu.transport.memory:Transport',
     'redis': 'kombu.transport.redis:Transport',
+    'rediss': 'kombu.transport.redis:Transport',
     'SQS': 'kombu.transport.SQS:Transport',
     'sqs': 'kombu.transport.SQS:Transport',
     'mongodb': 'kombu.transport.mongodb:Transport',

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -819,6 +819,15 @@ class test_Channel:
                     redis.redis.SSLConnection,
                 )
 
+    def test_rediss_connection(self):
+        with patch('kombu.transport.redis.Channel._create_client'):
+            with Connection('rediss://') as conn:
+                connparams = conn.default_channel._connparams()
+                assert issubclass(
+                    connparams['connection_class'],
+                    redis.redis.SSLConnection,
+                )
+
 
 @skip.unless_module('redis')
 class test_Redis:


### PR DESCRIPTION
Putting a 'rediss'-specific check into a generic connection module feels
like a code smell but there doesn't appear to be another way to intercept
the connection initiation code. It defaults to the least secure form, as
there is no suitable default location for `ca_certs`. The recommendation
would still be to follow the documentation and specify `broker_use_ssl` if
coming from celery.

https://github.com/celery/kombu/issues/862
