### PR TITLE
Fixed error when `query` dict has keyname equal to `virtual_host` on `kombu.utils.url.parse_url`

### DIFF
--- a/kombu/utils/url.py
+++ b/kombu/utils/url.py
@@ -32,9 +32,11 @@ def parse_url(url):
     # type: (str) -> Dict
     """Parse URL into mapping of components."""
     scheme, host, port, user, password, path, query = _parse_url(url)
-    return dict(transport=scheme, hostname=host,
+    _result = dict(transport=scheme, hostname=host,
                 port=port, userid=user,
-                password=password, virtual_host=path, **query)
+                password=password, virtual_host=path)
+    _result.update(query)
+    return _result
 
 
 def url_to_parts(url):


### PR DESCRIPTION
Exception has occured when `query` dict has keyname equal to `virtual_host`
`# celery worker --app apps.myapp.celeryapp`
```
Traceback (most recent call last):
  File "/usr/local/bin/celery", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.6/site-packages/celery/__main__.py", line 14, in main
    _main()
  File "/usr/local/lib/python3.6/site-packages/celery/bin/celery.py", line 326, in main
    cmd.execute_from_commandline(argv)
  File "/usr/local/lib/python3.6/site-packages/celery/bin/celery.py", line 488, in execute_from_commandline
    super(CeleryCommand, self).execute_from_commandline(argv)))
  File "/usr/local/lib/python3.6/site-packages/celery/bin/base.py", line 281, in execute_from_commandline
    return self.handle_argv(self.prog_name, argv[1:])
  File "/usr/local/lib/python3.6/site-packages/celery/bin/celery.py", line 480, in handle_argv
    return self.execute(command, argv)
  File "/usr/local/lib/python3.6/site-packages/celery/bin/celery.py", line 412, in execute
    ).run_from_argv(self.prog_name, argv[1:], command=argv[0])
  File "/usr/local/lib/python3.6/site-packages/celery/bin/worker.py", line 221, in run_from_argv
    return self(*args, **options)
  File "/usr/local/lib/python3.6/site-packages/celery/bin/base.py", line 244, in __call__
    ret = self.run(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/celery/bin/worker.py", line 255, in run
    **kwargs)
  File "/usr/local/lib/python3.6/site-packages/celery/worker/worker.py", line 99, in __init__
    self.setup_instance(**self.prepare_args(**kwargs))
  File "/usr/local/lib/python3.6/site-packages/celery/worker/worker.py", line 120, in setup_instance
    self._conninfo = self.app.connection_for_read()
  File "/usr/local/lib/python3.6/site-packages/celery/app/base.py", line 752, in connection_for_read
    return self._connection(url or self.conf.broker_read_url, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/celery/app/base.py", line 828, in _connection
    'broker_connection_timeout', connect_timeout
  File "/usr/local/lib/python3.6/site-packages/kombu/connection.py", line 181, in __init__
    url_params = parse_url(hostname)
  File "/usr/local/lib/python3.6/site-packages/kombu/utils/url.py", line 39, in parse_url
    password=password, virtual_host=path, **query)
TypeError: type object got multiple values for keyword argument 'virtual_host'
```
