### PR TITLE
Allow mutex to be noop for eventlet

### DIFF
--- a/kombu/resource.py
+++ b/kombu/resource.py
@@ -188,9 +188,16 @@ class Resource(object):
             self._shrink_down(collect=limit > 0)
 
     def _shrink_down(self, collect=True):
+        class Noop:
+            def __enter__(self):
+                pass
+
+            def __exit__(self, type, value, traceback):
+                pass
+
         resource = self._resource
         # Items to the left are last recently used, so we remove those first.
-        with resource.mutex:
+        with getattr(resource, 'mutex', Noop()):
             while len(resource.queue) > self.limit:
                 R = resource.queue.popleft()
                 if collect:


### PR DESCRIPTION
As documented in https://github.com/celery/kombu/issues/741 and https://github.com/eventlet/eventlet/issues/415 there is a mismatch between the monkey-patched eventlet queue and the interface kombu is expecting. This causes celery to crash when the `broker_pool_limit` config option is set. https://github.com/eventlet/eventlet/issues/415 suggests that the mutex can be a noop and all will be fine, so that's what I've done here.

As a side note, I can't get the tests to run for me locally, and there isn't much of a `Here's how to get started contributing to kombu` section. Maybe that's something to consider?