### PR TITLE
Fix a deprecation warning about logger.warn()

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,6 +22,7 @@ Basil Mironenko <bmironenko@ddn.com>
 Bobby Beever <bobby.beever@yahoo.com>
 Brian Bernstein
 Brian Bouterse <bmbouter@redhat.com>
+Bruno Alla <alla.brunoo@gmail.com>
 C Anthony Risinger <anthony+corvisa.com@xtfx.me>
 Chris Erway <cce@appneta.com>
 Christophe Chauvet <christophe.chauvet@gmail.com>

--- a/kombu/common.py
+++ b/kombu/common.py
@@ -403,8 +403,8 @@ class QoS(object):
         if pcount != self.prev:
             new_value = pcount
             if pcount > PREFETCH_COUNT_MAX:
-                logger.warn('QoS: Disabled: prefetch_count exceeds %r',
-                            PREFETCH_COUNT_MAX)
+                logger.warning('QoS: Disabled: prefetch_count exceeds %r',
+                               PREFETCH_COUNT_MAX)
                 new_value = 0
             logger.debug('basic.qos: prefetch_count->%s', new_value)
             self.callback(prefetch_count=new_value)

--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -243,8 +243,10 @@ class Connection(object):
         if transport == 'amqp' and supports_librabbitmq():
             transport = 'librabbitmq'
         if transport == 'rediss' and ssl_available and not ssl:
-            logger.warn('Secure redis scheme specified (rediss) with no ssl '
-                        'options, defaulting to insecure SSL behaviour.')
+            logger.warning(
+                'Secure redis scheme specified (rediss) with no ssl '
+                'options, defaulting to insecure SSL behaviour.'
+            )
             ssl = {'ssl_cert_reqs': CERT_NONE}
         self.hostname = hostname
         self.userid = userid

--- a/kombu/transport/etcd.py
+++ b/kombu/transport/etcd.py
@@ -267,5 +267,5 @@ class Transport(virtual.Transport):
                 if x.startswith('python-etcd'):
                     return x.split('==')[1]
         except (ImportError, IndexError):
-            logger.warn('Unable to find the python-etcd version.')
+            logger.warning('Unable to find the python-etcd version.')
             return 'Unknown'

--- a/kombu/transport/virtual/base.py
+++ b/kombu/transport/virtual/base.py
@@ -977,7 +977,7 @@ class Transport(base.Transport):
         try:
             callback = self._callbacks[queue]
         except KeyError:
-            logger.warn(W_NO_CONSUMERS, queue)
+            logger.warning(W_NO_CONSUMERS, queue)
             self._reject_inbound_message(message)
         else:
             callback(message)

--- a/t/unit/test_common.py
+++ b/t/unit/test_common.py
@@ -337,7 +337,7 @@ class test_QoS:
             # cannot use 2 ** 32 because of a bug on macOS Py2.5:
             # https://jira.mongodb.org/browse/PYTHON-389
             qos.set(4294967296)
-            logger.warn.assert_called()
+            logger.warning.assert_called()
             callback.assert_called_with(prefetch_count=0)
 
     def test_qos_increment_decrement(self):


### PR DESCRIPTION
This fixes a deprecation warning from the standard library's logging module:

> The 'warn' method is deprecated, use 'warning' instead