### PR TITLE
Fix double execution of tasks with warm shutdown

### DIFF
--- a/kombu/asynchronous/hub.py
+++ b/kombu/asynchronous/hub.py
@@ -245,6 +245,8 @@ class Hub(object):
             pass
 
     def close(self, *args):
+        for item in filter(None, self._ready):
+            item()
         [self._unregister(fd) for fd in self.readers]
         self.readers.clear()
         [self._unregister(fd) for fd in self.writers]


### PR DESCRIPTION
This happened when `ack_late` option enabled. Ack happend by call `Hub.call_soon`. It puts callback to `Hub._ready` set. Callbacks from there called in `Hub.create_loop` method. It is called from [celery.worker.loops.asynloop](https://github.com/celery/celery/blob/master/celery/worker/loops.py#L93) inside of while. On warm shutdown this cycle is breaking and `Hub.create_loop` is never called. Because of this current message never will be acked and task will run again on next Celery start. Related to issue in celery: https://github.com/celery/celery/issues/3796 