### PR TITLE
Replace README web link with link to documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@
 |build-status| |coverage| |license| |wheel| |pyversion| |pyimp|
 
 :Version: 4.2.1
-:Web: http://kombu.me/
+:Documentation: https://kombu.readthedocs.io/
 :Download: https://pypi.org/project/kombu/
 :Source: https://github.com/celery/kombu/
 :Keywords: messaging, amqp, rabbitmq, redis, mongodb, python, queue


### PR DESCRIPTION
The link in the README to kombu.me is broken (#930). This PR replaces the broken link with a link to the documentation.