### PR TITLE
Update default login method for librabbitmq and pyamqp

### DIFF
--- a/kombu/transport/librabbitmq.py
+++ b/kombu/transport/librabbitmq.py
@@ -182,5 +182,5 @@ class Transport(base.Transport):
             'port': (self.default_ssl_port if self.client.ssl
                      else self.default_port),
             'hostname': 'localhost',
-            'login_method': 'AMQPLAIN',
+            'login_method': 'PLAIN',
         }

--- a/kombu/transport/pyamqp.py
+++ b/kombu/transport/pyamqp.py
@@ -162,7 +162,7 @@ class Transport(base.Transport):
             'port': (self.default_ssl_port if self.client.ssl
                      else self.default_port),
             'hostname': 'localhost',
-            'login_method': 'AMQPLAIN',
+            'login_method': 'PLAIN',
         }
 
     def get_manager(self, *args, **kwargs):


### PR DESCRIPTION
Using PLAIN as the default seems to have become the obvious choice:  See https://www.rabbitmq.com/authentication.html

AMQPLAIN is only retained for backwards compatability and has become non-standard.  If it's an active decision to keep AMQPLAIN I am fine with that, I've just run across many installations where people are taking AMQPLAIN out of the server config for new setups and people using kombu are wondering why their connections won't work.