### PR TITLE
handling non-base64-encoded SQS message

### DIFF
--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -219,7 +219,10 @@ class Channel(virtual.Channel):
             self.sqs.send_message(**kwargs)
 
     def _message_to_python(self, message, queue_name, queue):
-        body = base64.b64decode(message['Body'].encode())
+        try:
+            body = base64.b64decode(message['Body'].encode())
+        except:
+            body = message['Body'].encode()
         payload = loads(bytes_to_str(body))
         if queue_name in self._noack_queues:
             queue = self._new_queue(queue_name)


### PR DESCRIPTION
Not all AWS SQS messages have base64 encoded message body. For example, a S3 event derived SQS message has a `Body` as an unencoded JSON string.