### PR TITLE
Removed Jython bz2 import fallback

### DIFF
--- a/kombu/compression.py
+++ b/kombu/compression.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 
 from kombu.utils.encoding import ensure_bytes
 
+import bz2
 import zlib
 
 _aliases = {}
@@ -70,11 +71,7 @@ def decompress(body, content_type):
 register(zlib.compress,
          zlib.decompress,
          'application/x-gzip', aliases=['gzip', 'zlib'])
-try:
-    import bz2
-except ImportError:
-    pass  # Jython?
-else:
-    register(bz2.compress,
-             bz2.decompress,
-             'application/x-bz2', aliases=['bzip2', 'bzip'])
+
+register(bz2.compress,
+         bz2.decompress,
+         'application/x-bz2', aliases=['bzip2', 'bzip'])

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ all_files = 1
 [flake8]
 # classes can be lowercase, arguments and variables can be uppercase
 # whenever it makes the code more readable.
-ignore = N806, N802, N801, N803
+ignore = W504, N806, N802, N801, N803
 
 [pep257]
 ignore = D102,D104,D203,D105,D213

--- a/t/unit/test_compression.py
+++ b/t/unit/test_compression.py
@@ -1,28 +1,13 @@
 from __future__ import absolute_import, unicode_literals
 
-import sys
-
-from case import mock, skip
-
 from kombu import compression
 
 
 class test_compression:
 
-    @mock.mask_modules('bz2')
-    def test_no_bz2(self):
-        c = sys.modules.pop('kombu.compression')
-        try:
-            import kombu.compression
-            assert not hasattr(kombu.compression, 'bz2')
-        finally:
-            if c is not None:
-                sys.modules['kombu.compression'] = c
-
     def test_encoders__gzip(self):
         assert 'application/x-gzip' in compression.encoders()
 
-    @skip.unless_module('bz2')
     def test_encoders__bz2(self):
         assert 'application/x-bz2' in compression.encoders()
 
@@ -33,7 +18,6 @@ class test_compression:
         d = compression.decompress(c, ctype)
         assert d == text
 
-    @skip.unless_module('bz2')
     def test_compress__decompress__bzip2(self):
         text = b'The Brown Quick Fox Over The Lazy Dog Jumps'
         c, ctype = compression.compress(text, 'bzip2')


### PR DESCRIPTION
This appears to have been resolved. The touched lines were from 2011, and the satus of the buf changed in 2013. I didn't check on Jython, my suggestion is only based on that report.

http://bugs.jython.org/issue1445