### PR TITLE
disambiguate docstring typehints causing warnings building celery docs

### DIFF
--- a/kombu/messaging.py
+++ b/kombu/messaging.py
@@ -21,7 +21,7 @@ class Producer(object):
 
     Arguments:
         channel (kombu.Connection, ChannelT): Connection or channel.
-        exchange (Exchange, str): Optional default exchange.
+        exchange (kombu.entity.Exchange, str): Optional default exchange.
         routing_key (str): Optional default routing key.
         serializer (str): Default serializer. Default is `"json"`.
         compression (str): Default compression method.
@@ -135,7 +135,7 @@ class Producer(object):
             compression (str): Compression method to use.  Default is none.
             headers (Dict): Mapping of arbitrary headers to pass along
                 with the message body.
-            exchange (Exchange, str): Override the exchange.
+            exchange (kombu.entity.Exchange, str): Override the exchange.
                 Note that this exchange must have been declared.
             declare (Sequence[EntityT]): Optional list of required entities
                 that must have been declared before publishing the message.


### PR DESCRIPTION
Fixes #940 - this is a very minor docstring change. I just wanted to fix all the warnings that occur when building the Celery docs. I've noticed a similar set of issues with the Kombu docs and, unless you want me to stop, I would be happy to fix those as well when I have a chance.