### PR TITLE
Add boto3 default region before hardcoded default

### DIFF
--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -467,7 +467,9 @@ class Channel(virtual.Channel):
 
     @cached_property
     def region(self):
-        return self.transport_options.get('region') or self.default_region
+        return (self.transport_options.get('region') or
+                boto3.Session().region_name or
+                self.default_region)
 
     @cached_property
     def regioninfo(self):

--- a/t/unit/transport/test_SQS.py
+++ b/t/unit/transport/test_SQS.py
@@ -7,7 +7,6 @@ slightly.
 
 from __future__ import absolute_import, unicode_literals
 
-import boto3
 import os
 import pytest
 import random
@@ -176,6 +175,7 @@ class test_Channel:
         assert self.queue_name in self.channel._queue_cache
 
     def test_region(self):
+        import boto3
         _environ = dict(os.environ)
 
         # when the region is unspecified

--- a/t/unit/transport/test_SQS.py
+++ b/t/unit/transport/test_SQS.py
@@ -7,6 +7,8 @@ slightly.
 
 from __future__ import absolute_import, unicode_literals
 
+import boto3
+import os
 import pytest
 import random
 import string
@@ -172,6 +174,36 @@ class test_Channel:
     def test_init(self):
         """kombu.SQS.Channel instantiates correctly with mocked queues"""
         assert self.queue_name in self.channel._queue_cache
+
+    def test_region(self):
+        _environ = dict(os.environ)
+
+        # when the region is unspecified
+        connection = Connection(transport=SQS.Transport)
+        channel = connection.channel()
+        assert channel.transport_options.get('region') is None
+        # the default region is us-east-1
+        assert channel.region == 'us-east-1'
+
+        # when boto3 picks a region
+        os.environ['AWS_DEFAULT_REGION'] = 'us-east-2'
+        assert boto3.Session().region_name == 'us-east-2'
+        # the default region should match
+        connection = Connection(transport=SQS.Transport)
+        channel = connection.channel()
+        assert channel.region == 'us-east-2'
+
+        # when transport_options are provided
+        connection = Connection(transport=SQS.Transport, transport_options={
+            'region': 'us-west-2'
+        })
+        channel = connection.channel()
+        assert channel.transport_options.get('region') == 'us-west-2'
+        # the specified region should be used
+        assert connection.channel().region == 'us-west-2'
+
+        os.environ.clear()
+        os.environ.update(_environ)
 
     def test_endpoint_url(self):
         url = 'sqs://@localhost:5493'


### PR DESCRIPTION
Implements a fix for #950, slightly different from the original proposal.

I did that because the boto3 library could be missing. I'm guessing, from the guard condition at the constructor:

```
def __init__(self, *args, **kwargs):
        if boto3 is None:
            raise ImportError('boto3 is not installed')
        super(Channel, self).__init__(*args, **kwargs)
```

So I couldn't just use boto3 in the class definition to override the default region.
Instead I think it's better to just put it as a default with higher precedence than the current default region.