### PR TITLE
fix #933

### DIFF
--- a/kombu/utils/url.py
+++ b/kombu/utils/url.py
@@ -7,8 +7,18 @@ from functools import partial
 try:
     from urllib.parse import parse_qsl, quote, unquote, urlparse
 except ImportError:
-    from urllib import quote, unquote                  # noqa
-    from urlparse import urlparse, parse_qsl    # noqa
+    import urlparse
+    def _splitnetloc_(url, start=0):
+        delim = len(url)
+        netloc_delim = url.find("@", start)
+        for c in '/?#':
+            wdelim = url.find(c, start)
+            if wdelim >= 0 and netloc_delim < wdelim:
+                delim = min(delim, wdelim)
+        return url[start:delim], url[delim:]
+    urlparse._splitnetloc = _splitnetloc_
+    from urllib import quote, unquote # noqa
+    from urlparse import urlparse, parse_qsl # noqa
 
 from kombu.five import bytes_if_py2, string_t
 

--- a/t/unit/utils/test_url.py
+++ b/t/unit/utils/test_url.py
@@ -37,3 +37,11 @@ def test_maybe_sanitize_url(url, expected):
     assert maybe_sanitize_url(url) == expected
     assert (maybe_sanitize_url('http://u:p@e.com//foo') ==
             'http://u:**@e.com//foo')
+
+@pytest.mark.parametrize('possible_url,expected', [
+    ('amqp://user:pass#@localhost:5672/my/vhost', {'password': 'pass#', 'virtual_host': 'my/vhost', 'hostname': 'localhost', 'userid': 'user', 'port': 5672, 'transport': 'amqp'}),
+    ('sqs://access_key:secret/key@', {'password': 'secret/key', 'virtual_host': None, 'hostname': None, 'userid': 'access_key', 'port': None, 'transport': 'sqs'}),
+    ('amqp://mocspi:J_wPHlx8HZnr5a-v3quwMR1gtRdT@test.test.test.com/@mocsknpi', {'password': 'J_wPHlx8HZnr5a-v3quwMR1gtRdT', 'virtual_host': '@mocsknpi', 'hostname': 'test.test.test.com', 'userid': 'mocspi', 'port': None, 'transport': 'amqp'}),
+])
+def test_parse_possible_urls(possible_url, expected):
+    assert parse_url(possible_url) == expected


### PR DESCRIPTION
The problem is in the function _splitnetloc used in urlsplit, it uses "/?#" as delim to extract netloc. We can override it to check for position of "@" and then use delim that appears after it.

Fixes #933