### PR TITLE
Fix resizing and expose option for celery to forcibly resize

### DIFF
--- a/kombu/pools.py
+++ b/kombu/pools.py
@@ -13,7 +13,8 @@ from .utils.compat import register_after_fork
 from .utils.functional import lazy
 
 __all__ = ('ProducerPool', 'PoolGroup', 'register_group',
-           'connections', 'producers', 'get_limit', 'set_limit', 'reset', 'set_forced_resize')
+           'connections', 'producers', 'get_limit', 'set_limit', 'reset',
+           'set_forced_resize')
 _limit = [10]
 _groups = []
 use_global_limit = object()
@@ -154,4 +155,3 @@ def set_forced_resize(value):
     """Set forced-resize to force pool resizing even when in use."""
     for p in _all_pools():
         p.forced_resize = value
-

--- a/kombu/resource.py
+++ b/kombu/resource.py
@@ -186,7 +186,7 @@ class Resource(object):
         if reset:
             try:
                 self.force_close_all()
-            except Exception, e:
+            except Exception:
                 pass
         self.setup()
         if limit < prev_limit:

--- a/kombu/resource.py
+++ b/kombu/resource.py
@@ -185,7 +185,7 @@ class Resource(object):
                 pass
         self.setup()
         if limit < prev_limit:
-            self._shrink_down(collect=limit > 0)
+            self._shrink_down(collect=prev_limit > 0)
 
     def _shrink_down(self, collect=True):
         resource = self._resource

--- a/kombu/resource.py
+++ b/kombu/resource.py
@@ -185,7 +185,7 @@ class Resource(object):
                 pass
         self.setup()
         if limit < prev_limit:
-            self._shrink_down(collect=prev_limit > 0)
+            self._shrink_down(collect=limit >= 0)
 
     def _shrink_down(self, collect=True):
         resource = self._resource

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -1107,7 +1107,7 @@ class SentinelChannel(Channel):
         sentinel_inst = sentinel.Sentinel(
             connection_list,
             min_other_sentinels=getattr(self, 'min_other_sentinels', 0),
-            sentinel_kwargs=getattr(self, 'sentinel_kwargs',None),
+            sentinel_kwargs=getattr(self, 'sentinel_kwargs', None),
             **additional_params)
 
         master_name = getattr(self, 'master_name', None)

--- a/t/unit/test_pools.py
+++ b/t/unit/test_pools.py
@@ -255,7 +255,10 @@ class test_fun_PoolGroup:
     def test_resource_resizing(self):
         p = pools.producers[Connection('memory://localhost:777')]
         c = pools.connections[Connection('memory//localhost:678')]
-        in_use = lambda pool: len(pool._resource.queue) + len(pool._dirty)
+
+        def in_use(pool):
+            return len(pool._resource.queue) + len(pool._dirty)
+
         pools.set_forced_resize(True)
         assert p.forced_resize is True
         pools.set_limit(10)

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -1344,7 +1344,8 @@ class test_RedisSentinel:
     def test_getting_master_from_sentinel(self):
         with patch('redis.sentinel.Sentinel') as patched:
             connection = Connection(
-                'sentinel://localhost:65534/;sentinel://localhost:65535/;sentinel://localhost:65536/;',
+                'sentinel://localhost:65534/;\
+                sentinel://localhost:65535/;sentinel://localhost:65536/;',
                 transport_options={
                     'master_name': 'not_important',
                 },
@@ -1352,7 +1353,8 @@ class test_RedisSentinel:
 
             connection.channel()
             patched.assert_called_once_with(
-                [[u'localhost', u'65534'], [u'localhost', u'65535'], [u'localhost', u'65536']],
+                [[u'localhost', u'65534'], [u'localhost', u'65535'],
+                 [u'localhost', u'65536']],
                 connection_class=mock.ANY, db=0, max_connections=10,
                 min_other_sentinels=0, password=None, sentinel_kwargs=None,
                 socket_connect_timeout=None, socket_keepalive=None,


### PR DESCRIPTION
It pops from the self._resource.queue but does not collect the resource when shrinking down