### PR TITLE
Avoid raising StopIterator in generators

### DIFF
--- a/kombu/asynchronous/hub.py
+++ b/kombu/asynchronous/hub.py
@@ -305,8 +305,8 @@ class Hub(object):
                 try:
                     events = poll(poll_timeout)
                     #  print('[EVENTS]: %s' % (self.repr_events(events),))
-                except ValueError:  # Issue 882
-                    raise StopIteration()
+                except ValueError:  # Issue celery/#882
+                    return
 
                 for fd, event in events or ():
                     general_error = False


### PR DESCRIPTION
According to [PEP-479](https://www.python.org/dev/peps/pep-0479/) StopIteration should not be used any more to indicate the termination of a generator.
Starting from Python 3.7 this behaviour is always enforced and a RuntimeError is raised instead.
We now return instead of raising StopIteration.