### PR TITLE
Fix failing unittests of pyamqp transport.

### DIFF
--- a/t/unit/transport/test_pyamqp.py
+++ b/t/unit/transport/test_pyamqp.py
@@ -68,11 +68,11 @@ class test_Channel:
         assert self.channel.connection is None
 
     def test_basic_consume_registers_ack_status(self):
-        self.channel.wait_returns = 'my-consumer-tag'
+        self.channel.wait_returns = ['my-consumer-tag']
         self.channel.basic_consume('foo', no_ack=True)
         assert 'my-consumer-tag' in self.channel.no_ack_consumers
 
-        self.channel.wait_returns = 'other-consumer-tag'
+        self.channel.wait_returns = ['other-consumer-tag']
         self.channel.basic_consume('bar', no_ack=False)
         assert 'other-consumer-tag' not in self.channel.no_ack_consumers
 


### PR DESCRIPTION
Failing unittests were caused by PR https://github.com/celery/py-amqp/pull/221.