### PR TITLE
Simplify kombu.asynchronous.http.get_client

### DIFF
--- a/kombu/asynchronous/http/__init__.py
+++ b/kombu/asynchronous/http/__init__.py
@@ -18,6 +18,6 @@ def get_client(hub=None, **kwargs):
     hub = hub or get_event_loop()
     assert hub is not None
     client = getattr(hub, '_current_http_client', None)
-    if not client:
+    if client is None:
         client = hub._current_http_client = Client(hub, **kwargs)
     return client

--- a/kombu/asynchronous/http/__init__.py
+++ b/kombu/asynchronous/http/__init__.py
@@ -16,8 +16,8 @@ def Client(hub=None, **kwargs):
 def get_client(hub=None, **kwargs):
     """Get or create HTTP client bound to the current event loop."""
     hub = hub or get_event_loop()
-    try:
-        return hub._current_http_client
-    except AttributeError:
+    assert hub is not None
+    client = getattr(hub, '_current_http_client', None)
+    if not client:
         client = hub._current_http_client = Client(hub, **kwargs)
-        return client
+    return client


### PR DESCRIPTION
This is code is equivalent, with the difference that if `Client.__init__` fails, that won't have the AttributeError chained to it (on Python 3). I believe this is slightly less confusing.

From a performance standpoint, this is roughly equivalent, as can be seen in:
```py
from timeit import timeit

secs = timeit("""
class Foo(object):
    pass

foo = Foo()
try:
    foo.bar
except AttributeError:
    foo.bar = 'baz'
""", number=100_000)

print(secs)

secs = timeit("""
class Foo(object):
    pass

foo = Foo()
bar = getattr(foo, 'bar', None)
if not bar:
    foo.bar = 'baz'
""", number=100_000)

print(secs)
```
on my machine resulting in:
```
1.029316808
0.9725863030000002
```