### PR TITLE
SQS: fix trimming .fifo from queue name

### DIFF
--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -151,7 +151,7 @@ class Channel(virtual.Channel):
     def entity_name(self, name, table=CHARS_REPLACE_TABLE):
         """Format AMQP queue name into a legal SQS queue name."""
         if name.endswith('.fifo'):
-            partial = name.rstrip('.fifo')
+            partial = name[:-len('.fifo')]
             partial = text_t(safe_str(partial)).translate(table)
             return partial + '.fifo'
         else:

--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -57,7 +57,7 @@ from . import virtual
 
 logger = get_logger(__name__)
 
-# dots are replaced by dash, all other punctuation
+# dots are replaced by dash, dash remains dash, all other punctuation
 # replaced by underscore.
 CHARS_REPLACE_TABLE = {
     ord(c): 0x5f for c in string.punctuation if c not in '-_.'

--- a/t/unit/transport/test_SQS.py
+++ b/t/unit/transport/test_SQS.py
@@ -226,7 +226,8 @@ class test_Channel:
 
     def test_entity_name(self):
         assert self.channel.entity_name('foo') == 'foo'
-        assert self.channel.entity_name('foo.bar-baz*qux_quux') == 'foo-bar-baz_qux_quux'
+        assert self.channel.entity_name('foo.bar-baz*qux_quux') == \
+            'foo-bar-baz_qux_quux'
         assert self.channel.entity_name('abcdef.fifo') == 'abcdef.fifo'
 
     def test_new_queue(self):

--- a/t/unit/transport/test_SQS.py
+++ b/t/unit/transport/test_SQS.py
@@ -224,6 +224,11 @@ class test_Channel:
         conn = Connection(hostname=None, transport=SQS.Transport)
         assert conn.hostname == conn.clone().hostname
 
+    def test_entity_name(self):
+        assert self.channel.entity_name('foo') == 'foo'
+        assert self.channel.entity_name('foo.bar-baz*qux_quux') == 'foo-bar-baz_qux_quux'
+        assert self.channel.entity_name('abcdef.fifo') == 'abcdef.fifo'
+
     def test_new_queue(self):
         queue_name = 'new_unittest_queue'
         self.channel._new_queue(queue_name)


### PR DESCRIPTION
A more conservative take on https://github.com/celery/kombu/pull/887 + tests.

Fixes #888.