### PR TITLE
Added support for lzma compression

### DIFF
--- a/kombu/compression.py
+++ b/kombu/compression.py
@@ -6,6 +6,15 @@ from kombu.utils.encoding import ensure_bytes
 import bz2
 import zlib
 
+try:
+    import lzma
+except ImportError:  # pragma: no cover
+    # TODO: Drop fallback to backports once we drop Python 2.7 support
+    try:
+        from backports import lzma
+    except ImportError:  # pragma: no cover
+        lzma = None
+
 _aliases = {}
 _encoders = {}
 _decoders = {}
@@ -85,3 +94,9 @@ else:
     register(brotli.compress,
              brotli.decompress,
              'application/x-brotli', aliases=['brotli'])
+
+# TODO: Drop condition once we drop Python 2.7 support
+if lzma:
+    register(lzma.compress,
+             lzma.decompress,
+             'application/x-lzma', aliases=['lzma', 'xz'])

--- a/kombu/compression.py
+++ b/kombu/compression.py
@@ -96,7 +96,7 @@ else:
              'application/x-brotli', aliases=['brotli'])
 
 # TODO: Drop condition once we drop Python 2.7 support
-if lzma:
+if lzma:  # pragma: no cover
     register(lzma.compress,
              lzma.decompress,
              'application/x-lzma', aliases=['lzma', 'xz'])

--- a/requirements/extras/lzma.txt
+++ b/requirements/extras/lzma.txt
@@ -1,0 +1,1 @@
+backports.lzma;python_version<"3.3"

--- a/requirements/test-ci-py2.txt
+++ b/requirements/test-ci-py2.txt
@@ -1,1 +1,2 @@
 -r extras/sqs.txt
+-r extras/lzma.txt

--- a/t/unit/test_compression.py
+++ b/t/unit/test_compression.py
@@ -18,6 +18,16 @@ class test_compression:
 
         assert 'application/x-brotli' in compression.encoders()
 
+    def test_encoders__lzma(self):
+        pytest.importorskip('lzma')
+
+        assert 'application/x-lzma' in compression.encoders()
+
+    def test_encoders__backports_lzma(self):
+        pytest.importorskip('backports.lzma')
+
+        assert 'application/x-lzma' in compression.encoders()
+
     def test_compress__decompress__zlib(self):
         text = b'The Quick Brown Fox Jumps Over The Lazy Dog'
         c, ctype = compression.compress(text, 'zlib')
@@ -37,6 +47,21 @@ class test_compression:
 
         text = b'The Brown Quick Fox Over The Lazy Dog Jumps'
         c, ctype = compression.compress(text, 'brotli')
+
+    def test_compress__decompress__lzma(self):
+        pytest.importorskip('lzma')
+
+        text = b'The Brown Quick Fox Over The Lazy Dog Jumps'
+        c, ctype = compression.compress(text, 'lzma')
+        assert text != c
+        d = compression.decompress(c, ctype)
+        assert d == text
+
+    def test_compress__decompress__backports_lzma(self):
+        pytest.importorskip('backports.lzma')
+
+        text = b'The Brown Quick Fox Over The Lazy Dog Jumps'
+        c, ctype = compression.compress(text, 'lzma')
         assert text != c
         d = compression.decompress(c, ctype)
         assert d == text


### PR DESCRIPTION
LZMA has been available since Python 3.3.

This PR introduces LZMA compression support for tasks.
In addition, we also support using the backported version for Python 2.7.