### PR TITLE
Added optional support for zstd compression

### DIFF
--- a/kombu/compression.py
+++ b/kombu/compression.py
@@ -100,3 +100,20 @@ if lzma:  # pragma: no cover
     register(lzma.compress,
              lzma.decompress,
              'application/x-lzma', aliases=['lzma', 'xz'])
+
+try:
+    import zstandard as zstd
+except ImportError:  # pragma: no cover
+    pass
+else:
+    def zstd_compress(body):
+        c = zstd.ZstdCompressor()
+        return c.compress(body)
+
+    def zstd_decompress(body):
+        d = zstd.ZstdDecompressor()
+        return d.decompress(body)
+
+    register(zstd_compress,
+             zstd_decompress,
+             'application/zstd', aliases=['zstd', 'zstandard'])

--- a/requirements/extras/zstd.txt
+++ b/requirements/extras/zstd.txt
@@ -1,0 +1,1 @@
+zstandard

--- a/requirements/test-ci.txt
+++ b/requirements/test-ci.txt
@@ -10,4 +10,5 @@ msgpack-python>0.2.0
 -r extras/librabbitmq.txt
 -r extras/zookeeper.txt
 -r extras/brotli.txt
+-r extras/zstd.txt
 sqlalchemy

--- a/t/unit/test_compression.py
+++ b/t/unit/test_compression.py
@@ -28,6 +28,11 @@ class test_compression:
 
         assert 'application/x-lzma' in compression.encoders()
 
+    def test_encoders__zstd(self):
+        pytest.importorskip('zstandard')
+
+        assert 'application/zstd' in compression.encoders()
+
     def test_compress__decompress__zlib(self):
         text = b'The Quick Brown Fox Jumps Over The Lazy Dog'
         c, ctype = compression.compress(text, 'zlib')
@@ -62,6 +67,15 @@ class test_compression:
 
         text = b'The Brown Quick Fox Over The Lazy Dog Jumps'
         c, ctype = compression.compress(text, 'lzma')
+        assert text != c
+        d = compression.decompress(c, ctype)
+        assert d == text
+
+    def test_compress__decompress__zstd(self):
+        pytest.importorskip('zstandard')
+
+        text = b'The Brown Quick Fox Over The Lazy Dog Jumps'
+        c, ctype = compression.compress(text, 'zstd')
         assert text != c
         d = compression.decompress(c, ctype)
         assert d == text


### PR DESCRIPTION
> Zstandard, or zstd as short version, is a fast lossless compression algorithm, targeting real-time compression scenarios at zlib-level and better compression ratios. It's backed by a very fast entropy stage, provided by Huff0 and FSE library.

We now allow users to install the python bindings to zstd and compress tasks using the zstd algorithm.