### PR TITLE
import collections.ABCs from correct module

### DIFF
--- a/kombu/utils/functional.py
+++ b/kombu/utils/functional.py
@@ -5,7 +5,8 @@ import random
 import sys
 import threading
 
-from collections import Iterable, Mapping, OrderedDict
+from collections import OrderedDict
+from collections.abc import Iterable, Mapping
 from itertools import count, repeat
 from time import sleep, time
 

--- a/kombu/utils/functional.py
+++ b/kombu/utils/functional.py
@@ -6,7 +6,12 @@ import sys
 import threading
 
 from collections import OrderedDict
-from collections.abc import Iterable, Mapping
+
+try:
+    from collections.abc import Iterable, Mapping
+except ImportError:
+    from collections import Iterable, Mapping
+
 from itertools import count, repeat
 from time import sleep, time
 

--- a/kombu/utils/url.py
+++ b/kombu/utils/url.py
@@ -1,7 +1,7 @@
 """URL Utilities."""
 from __future__ import absolute_import, unicode_literals
 
-from collections import Mapping
+from collections.abc import Mapping
 from functools import partial
 
 try:

--- a/kombu/utils/url.py
+++ b/kombu/utils/url.py
@@ -1,7 +1,11 @@
 """URL Utilities."""
 from __future__ import absolute_import, unicode_literals
 
-from collections.abc import Mapping
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
+
 from functools import partial
 
 try:

--- a/t/unit/transport/test_qpid.py
+++ b/t/unit/transport/test_qpid.py
@@ -9,7 +9,12 @@ import time
 import uuid
 
 from collections import OrderedDict
-from collections.abc import Callable
+
+try:
+    from collections.abc import Callable
+except ImportError:
+    from collections import Callable
+
 from itertools import count
 
 from case import Mock, call, patch, skip

--- a/t/unit/transport/test_qpid.py
+++ b/t/unit/transport/test_qpid.py
@@ -8,7 +8,8 @@ import sys
 import time
 import uuid
 
-from collections import Callable, OrderedDict
+from collections import OrderedDict
+from collections.abc import Callable
 from itertools import count
 
 from case import Mock, call, patch, skip


### PR DESCRIPTION
I got the deprecation warnings about the abstract base classes from the collections module:

```
/kombu/kombu/utils/functional.py:8: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import Iterable, Mapping, OrderedDict
```

it seems like an easy fix, so I just went ahead and did it.