### PR TITLE
Fix breaking change in Azure ServiceBus SDK

### DIFF
--- a/kombu/transport/azureservicebus.py
+++ b/kombu/transport/azureservicebus.py
@@ -29,9 +29,15 @@ from kombu.utils.objects import cached_property
 from . import virtual
 
 try:
+    # azure-servicebus version <= 0.21.1
     from azure.servicebus import ServiceBusService, Message, Queue
 except ImportError:
-    ServiceBusService = Message = Queue = None
+    try:
+        # azure-servicebus version >= 0.50.0
+        from azure.servicebus.control_client import \
+            ServiceBusService, Message, Queue
+    except ImportError:
+        ServiceBusService = Message = Queue = None
 
 # dots are replaced by dash, all other punctuation replaced by underscore.
 CHARS_REPLACE_TABLE = {


### PR DESCRIPTION
The Azure ServiceBus SDK upgrade from version 0.21.1 to 0.50.0 introduced a breaking change which affects the `azureservicebus://` transport. This pull request makes kombu compatible with both old and new versions of the SDK. See [the Azure ServiceBus SDK release notes](https://github.com/Azure/azure-sdk-for-python/tree/97b71f2670fe3ebffd4c834c8d7681284d02e048/azure-servicebus#migration-from-0211-to-0500) for more background.
