### PR TITLE
Traceback can be disabled for all log levels

### DIFF
--- a/kombu/log.py
+++ b/kombu/log.py
@@ -68,21 +68,19 @@ class LogMixin(object):
         return self.log(logging.WARN, *args, **kwargs)
 
     def error(self, *args, **kwargs):
-        return self._error(logging.ERROR, *args, **kwargs)
+        kwargs.setdefault('exc_info', True)
+        return self.log(logging.ERROR, *args, **kwargs)
 
     def critical(self, *args, **kwargs):
-        return self._error(logging.CRITICAL, *args, **kwargs)
-
-    def _error(self, severity, *args, **kwargs):
         kwargs.setdefault('exc_info', True)
-        if DISABLE_TRACEBACKS:
-            kwargs.pop('exc_info', None)
-        return self.log(severity, *args, **kwargs)
+        return self.log(logging.CRITICAL, *args, **kwargs)
 
     def annotate(self, text):
         return '%s - %s' % (self.logger_name, text)
 
     def log(self, severity, *args, **kwargs):
+        if DISABLE_TRACEBACKS:
+            kwargs.pop('exc_info', None)
         if self.logger.isEnabledFor(severity):
             log = self.logger.log
             if len(args) > 1 and isinstance(args[0], string_t):


### PR DESCRIPTION
I noticed that  `DISABLE_TRACEBACKS` env variables wasn't always respected by the logger.

For example in `kombu\mixin.py` (line 56) with this kind of code:
```python
    def on_connection_error(self, exc, interval):
        warn(W_CONN_ERROR, interval, exc, exc_info=1)
```

Debug, info and warn logger level weren't tested about the `DISABLE_TRACEBACKS` settings and now are to provide a way to disable traceback(s) printing or file-logging.

This change should not change the default behavior of log/logger unless the `DISABLE_TRACEBACKS` env variable is set.