### PR TITLE
Support SSL URL parameters correctly for rediss protocol

### DIFF
--- a/kombu/utils/url.py
+++ b/kombu/utils/url.py
@@ -45,21 +45,20 @@ def parse_url(url):
     """Parse URL into mapping of components."""
     scheme, host, port, user, password, path, query = _parse_url(url)
     if query:
-        keys = list(query.keys())
+        keys = [key for key in query.keys() if key.startswith('ssl_')]
         for key in keys:
-            if key.startswith('ssl_'):
-                if key == 'ssl_cert_reqs':
-                    if ssl_available:
-                        query[key] = getattr(ssl, query[key])
-                    else:
-                        query[key] = None
-                        logger.warn('Defaulting to insecure SSL behaviour.')
+            if key == 'ssl_cert_reqs':
+                if ssl_available:
+                    query[key] = getattr(ssl, query[key])
+                else:
+                    query[key] = None
+                    logger.warn('Defaulting to insecure SSL behaviour.')
 
-                if 'ssl' not in query:
-                    query['ssl'] = {}
+            if 'ssl' not in query:
+                query['ssl'] = {}
 
-                query['ssl'][key] = query[key]
-                del query[key]
+            query['ssl'][key] = query[key]
+            del query[key]
 
     return dict(transport=scheme, hostname=host,
                 port=port, userid=user,

--- a/kombu/utils/url.py
+++ b/kombu/utils/url.py
@@ -27,6 +27,7 @@ from .compat import NamedTuple
 from ..log import get_logger
 
 safequote = partial(quote, safe=bytes_if_py2(''))
+logger = get_logger(__name__)
 
 
 urlparts = NamedTuple('urlparts', [

--- a/kombu/utils/url.py
+++ b/kombu/utils/url.py
@@ -51,7 +51,6 @@ def parse_url(url):
                 if key == 'ssl_cert_reqs':
                     if ssl_available:
                         query[key] = getattr(ssl, query[key])
-
                     else:
                         query[key] = None
                         logger.warn('Defaulting to insecure SSL behaviour.')

--- a/t/unit/utils/test_url.py
+++ b/t/unit/utils/test_url.py
@@ -8,9 +8,9 @@ except ImportError:
 
 import ssl
 
-from case import mock
 import pytest
 
+import kombu.utils.url
 from kombu.utils.url import as_url, parse_url, maybe_sanitize_url
 
 
@@ -63,16 +63,9 @@ def test_ssl_parameters():
     assert kwargs['ssl']['ssl_certfile'] == '/var/ssl/server-cert.pem'
     assert kwargs['ssl']['ssl_keyfile'] == '/var/ssl/priv/worker-key.pem'
 
+    kombu.utils.url.ssl_available = False
 
-@mock.mask_modules('ssl')
-def test_ssl_parameters_no_ssl_module():
-    from kombu.utils.url import parse_url
-    url = 'rediss://user:password@host:6379/0?'
-    querystring = urlencode({
-        'ssl_cert_reqs': 'CERT_REQUIRED',
-        'ssl_ca_certs': '/var/ssl/myca.pem',
-        'ssl_certfile': '/var/ssl/server-cert.pem',
-        'ssl_keyfile': '/var/ssl/priv/worker-key.pem',
-    })
     kwargs = parse_url(url + querystring)
     assert kwargs['ssl']['ssl_cert_reqs'] is None
+
+    kombu.utils.url.ssl_available = True

--- a/t/unit/utils/test_url.py
+++ b/t/unit/utils/test_url.py
@@ -64,8 +64,8 @@ def test_ssl_parameters():
     if ssl_available:
         assert kwargs['ssl']['ssl_cert_reqs'] == ssl.CERT_REQUIRED
         assert kwargs['ssl']['ssl_ca_certs'] == '/var/ssl/myca.pem'
-        assert kwargs['ssl']['ssl_certfile'] == '/var/ssl/redis-server-cert.pem'
-        assert kwargs['ssl']['ssl_keyfile'] == '/var/ssl/private/worker-key.pem'
+        assert kwargs['ssl']['ssl_certfile'] == '/var/ssl/server-cert.pem'
+        assert kwargs['ssl']['ssl_keyfile'] == '/var/ssl/priv/worker-key.pem'
 
     else:
         assert kwargs['ssl']['ssl_cert_reqs'] is None

--- a/t/unit/utils/test_url.py
+++ b/t/unit/utils/test_url.py
@@ -6,6 +6,12 @@ try:
 except ImportError:
     from urllib import urlencode
 
+try:
+    import ssl
+    ssl_available = True
+except ImportError:  # pragma: no cover
+    ssl_available = False
+
 import pytest
 
 from kombu.utils.url import as_url, parse_url, maybe_sanitize_url
@@ -55,7 +61,11 @@ def test_ssl_parameters():
     })
     kwargs = parse_url(url + querystring)
     assert kwargs['transport'] == 'rediss'
-    assert kwargs['ssl']['ssl_cert_reqs'].value == 2
-    assert kwargs['ssl']['ssl_ca_certs'] == '/var/ssl/myca.pem'
-    assert kwargs['ssl']['ssl_certfile'] == '/var/ssl/redis-server-cert.pem'
-    assert kwargs['ssl']['ssl_keyfile'] == '/var/ssl/private/worker-key.pem'
+    if ssl_available:
+        assert kwargs['ssl']['ssl_cert_reqs'].value == 2
+        assert kwargs['ssl']['ssl_ca_certs'] == '/var/ssl/myca.pem'
+        assert kwargs['ssl']['ssl_certfile'] == '/var/ssl/redis-server-cert.pem'
+        assert kwargs['ssl']['ssl_keyfile'] == '/var/ssl/private/worker-key.pem'
+
+    else:
+        assert kwargs['ssl']['ssl_cert_reqs'] is None

--- a/t/unit/utils/test_url.py
+++ b/t/unit/utils/test_url.py
@@ -6,12 +6,6 @@ try:
 except ImportError:
     from urllib import urlencode
 
-try:
-    import ssl
-    ssl_available = True
-except ImportError:  # pragma: no cover
-    ssl_available = False
-
 from case import mock
 import pytest
 
@@ -70,6 +64,7 @@ def test_ssl_parameters():
 
 @mock.mask_modules('ssl')
 def test_ssl_parameters_no_ssl_module():
+    from kombu.utils.url import parse_url
     url = 'rediss://user:password@host:6379/0?'
     querystring = urlencode({
         'ssl_cert_reqs': 'CERT_REQUIRED',

--- a/t/unit/utils/test_url.py
+++ b/t/unit/utils/test_url.py
@@ -6,6 +6,8 @@ try:
 except ImportError:
     from urllib import urlencode
 
+import ssl
+
 from case import mock
 import pytest
 

--- a/t/unit/utils/test_url.py
+++ b/t/unit/utils/test_url.py
@@ -12,6 +12,7 @@ try:
 except ImportError:  # pragma: no cover
     ssl_available = False
 
+from case import mock
 import pytest
 
 from kombu.utils.url import as_url, parse_url, maybe_sanitize_url
@@ -61,11 +62,20 @@ def test_ssl_parameters():
     })
     kwargs = parse_url(url + querystring)
     assert kwargs['transport'] == 'rediss'
-    if ssl_available:
-        assert kwargs['ssl']['ssl_cert_reqs'] == ssl.CERT_REQUIRED
-        assert kwargs['ssl']['ssl_ca_certs'] == '/var/ssl/myca.pem'
-        assert kwargs['ssl']['ssl_certfile'] == '/var/ssl/server-cert.pem'
-        assert kwargs['ssl']['ssl_keyfile'] == '/var/ssl/priv/worker-key.pem'
+    assert kwargs['ssl']['ssl_cert_reqs'] == ssl.CERT_REQUIRED
+    assert kwargs['ssl']['ssl_ca_certs'] == '/var/ssl/myca.pem'
+    assert kwargs['ssl']['ssl_certfile'] == '/var/ssl/server-cert.pem'
+    assert kwargs['ssl']['ssl_keyfile'] == '/var/ssl/priv/worker-key.pem'
 
-    else:
-        assert kwargs['ssl']['ssl_cert_reqs'] is None
+
+@mock.mask_modules('ssl')
+def test_ssl_parameters_no_ssl_module():
+    url = 'rediss://user:password@host:6379/0?'
+    querystring = urlencode({
+        'ssl_cert_reqs': 'CERT_REQUIRED',
+        'ssl_ca_certs': '/var/ssl/myca.pem',
+        'ssl_certfile': '/var/ssl/server-cert.pem',
+        'ssl_keyfile': '/var/ssl/priv/worker-key.pem',
+    })
+    kwargs = parse_url(url + querystring)
+    assert kwargs['ssl']['ssl_cert_reqs'] is None

--- a/t/unit/utils/test_url.py
+++ b/t/unit/utils/test_url.py
@@ -56,8 +56,8 @@ def test_ssl_parameters():
     querystring = urlencode({
         'ssl_cert_reqs': 'CERT_REQUIRED',
         'ssl_ca_certs': '/var/ssl/myca.pem',
-        'ssl_certfile': '/var/ssl/redis-server-cert.pem',
-        'ssl_keyfile': '/var/ssl/private/worker-key.pem',
+        'ssl_certfile': '/var/ssl/server-cert.pem',
+        'ssl_keyfile': '/var/ssl/priv/worker-key.pem',
     })
     kwargs = parse_url(url + querystring)
     assert kwargs['transport'] == 'rediss'

--- a/t/unit/utils/test_url.py
+++ b/t/unit/utils/test_url.py
@@ -62,7 +62,7 @@ def test_ssl_parameters():
     kwargs = parse_url(url + querystring)
     assert kwargs['transport'] == 'rediss'
     if ssl_available:
-        assert kwargs['ssl']['ssl_cert_reqs'].value == 2
+        assert kwargs['ssl']['ssl_cert_reqs'] == ssl.CERT_REQUIRED
         assert kwargs['ssl']['ssl_ca_certs'] == '/var/ssl/myca.pem'
         assert kwargs['ssl']['ssl_certfile'] == '/var/ssl/redis-server-cert.pem'
         assert kwargs['ssl']['ssl_keyfile'] == '/var/ssl/private/worker-key.pem'


### PR DESCRIPTION
If you use the `rediss://` protocol as recommended in Celery:
```
result_backend = 'rediss://:password@host:port/db?\
    ssl_cert_reqs=CERT_REQUIRED\
    &ssl_ca_certs=%2Fvar%2Fssl%2Fmyca.pem\                  # /var/ssl/myca.pem
    &ssl_certfile=%2Fvar%2Fssl%2Fredis-server-cert.pem\     # /var/ssl/redis-server-cert.pem
    &ssl_keyfile=%2Fvar%2Fssl%2Fprivate%2Fworker-key.pem'   # /var/ssl/private/worker-key.pem
```
http://docs.celeryproject.org/en/latest/userguide/configuration.html#configuring-the-backend-url

The URL does not get initialized with the correct SSL parameters.

I added some extra logic in the URL parser to extract SSL parameters and pass them through correctly.
