### PR TITLE
Restore bz2 import checks in compression.py

### DIFF
--- a/kombu/compression.py
+++ b/kombu/compression.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, unicode_literals
 
 from kombu.utils.encoding import ensure_bytes
 
-import bz2
 import zlib
 
 try:
@@ -82,9 +81,14 @@ register(zlib.compress,
          zlib.decompress,
          'application/x-gzip', aliases=['gzip', 'zlib'])
 
-register(bz2.compress,
-         bz2.decompress,
-         'application/x-bz2', aliases=['bzip2', 'bzip'])
+try:
+    import bz2
+except ImportError:
+    pass  # No bz2 support
+else:
+    register(bz2.compress,
+             bz2.decompress,
+             'application/x-bz2', aliases=['bzip2', 'bzip'])
 
 try:
     import brotli

--- a/t/unit/test_compression.py
+++ b/t/unit/test_compression.py
@@ -2,6 +2,10 @@ from __future__ import absolute_import, unicode_literals
 
 import pytest
 
+import sys
+
+from case import mock, skip
+
 from kombu import compression
 
 
@@ -10,6 +14,7 @@ class test_compression:
     def test_encoders__gzip(self):
         assert 'application/x-gzip' in compression.encoders()
 
+    @skip.unless_module('bz2')
     def test_encoders__bz2(self):
         assert 'application/x-bz2' in compression.encoders()
 
@@ -79,3 +84,13 @@ class test_compression:
         assert text != c
         d = compression.decompress(c, ctype)
         assert d == text
+
+    @mock.mask_modules('bz2')
+    def test_no_bz2(self):
+        c = sys.modules.pop('kombu.compression')
+        try:
+            import kombu.compression
+            assert not hasattr(kombu.compression, 'bz2')
+        finally:
+            if c is not None:
+                sys.modules['kombu.compression'] = c


### PR DESCRIPTION
This was removed in #938 due to assumption that it only affected Jython but
the condition can be present in systems built without bz2 support.

Not sure if this is a system configuration the project wants to support but systems without bz2 work with 4.2.2 and fail with 4.3.0.

This is essentially a rollback of the #938