### PR TITLE
Handle the case when only one Redis Sentinel node is provided

### DIFF
--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -1100,13 +1100,19 @@ class SentinelChannel(Channel):
 
         additional_params.pop('host', None)
         additional_params.pop('port', None)
-        connection_list = []
+
+        sentinels = []
         for url in self.connection.client.alt:
             url = _parse_url(url)
             if url.scheme == 'sentinel':
-                connection_list.append([url.hostname, str(url.port)])
+                sentinels.append((url.hostname, url.port))
+
+        # Fallback for when only one sentinel is provided.
+        if not sentinels:
+            sentinels.append((connparams['host'], connparams['port']))
+
         sentinel_inst = sentinel.Sentinel(
-            connection_list,
+            sentinels,
             min_other_sentinels=getattr(self, 'min_other_sentinels', 0),
             sentinel_kwargs=getattr(self, 'sentinel_kwargs', None),
             **additional_params)

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -1356,11 +1356,33 @@ class test_RedisSentinel:
             connection.channel()
             patched.assert_called_once_with(
                 [
-                    [u'localhost', u'65532'],
-                    [u'localhost', u'65533'],
-                    [u'localhost', u'65534'],
-                    [u'localhost', u'65535'],
+                    (u'localhost', 65532),
+                    (u'localhost', 65533),
+                    (u'localhost', 65534),
+                    (u'localhost', 65535),
                 ],
+                connection_class=mock.ANY, db=0, max_connections=10,
+                min_other_sentinels=0, password=None, sentinel_kwargs=None,
+                socket_connect_timeout=None, socket_keepalive=None,
+                socket_keepalive_options=None, socket_timeout=None)
+
+            master_for = patched.return_value.master_for
+            master_for.assert_called()
+            master_for.assert_called_with('not_important', ANY)
+            master_for().connection_pool.get_connection.assert_called()
+
+    def test_getting_master_from_sentinel_single_node(self):
+        with patch('redis.sentinel.Sentinel') as patched:
+            connection = Connection(
+                'sentinel://localhost:65532/',
+                transport_options={
+                    'master_name': 'not_important',
+                },
+            )
+
+            connection.channel()
+            patched.assert_called_once_with(
+                [(u'localhost', 65532)],
                 connection_class=mock.ANY, db=0, max_connections=10,
                 min_other_sentinels=0, password=None, sentinel_kwargs=None,
                 socket_connect_timeout=None, socket_keepalive=None,


### PR DESCRIPTION
The problem is that `self.connection.client.alt` is only populated when there's more than one client URL provided, e.g. `"sentinel://foo;sentinel://bar"`. It will also always contain all URLs, including the primary/first entry.

So if the `alt` list is empty, it (usually) means there was only one client URL provided.

I also took the liberty to perform name and type changes to be more in line with the examples and documentation in the `redis` library. The argument is `sentinels`, not `connection_list`. And it's of the type `List[Tuple[str, int]]`, not `List[List[str, str]]`.

Fixes #1004