### PR TITLE
ISSUE-1006: Port improved connection disconnect from redis-py 3.2.0

### DIFF
--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -938,6 +938,11 @@ class Channel(virtual.Channel):
                     # to become unusable, however close() only
                     # affect process-local copies of fds.
                     # So we just override Connection's disconnect method.
+                    #
+                    # TODO: The above note has been fixed in redis-py v3.2.0
+                    # and can be removed when support for versions older than
+                    # v3.2 has been dropped and be replaced with a call to
+                    # 'super().disconnect()'.
                     self._parser.on_disconnect()
                     channel._on_connection_disconnect(self)
                     if self._sock is None:

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import numbers
+import os
 import socket
 
 from bisect import bisect
@@ -942,7 +943,8 @@ class Channel(virtual.Channel):
                     if self._sock is None:
                         return
                     try:
-                        # self._sock.shutdown(socket.SHUT_RDWR)
+                        if os.getpid() == self.pid:
+                            self._sock.shutdown(socket.SHUT_RDWR)
                         self._sock.close()
                     except socket.error:
                         pass


### PR DESCRIPTION
Solution proposal 2 to fix #1006. See #1011 proposal 1.

Port the fixes of `Connection.disconnect` from upstream redis-py v3.2.0: https://github.com/andymccurdy/redis-py/commit/4e1e74809235edc19e03edb79c97c80a3e4e9eca

Fixes #1006