### PR TITLE
qpid: correctly declare support for async event loop

### DIFF
--- a/kombu/transport/qpid.py
+++ b/kombu/transport/qpid.py
@@ -119,7 +119,7 @@ except ImportError:  # pragma: no cover
 from kombu.five import Empty, items, monotonic, PY3
 from kombu.log import get_logger
 from kombu.transport.virtual import Base64, Message
-from kombu.transport import base
+from kombu.transport import base, virtual
 
 
 logger = get_logger(__name__)
@@ -1406,7 +1406,9 @@ class Transport(base.Transport):
     polling_interval = None
 
     # This Transport does support the Celery asynchronous event model.
-    supports_ev = True
+    implements = virtual.Transport.implements.extend(
+        asynchronous=True,
+    )
 
     # The driver type and name for identification purposes.
     driver_type = 'qpid'

--- a/t/unit/transport/test_qpid.py
+++ b/t/unit/transport/test_qpid.py
@@ -1663,9 +1663,6 @@ class test_Transport_class_attributes(object):
     def test_verify_polling_disabled(self):
         assert Transport.polling_interval is None
 
-    def test_transport_verify_supports_asynchronous_events(self):
-        assert Transport.supports_ev
-
     def test_verify_driver_type_and_name(self):
         assert Transport.driver_type == 'qpid'
         assert Transport.driver_name == 'qpid'
@@ -1818,6 +1815,10 @@ class test_Transport(object):
     def setup(self):
         """Creates a mock_client to be used in testing."""
         self.mock_client = Mock()
+
+    def test_supports_ev(self):
+        """Test that the transport claims to support async event loop"""
+        assert Transport(self.mock_client).supports_ev
 
     def test_close_connection(self):
         """Test that close_connection calls close on the connection."""


### PR DESCRIPTION
qpid transport supports an async interface, but this wasn't declared
properly. It was missing an appropriate 'implements' class property.

This seems to have been missed because:

- kombu 4.x was branched from 3.0.21
- qpid transport was originally added after that in 3.0.24
- Transport.implements was added in commit 6a1abb7e9 on the 4.x branch
  only, before the qpid transport was in that branch
- qpid transport code was then copied between 3.x and 4.x branches but
  addition of Transport.implements was missed.