### PR TITLE
Allow users to switch URLs while omitting the resource identifier

### DIFF
--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -220,16 +220,22 @@ class Connection(object):
 
         self.declared_entities = set()
 
-    def switch(self, url):
-        """Switch connection parameters to use a new URL.
+    def switch(self, conn_str):
+        """Switch connection parameters to use a new URL or hostname.
 
         Note:
             Does not reconnect!
+
+        Arguments:
+            conn_str (str): either a hostname or URL.
         """
         self.close()
         self.declared_entities.clear()
         self._closed = False
-        self._init_params(**dict(self._initial_params, **parse_url(url)))
+        conn_params = (
+            parse_url(conn_str) if "://" in conn_str else {"hostname": conn_str}
+        )
+        self._init_params(**dict(self._initial_params, **conn_params))
 
     def maybe_switch_next(self):
         """Switch to next URL given by the current failover strategy."""

--- a/t/unit/test_connection.py
+++ b/t/unit/test_connection.py
@@ -299,6 +299,16 @@ class test_Connection:
         assert c.hostname == 'foo'
         assert c.transport_cls, ('librabbitmq', 'pyamqp' in 'amqp')
 
+    def test_switch_without_uri_identifier(self):
+        c = Connection('amqp://foo')
+        assert c.hostname == 'foo'
+        assert c.transport_cls, ('librabbitmq', 'pyamqp' in 'amqp')
+        c._closed = True
+        c.switch('example.com')
+        assert not c._closed
+        assert c.hostname == 'example.com'
+        assert c.transport_cls, ('librabbitmq', 'pyamqp' in 'amqp')
+
     def test_heartbeat_check(self):
         c = Connection(transport=Transport)
         c.transport.heartbeat_check = Mock()


### PR DESCRIPTION
Prior to this change, one needed to specify a URL using a URI
identifier, e.g., `pyamqp://foo.bar`. This change makes it so calling
`.switch(..)` again results in switching the host, not switching the
resource identifier.

This simplifies setting up connections with just hostnames specifying
the resource identifier once, separately.

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>