### PR TITLE
Include priority in properties only if it's not None

### DIFF
--- a/kombu/transport/librabbitmq.py
+++ b/kombu/transport/librabbitmq.py
@@ -57,8 +57,12 @@ class Channel(amqp.Channel, base.StdChannel):
         properties = properties if properties is not None else {}
         properties.update({'content_type': content_type,
                            'content_encoding': content_encoding,
-                           'headers': headers,
-                           'priority': priority})
+                           'headers': headers})
+        # Don't include priority if it's not an integer.
+        # If that's the case librabbitmq will fail
+        # and raise an exception.
+        if priority is not None:
+            properties['priority'] = priority
         return body, properties
 
     def prepare_queue_arguments(self, arguments, **kwargs):


### PR DESCRIPTION
Since we attempt to serialize the priority property if it exists in the dictionary (See https://github.com/celery/librabbitmq/blob/3fa1d38c4e66e6efdbdc7d584abe0a59857bef29/Modules/_librabbitmq/connection.c#L739) it must be an integer.

Fixes celery/celery#5340.