### PR TITLE
Removed dangerous default mutable arguments from function definitions…

### DIFF
--- a/kombu/asynchronous/timer.py
+++ b/kombu/asynchronous/timer.py
@@ -108,13 +108,16 @@ class Timer(object):
     def __exit__(self, *exc_info):
         self.stop()
 
-    def call_at(self, eta, fun, args=(), kwargs={}, priority=0):
+    def call_at(self, eta, fun, args=(), kwargs=None, priority=0):
+        kwargs = {} if not kwargs else kwargs
         return self.enter_at(self.Entry(fun, args, kwargs), eta, priority)
 
-    def call_after(self, secs, fun, args=(), kwargs={}, priority=0):
+    def call_after(self, secs, fun, args=(), kwargs=None, priority=0):
+        kwargs = {} if not kwargs else kwargs
         return self.enter_after(secs, self.Entry(fun, args, kwargs), priority)
 
-    def call_repeatedly(self, secs, fun, args=(), kwargs={}, priority=0):
+    def call_repeatedly(self, secs, fun, args=(), kwargs=None, priority=0):
+        kwargs = {} if not kwargs else kwargs
         tref = self.Entry(fun, args, kwargs)
 
         @wraps(fun)

--- a/kombu/entity.py
+++ b/kombu/entity.py
@@ -30,8 +30,9 @@ def pretty_bindings(bindings):
 
 
 def maybe_delivery_mode(
-        v, modes=DELIVERY_MODES, default=PERSISTENT_DELIVERY_MODE):
+        v, modes=None, default=PERSISTENT_DELIVERY_MODE):
     """Get delivery mode by name (or none if undefined)."""
+    modes = DELIVERY_MODES if not modes else modes
     if v:
         return v if isinstance(v, numbers.Integral) else modes[v]
     return default

--- a/kombu/log.py
+++ b/kombu/log.py
@@ -47,9 +47,8 @@ def naive_format_parts(fmt):
         yield None if not e or not parts[i - 1] else e[0]
 
 
-def safeify_format(fmt, args,
-                   filters={'s': safe_str,
-                            'r': safe_repr}):
+def safeify_format(fmt, args, filters=None):
+    filters = {'s': safe_str, 'r': safe_repr} if not filters else filters
     for index, type in enumerate(naive_format_parts(fmt)):
         filt = filters.get(type)
         yield filt(args[index]) if filt else args[index]

--- a/kombu/message.py
+++ b/kombu/message.py
@@ -61,9 +61,10 @@ class Message(object):
         )
 
     def __init__(self, body=None, delivery_tag=None,
-                 content_type=None, content_encoding=None, delivery_info={},
+                 content_type=None, content_encoding=None, delivery_info=None,
                  properties=None, headers=None, postencode=None,
                  accept=None, channel=None, **kwargs):
+        delivery_info = {} if not delivery_info else delivery_info
         self.errors = [] if self.errors is None else self.errors
         self.channel = channel
         self.delivery_tag = delivery_tag

--- a/kombu/pidbox.py
+++ b/kombu/pidbox.py
@@ -115,7 +115,8 @@ class Node(object):
                        ticket=ticket)
         return reply
 
-    def handle(self, method, arguments={}):
+    def handle(self, method, arguments=None):
+        arguments = {} if not arguments else arguments
         return self.handlers[method](self.state, **arguments)
 
     def handle_call(self, method, arguments):
@@ -208,21 +209,25 @@ class Mailbox(object):
         hostname = hostname or socket.gethostname()
         return self.node_cls(hostname, state, channel, handlers, mailbox=self)
 
-    def call(self, destination, command, kwargs={},
+    def call(self, destination, command, kwargs=None,
              timeout=None, callback=None, channel=None):
+        kwargs = {} if not kwargs else kwargs
         return self._broadcast(command, kwargs, destination,
                                reply=True, timeout=timeout,
                                callback=callback,
                                channel=channel)
 
-    def cast(self, destination, command, kwargs={}):
+    def cast(self, destination, command, kwargs=None):
+        kwargs = {} if not kwargs else kwargs
         return self._broadcast(command, kwargs, destination, reply=False)
 
-    def abcast(self, command, kwargs={}):
+    def abcast(self, command, kwargs=None):
+        kwargs = {} if not kwargs else kwargs
         return self._broadcast(command, kwargs, reply=False)
 
-    def multi_call(self, command, kwargs={}, timeout=1,
+    def multi_call(self, command, kwargs=None, timeout=1,
                    limit=None, callback=None, channel=None):
+        kwargs = {} if not kwargs else kwargs
         return self._broadcast(command, kwargs, reply=True,
                                timeout=timeout, limit=limit,
                                callback=callback,

--- a/kombu/serialization.py
+++ b/kombu/serialization.py
@@ -411,7 +411,7 @@ _setupfuns = {
 }
 
 
-def enable_insecure_serializers(choices=['pickle', 'yaml', 'msgpack']):
+def enable_insecure_serializers(choices=None):
     """Enable serializers that are considered to be unsafe.
 
     Note:
@@ -419,6 +419,7 @@ def enable_insecure_serializers(choices=['pickle', 'yaml', 'msgpack']):
         can also specify a list of serializers (by name or content type)
         to enable.
     """
+    choices = ['pickle', 'yaml', 'msgpack'] if not choices else choices
     for choice in choices:
         try:
             registry.enable(choice)
@@ -426,7 +427,7 @@ def enable_insecure_serializers(choices=['pickle', 'yaml', 'msgpack']):
             pass
 
 
-def disable_insecure_serializers(allowed=['json']):
+def disable_insecure_serializers(allowed=None):
     """Disable untrusted serializers.
 
     Will disable all serializers except ``json``
@@ -437,6 +438,7 @@ def disable_insecure_serializers(allowed=['json']):
         in these formats, but consumers will not accept
         incoming data using the untrusted content types.
     """
+    allowed = ['json'] if not allowed else allowed
     for name in registry._decoders:
         registry.disable(name)
     if allowed is not None:
@@ -452,7 +454,8 @@ for ep, args in entrypoints('kombu.serializers'):  # pragma: no cover
     register(ep.name, *args)
 
 
-def prepare_accept_content(l, name_to_type=registry.name_to_type):
+def prepare_accept_content(l, name_to_type=None):
+    name_to_type = registry.name_to_type if not name_to_type else name_to_type
     if l is not None:
         return {n if '/' in n else name_to_type[n] for n in l}
     return l

--- a/kombu/utils/debug.py
+++ b/kombu/utils/debug.py
@@ -11,9 +11,9 @@ from kombu.log import get_logger
 __all__ = ('setup_logging', 'Logwrapped')
 
 
-def setup_logging(loglevel=logging.DEBUG, loggers=['kombu.connection',
-                                                   'kombu.channel']):
+def setup_logging(loglevel=logging.DEBUG, loggers=None):
     """Setup logging to stdout."""
+    loggers = ['kombu.connection', 'kombu.channel'] if not loggers else loggers
     for logger_name in loggers:
         logger = get_logger(logger_name)
         logger.addHandler(logging.StreamHandler())

--- a/kombu/utils/functional.py
+++ b/kombu/utils/functional.py
@@ -299,7 +299,7 @@ def fxrangemax(start=1.0, stop=None, step=1.0, max=100.0):
         sum_ += cur
 
 
-def retry_over_time(fun, catch, args=[], kwargs={}, errback=None,
+def retry_over_time(fun, catch, args=None, kwargs=None, errback=None,
                     max_retries=None, interval_start=2, interval_step=2,
                     interval_max=30, callback=None, timeout=None):
     """Retry the function over and over until max retries is exceeded.
@@ -332,6 +332,8 @@ def retry_over_time(fun, catch, args=[], kwargs={}, errback=None,
             between retries.
         timeout (int): Maximum seconds waiting before we give up.
     """
+    kwargs = {} if not kwargs else kwargs
+    args = [] if not args else args
     interval_range = fxrange(interval_start,
                              interval_max + interval_start,
                              interval_step, repeatlast=True)
@@ -361,7 +363,8 @@ def reprkwargs(kwargs, sep=', ', fmt='{0}={1}'):
     return sep.join(fmt.format(k, _safe_repr(v)) for k, v in items(kwargs))
 
 
-def reprcall(name, args=(), kwargs={}, sep=', '):
+def reprcall(name, args=(), kwargs=None, sep=', '):
+    kwargs = {} if not kwargs else kwargs
     return '{0}({1}{2}{3})'.format(
         name, sep.join(map(_safe_repr, args or ())),
         (args and kwargs) and sep or '',

--- a/kombu/utils/imports.py
+++ b/kombu/utils/imports.py
@@ -7,7 +7,7 @@ import sys
 from kombu.five import reraise, string_t
 
 
-def symbol_by_name(name, aliases={}, imp=None, package=None,
+def symbol_by_name(name, aliases=None, imp=None, package=None,
                    sep='.', default=None, **kwargs):
     """Get symbol by qualified name.
 
@@ -40,6 +40,7 @@ def symbol_by_name(name, aliases={}, imp=None, package=None,
         >>> symbol_by_name(TaskPool) is TaskPool
         True
     """
+    aliases = {} if not aliases else aliases
     if imp is None:
         imp = importlib.import_module
 

--- a/kombu/utils/json.py
+++ b/kombu/utils/json.py
@@ -62,9 +62,9 @@ class JSONEncoder(_encoder_cls):
 _default_encoder = JSONEncoder
 
 
-def dumps(s, _dumps=json.dumps, cls=None,
-          default_kwargs=_json_extra_kwargs, **kwargs):
+def dumps(s, _dumps=json.dumps, cls=None, default_kwargs=None, **kwargs):
     """Serialize object to json string."""
+    default_kwargs = _json_extra_kwargs if not default_kwargs else default_kwargs
     return _dumps(s, cls=cls or _default_encoder,
                   **dict(default_kwargs, **kwargs))
 

--- a/kombu/utils/json.py
+++ b/kombu/utils/json.py
@@ -64,7 +64,8 @@ _default_encoder = JSONEncoder
 
 def dumps(s, _dumps=json.dumps, cls=None, default_kwargs=None, **kwargs):
     """Serialize object to json string."""
-    default_kwargs = _json_extra_kwargs if not default_kwargs else default_kwargs
+    if not default_kwargs:
+        default_kwargs = _json_extra_kwargs
     return _dumps(s, cls=cls or _default_encoder,
                   **dict(default_kwargs, **kwargs))
 


### PR DESCRIPTION
In several places, Celery & Kombu use dangerous default arguments which may cause subtle, insidious bugs, e.g.:

# bug demo code, not in Celery:

In [1]: def append(number, number_list=[]):
   ...:     number_list.append(number)
   ...:     print(number_list)
   ...:     return number_list
   ...: 

In [2]: append(5)  # expecting: [5], actual: [5]
[5]
Out[2]: [5]

In [3]: append(7)  # expecting: [7], actual: [5, 7]
[5, 7]
Out[3]: [5, 7]

In [4]: append(2)  # expecting: [2], actual: [5, 7, 2]
[5, 7, 2]
Out[4]: [5, 7, 2]

--As you can see, mutable default arguments can cause unwanted caching and spurious persistent values 
that can make debugging difficult.

