### PR TITLE
Add events field on memory channel

### DIFF
--- a/kombu/transport/memory.py
+++ b/kombu/transport/memory.py
@@ -5,11 +5,13 @@ from kombu.five import Queue, values
 
 from . import base
 from . import virtual
+from collections import defaultdict
 
 
 class Channel(virtual.Channel):
     """In-memory Channel."""
 
+    events = defaultdict(set)
     queues = {}
     do_restore = False
     supports_fanout = True

--- a/t/unit/transport/test_memory.py
+++ b/t/unit/transport/test_memory.py
@@ -181,4 +181,3 @@ class test_MemoryTransport:
 
         assert self.q3(self.c).get().payload == {'hello': 'on return'}
         assert self.q3(self.c).get() is None
-

--- a/t/unit/transport/test_memory.py
+++ b/t/unit/transport/test_memory.py
@@ -171,4 +171,14 @@ class test_MemoryTransport:
             pass
         channel = self.c.channel()
         producer = Producer(channel, on_return=on_return)
-        producer.publish({"foo": "bar"})
+        consumer = self.c.Consumer([self.q3])
+
+        producer.publish(
+            {'hello': 'on return'},
+            declare=consumer.queues,
+            exchange=self.fanout,
+        )
+
+        assert self.q3(self.c).get().payload == {'hello': 'on return'}
+        assert self.q3(self.c).get() is None
+

--- a/t/unit/transport/test_memory.py
+++ b/t/unit/transport/test_memory.py
@@ -163,3 +163,12 @@ class test_MemoryTransport:
         x = chan._queue_for('foo')
         assert x
         assert chan._queue_for('foo') is x
+
+    # see the issue
+    # https://github.com/celery/kombu/issues/1050
+    def test_producer_on_return(self):
+        def on_return(_exception, _exchange, _routing_key, _message):
+            pass
+        channel = self.c.channel()
+        producer = Producer(channel, on_return=on_return)
+        producer.publish({"foo": "bar"})


### PR DESCRIPTION
Part of https://github.com/celery/kombu/issues/1050, with this fix
the function does not raise the exception.
The init `defaultdict(set)` is the same init from amqp lib.