### PR TITLE
Removed bz2 fallbacks.

### DIFF
--- a/kombu/compression.py
+++ b/kombu/compression.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 
 from kombu.utils.encoding import ensure_bytes
 
+import bz2
 import zlib
 
 try:
@@ -81,14 +82,9 @@ register(zlib.compress,
          zlib.decompress,
          'application/x-gzip', aliases=['gzip', 'zlib'])
 
-try:
-    import bz2
-except ImportError:
-    pass  # No bz2 support
-else:
-    register(bz2.compress,
-             bz2.decompress,
-             'application/x-bz2', aliases=['bzip2', 'bzip'])
+register(bz2.compress,
+         bz2.decompress,
+         'application/x-bz2', aliases=['bzip2', 'bzip'])
 
 try:
     import brotli

--- a/t/unit/test_compression.py
+++ b/t/unit/test_compression.py
@@ -2,10 +2,6 @@ from __future__ import absolute_import, unicode_literals
 
 import pytest
 
-import sys
-
-from case import mock, skip
-
 from kombu import compression
 
 
@@ -14,7 +10,6 @@ class test_compression:
     def test_encoders__gzip(self):
         assert 'application/x-gzip' in compression.encoders()
 
-    @skip.unless_module('bz2')
     def test_encoders__bz2(self):
         assert 'application/x-bz2' in compression.encoders()
 
@@ -84,13 +79,3 @@ class test_compression:
         assert text != c
         d = compression.decompress(c, ctype)
         assert d == text
-
-    @mock.mask_modules('bz2')
-    def test_no_bz2(self):
-        c = sys.modules.pop('kombu.compression')
-        try:
-            import kombu.compression
-            assert not hasattr(kombu.compression, 'bz2')
-        finally:
-            if c is not None:
-                sys.modules['kombu.compression'] = c


### PR DESCRIPTION
https://docs.python.org/3/library/bz2.html bz2 is in the standard library.