### PR TITLE
Use fastuuid on CPython>=3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ before_install:
   - sudo apt install libcurl4-openssl-dev libssl-dev gnutls-dev
 install:
     - pip --disable-pip-version-check install -U pip setuptools wheel | cat
-    - pip --disable-pip-version-check install -U tox | cat
+    - pip --disable-pip-version-check install --upgrade-strategy eager -U tox | cat
 script: tox -v -- -v
 after_success:
   - .tox/$TRAVIS_PYTHON_VERSION/bin/coverage xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,8 @@ matrix:
       dist: xenial
       python: 3.7
 
+before_install:
+  - sudo apt install libcurl4-openssl-dev libssl-dev gnutls-dev
 install:
     - pip --disable-pip-version-check install -U pip setuptools wheel | cat
     - pip --disable-pip-version-check install -U tox | cat

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ matrix:
       python: 3.7
 
 before_install:
+  - sudo apt update
   - sudo apt install libcurl4-openssl-dev libssl-dev gnutls-dev
 install:
     - pip --disable-pip-version-check install -U pip setuptools wheel | cat

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,15 +38,19 @@ matrix:
     - env: TOXENV=flake8
       stage: lint
       dist: xenial
+      python: 3.7
     - env: TOXENV=flakeplus
       stage: lint
       dist: xenial
+      python: 2.7
     - env: TOXENV=apicheck
       stage: lint
       dist: xenial
+      python: 3.7
     - env: TOXENV=pydocstyle
       stage: lint
       dist: xenial
+      python: 3.7
 
 install:
     - pip --disable-pip-version-check install -U pip setuptools wheel | cat

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,19 @@ env:
 stages:
   - test
   - lint
-  
+
 
 matrix:
   include:
     - python: 2.7
       env: TOXENV=2.7
+      dist: xenial
     - python: 3.5
       env: TOXENV=3.5
+      dist: xenial
     - python: 3.6
       env: TOXENV=3.6
+      dist: xenial
     - python: 3.7
       env: TOXENV=3.7-linux
       sudo: true
@@ -34,12 +37,16 @@ matrix:
       before_install: sudo apt-get update && sudo apt-get install libgnutls-dev
     - env: TOXENV=flake8
       stage: lint
+      dist: xenial
     - env: TOXENV=flakeplus
       stage: lint
+      dist: xenial
     - env: TOXENV=apicheck
       stage: lint
+      dist: xenial
     - env: TOXENV=pydocstyle
       stage: lint
+      dist: xenial
 
 install:
     - pip --disable-pip-version-check install -U pip setuptools wheel | cat

--- a/kombu/serialization.py
+++ b/kombu/serialization.py
@@ -415,6 +415,7 @@ NOTSET = object()
 
 def enable_insecure_serializers(choices=NOTSET):
     """Enable serializers that are considered to be unsafe.
+
     Note:
         Will enable ``pickle``, ``yaml`` and ``msgpack`` by default, but you
         can also specify a list of serializers (by name or content type)

--- a/kombu/utils/uuid.py
+++ b/kombu/utils/uuid.py
@@ -1,7 +1,10 @@
 """UUID utilities."""
 from __future__ import absolute_import, unicode_literals
 
-from uuid import uuid4
+try:
+    from fastuuid import uuid4
+except ImportError:
+    from uuid import uuid4
 
 
 def uuid(_uuid=uuid4):

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,2 +1,2 @@
 amqp>=2.5.0,<3.0
-fastuuid;platform_python_implementation=="CPython" and python_version>="3.5"
+fastuuid;platform_python_implementation=="CPython" and python_version>="3.5" and sys_platform=="linux"

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,1 +1,2 @@
 amqp>=2.5.0,<3.0
+fastuuid;platform_python_implementation=="CPython" and python_version>="3.5"


### PR DESCRIPTION
Use FastUUID when possible.
FastUUID provides bindings to Rust's UUID library.

It is much faster and I wrote the bindings so I know they are production ready.