### PR TITLE
Fix broken build steps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,8 @@ matrix:
     - python: '3.6'
       env: TOXENV=apicheck
       stage: lint
-    - env: TOXENV=pydocstyle
+    - python: '3.6'
+      env: TOXENV=pydocstyle
       stage: lint
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,8 @@ matrix:
       stage: lint
     - env: TOXENV=flakeplus
       stage: lint
-    - env: TOXENV=apicheck
+    - python: '3.6'
+      env: TOXENV=apicheck
       stage: lint
     - env: TOXENV=pydocstyle
       stage: lint

--- a/kombu/serialization.py
+++ b/kombu/serialization.py
@@ -415,6 +415,7 @@ NOTSET = object()
 
 def enable_insecure_serializers(choices=NOTSET):
     """Enable serializers that are considered to be unsafe.
+
     Note:
         Will enable ``pickle``, ``yaml`` and ``msgpack`` by default, but you
         can also specify a list of serializers (by name or content type)

--- a/tox.ini
+++ b/tox.ini
@@ -30,9 +30,9 @@ commands = pip install -U -r{toxinidir}/requirements/dev.txt
            pytest -rxs -xv --cov=kombu --cov-report=xml --no-cov-on-fail {posargs}
 
 basepython =
-    2.7,flakeplus,flake8,linkcheck,cov,pydocstyle: python2.7
+    2.7,flakeplus,flake8,linkcheck,cov: python2.7
     3.5: python3.5
-    3.6,apicheck: python3.6
+    3.6,apicheck,pydocstyle: python3.6
     3.7: python3.7
     pypy,pypy3: pypy
 

--- a/tox.ini
+++ b/tox.ini
@@ -30,9 +30,9 @@ commands = pip install -U -r{toxinidir}/requirements/dev.txt
            pytest -rxs -xv --cov=kombu --cov-report=xml --no-cov-on-fail {posargs}
 
 basepython =
-    2.7,flakeplus,flake8,apicheck,linkcheck,cov,pydocstyle: python2.7
+    2.7,flakeplus,flake8,linkcheck,cov,pydocstyle: python2.7
     3.5: python3.5
-    3.6: python3.6
+    3.6,apicheck: python3.6
     3.7: python3.7
     pypy,pypy3: pypy
 


### PR DESCRIPTION
- [x] Fix pydocstyle linting error
- [x] Move apicheck to Python 3 to be able to install Sphinx 2.0+.
- [x] Also move pydocstyle linting checks to Python 3

Flake8 doesn't pass on Python 3.6 due to some keyword left for Python 2 compat, will have to wait for when Python 2 is dropped (#990)