### PR TITLE
Issue 129 fix maybe declare

### DIFF
--- a/kombu/common.py
+++ b/kombu/common.py
@@ -122,7 +122,8 @@ def maybe_declare(entity, channel=None, retry=False, **retry_policy):
 
 
 def _ensure_channel_is_bound(entity, channel):
-    """Make sure the channel is bound to the entity
+    """Make sure the channel is bound to the entity.
+
     :param entity: generic kombu nomenclature, generally an exchange or queue
     :param channel: channel to bind to the entity
     :return: the updated entity

--- a/kombu/common.py
+++ b/kombu/common.py
@@ -130,7 +130,8 @@ def _ensure_channel_is_bound(entity, channel):
     is_bound = entity.is_bound
     if not is_bound:
         if not channel:
-            raise ChannelError("Cannot bind channel {} to entity {}".format(channel, entity))
+            raise ChannelError(
+                "Cannot bind channel {} to entity {}".format(channel, entity))
         entity = entity.bind(channel)
         return entity
 
@@ -142,7 +143,9 @@ def _maybe_declare(entity, channel):
     entity = _ensure_channel_is_bound(entity, channel)
 
     if channel is None:
-        assert entity.is_bound
+        if not entity.is_bound:
+            raise ChannelError(
+                "channel is None and entity {} not bound.".format(entity))
         channel = entity.channel
 
     declared = ident = None

--- a/kombu/common.py
+++ b/kombu/common.py
@@ -140,7 +140,7 @@ def _maybe_declare(entity, channel):
     # _maybe_declare sets name on original for autogen queues
     orig = entity
 
-    entity = _ensure_channel_is_bound(entity, channel)
+    _ensure_channel_is_bound(entity, channel)
 
     if channel is None:
         if not entity.is_bound:

--- a/kombu/common.py
+++ b/kombu/common.py
@@ -99,7 +99,7 @@ class Broadcast(Queue):
             queue = '{0}.{1}'.format(queue or 'bcast', uuid())
         else:
             queue = queue or 'bcast.{0}'.format(uuid())
-        return super(Broadcast, self).__init__(
+        super(Broadcast, self).__init__(
             alias=alias or name,
             queue=queue,
             name=queue,

--- a/t/unit/test_common.py
+++ b/t/unit/test_common.py
@@ -176,7 +176,7 @@ class test_maybe_declare:
             'interval_max': 1,
             'max_retries': 3,
             'interval_step': 0.2,
-            'errback': lambda x: print("Called test errback retry policy"),
+            'errback': lambda x: "Called test errback retry policy",
         }
 
         # When: calling maybe_declare with retry enabled

--- a/t/unit/test_common.py
+++ b/t/unit/test_common.py
@@ -103,6 +103,25 @@ class test_Broadcast:
 
 class test_maybe_declare:
 
+    def _get_mock_channel(self):
+        # Given: A mock Channel with mock'd connection/client/entities
+        channel = Mock()
+        channel.connection.client.declared_entities = set()
+        return channel
+
+    def _get_mock_entity(self, is_bound=False, can_cache_declaration=True):
+        # Given: A mock Entity that is not bound but will be to the channel when its called
+        entity = Mock()
+        entity.can_cache_declaration = can_cache_declaration
+        entity.is_bound = is_bound
+
+        def _bind_entity(channel):
+            entity.channel = channel
+            entity.is_bound = True
+            return entity
+        entity.bind = _bind_entity
+        return entity
+
     def test_cacheable(self):
         channel = Mock()
         client = channel.connection.client = Mock()
@@ -125,16 +144,39 @@ class test_maybe_declare:
             maybe_declare(entity)
 
     def test_binds_entities(self):
-        channel = Mock()
-        channel.connection.client.declared_entities = set()
-        entity = Mock()
-        entity.can_cache_declaration = True
-        entity.is_bound = False
-        entity.bind.return_value = entity
-        entity.bind.return_value.channel = channel
+        # Given: A mock Channel and mock entity
+        channel = self._get_mock_channel()
+        # Given: A mock Entity that is not bound
+        entity = self._get_mock_entity()
+        assert not entity.is_bound, "Expected entity unbound to begin test."
 
+        # When: calling maybe_declare with default of no retry policy
         maybe_declare(entity, channel)
-        entity.bind.assert_called_with(channel)
+
+        # Then: the entity is now bound because it called to bind it
+        assert entity.is_bound is True, "Expected entity is now marked bound."
+
+    def test_binds_entities_when_retry_policy(self):
+        # Given: A mock Channel and mock entity
+        channel = self._get_mock_channel()
+        # Given: A mock Entity that is not bound
+        entity = self._get_mock_entity()
+        assert not entity.is_bound, "Expected entity unbound to begin test."
+
+        # Given: A retry policy
+        sample_retry_policy = {
+            'interval_start': 0,
+            'interval_max': 1,
+            'max_retries': 3,
+            'interval_step': 0.2,
+            'errback': lambda x: print("Called test errback retry policy"),
+        }
+
+        # When: calling maybe_declare with retry enabled
+        maybe_declare(entity, channel, retry=True, **sample_retry_policy)
+
+        # Then: the entity is now bound because it called to bind it
+        assert entity.is_bound is True, "Expected entity is now marked bound."
 
     def test_with_retry(self):
         channel = Mock()

--- a/t/unit/test_common.py
+++ b/t/unit/test_common.py
@@ -110,7 +110,7 @@ class test_maybe_declare:
         return channel
 
     def _get_mock_entity(self, is_bound=False, can_cache_declaration=True):
-        # Given: A mock Entity that is not bound but will be to the channel when its called
+        # Given: Unbound mock Entity (will bind to channel when bind called
         entity = Mock()
         entity.can_cache_declaration = can_cache_declaration
         entity.is_bound = is_bound


### PR DESCRIPTION
I was studying this recent issue https://github.com/celery/kombu/issues/1045 and how it related to the change merged here:  https://github.com/celery/kombu/pull/779/files

I think the spirit of change in that prior kombu PR is good from @tyarimi, but the Entity (Exchange or Queue or ...) must be bound before calling entity.channel.connection.client.ensure as it was before.

My Change here factors out the logic that ensures it is bound so that it can be reused.  Since I was adjusting that code, I updated the two asserts in the file to not be asserts because I learned at Pycon that production code should not use asserts since they can be stripped out in optimize and other things, it is better to make logical checks and raise appropriate exceptions.   Asserts are good for unit tests and other code that does not get run in production.

Anyway, I think this restores the behavior before the regression by ensuring the entity is bound to the channel before calling to the connection to ensure it uses the retry policy in _imaybe_declare