### PR TITLE
call out specific vine requirement

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,2 +1,2 @@
 https://github.com/celery/py-amqp/zipball/master
-https://github.com/celery/vine/zipball/master
+vine==1.3.0


### PR DESCRIPTION
Checking if this fixes appveyor build.  @thedrow mentioned that it was because pip was using easy_install, but I see that in the tox conf a few places that install from the dev.txt which was just pointing at the master tarballs for github vine.