### PR TITLE
Switch from pkg_resources importlib-metadata

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -4,6 +4,11 @@
  Change history
 ================
 
+Unreleased
+==========
+
+- Use importlib-metadata instead of pkg_resources for better performance
+
 .. _version-4.6.3:
 
 4.6.3

--- a/kombu/utils/compat.py
+++ b/kombu/utils/compat.py
@@ -7,6 +7,7 @@ import sys
 from functools import wraps
 
 from contextlib import contextmanager
+import importlib_metadata
 
 from kombu.five import reraise
 
@@ -83,11 +84,10 @@ def detect_environment():
 
 def entrypoints(namespace):
     """Return setuptools entrypoints for namespace."""
-    try:
-        from pkg_resources import iter_entry_points
-    except ImportError:
-        return iter([])
-    return ((ep, ep.load()) for ep in iter_entry_points(namespace))
+    return (
+        (ep, ep.load())
+        for ep in importlib_metadata.entry_points().get(namespace, [])
+    )
 
 
 def fileno(f):

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,1 +1,2 @@
 amqp>=2.5.0,<3.0
+importlib-metadata>=0.18

--- a/t/unit/utils/test_compat.py
+++ b/t/unit/utils/test_compat.py
@@ -11,21 +11,17 @@ from kombu.utils import compat
 from kombu.utils.compat import entrypoints, maybe_fileno
 
 
-class test_entrypoints:
+def test_entrypoints():
+    with patch(
+        'kombu.utils.compat.importlib_metadata.entry_points', create=True
+    ) as iterep:
+        eps = [Mock(), Mock()]
+        iterep.return_value = {'kombu.test': eps}
 
-    @mock.mask_modules('pkg_resources')
-    def test_without_pkg_resources(self):
-        assert list(entrypoints('kombu.test')) == []
-
-    @mock.module_exists('pkg_resources')
-    def test_with_pkg_resources(self):
-        with patch('pkg_resources.iter_entry_points', create=True) as iterep:
-            eps = iterep.return_value = [Mock(), Mock()]
-
-            assert list(entrypoints('kombu.test'))
-            iterep.assert_called_with('kombu.test')
-            eps[0].load.assert_called_with()
-            eps[1].load.assert_called_with()
+        assert list(entrypoints('kombu.test'))
+        iterep.assert_called_with()
+        eps[0].load.assert_called_with()
+        eps[1].load.assert_called_with()
 
 
 def test_maybe_fileno():


### PR DESCRIPTION
See e.g. https://github.com/pypa/setuptools/issues/510#issuecomment-463667124

On a moderatly large project (~200 installed packages) at $work this saves ~150 ms on
`python -c 'from kombu import Exchange'`