### PR TITLE
Add test for Retry policy timeout.

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,5 +2,6 @@ pytz>dev
 case>=1.5.2
 pytest
 pytest-sugar
+pytest-timeout
 Pyro4
 fakeredis==1.0.4

--- a/t/unit/test_connection.py
+++ b/t/unit/test_connection.py
@@ -472,6 +472,19 @@ class test_Connection:
 
         myfun.assert_called()
 
+    @pytest.mark.timeout(5)
+    def test_retry_policy(self):
+        with pytest.raises(OperationalError):
+            conn = Connection('pyamqp://localhost:8000')
+            producer = conn.Producer(serializer='json')
+            producer.publish(
+                'Hello world!', retry=True, retry_policy={
+                    'interval_start': 0,
+                    'interval_step': 1,
+                    'interval_max': 5,
+                    'max_retries': 3,
+                })
+
     def test_SimpleQueue(self):
         conn = self.conn
         q = conn.SimpleQueue('foo')


### PR DESCRIPTION
Related to #1024

I add a new Pytest plugin (`pytest-timeout`) to stop the tests so It doesn't run forever in Travis/Appveyor