### PR TITLE
Add missing parameter queue_args in kombu.connection.SimpleBuffer

### DIFF
--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -771,6 +771,7 @@ class Connection(object):
                            exchange_opts, **kwargs)
 
     def SimpleBuffer(self, name, no_ack=None, queue_opts=None,
+                     queue_args=None,
                      exchange_opts=None, channel=None, **kwargs):
         """Simple ephemeral queue API.
 
@@ -785,6 +786,7 @@ class Connection(object):
         """
         from .simple import SimpleBuffer
         return SimpleBuffer(channel or self, name, no_ack, queue_opts,
+                            queue_args,
                             exchange_opts, **kwargs)
 
     def _establish_connection(self):

--- a/t/unit/test_connection.py
+++ b/t/unit/test_connection.py
@@ -495,6 +495,37 @@ class test_Connection:
         q2 = conn.SimpleBuffer('foo', channel=chan)
         assert q2.channel is chan
 
+    def test_SimpleQueue_with_parameters(self):
+        conn = self.conn
+        q = conn.SimpleQueue(
+            'foo', True, {'durable': True}, {'x-queue-mode': 'lazy'},
+            {'durable': True, 'type': 'fanout', 'delivery_mode': 'persistent'})
+
+        assert q.queue.exchange.type == 'fanout'
+        assert q.queue.exchange.durable
+        assert not q.queue.exchange.auto_delete
+        delivery_mode_code = q.queue.exchange.PERSISTENT_DELIVERY_MODE
+        assert q.queue.exchange.delivery_mode == delivery_mode_code
+
+        assert q.queue.queue_arguments['x-queue-mode'] == 'lazy'
+
+        assert q.queue.durable
+        assert not q.queue.auto_delete
+
+    def test_SimpleBuffer_with_parameters(self):
+        conn = self.conn
+        q = conn.SimpleBuffer(
+            'foo', True, {'durable': True}, {'x-queue-mode': 'lazy'},
+            {'durable': True, 'type': 'fanout', 'delivery_mode': 'persistent'})
+        assert q.queue.exchange.type == 'fanout'
+        assert q.queue.exchange.durable
+        assert q.queue.exchange.auto_delete
+        delivery_mode_code = q.queue.exchange.PERSISTENT_DELIVERY_MODE
+        assert q.queue.exchange.delivery_mode == delivery_mode_code
+        assert q.queue.queue_arguments['x-queue-mode'] == 'lazy'
+        assert q.queue.durable
+        assert q.queue.auto_delete
+
     def test_Producer(self):
         conn = self.conn
         assert isinstance(conn.Producer(), Producer)

--- a/t/unit/test_simple.py
+++ b/t/unit/test_simple.py
@@ -108,9 +108,31 @@ class test_SimpleQueue(SimpleBase):
         assert not q.no_ack
 
     def test_queue_args(self):
-        q = self.connection.SimpleQueue('test_queue_args',
-                                        queue_args={'x-queue-mode': 'lazy'})
+        q = self.Queue('test_queue_args', queue_args={'x-queue-mode': 'lazy'})
+        assert len(q.queue.queue_arguments) == 1
         assert q.queue.queue_arguments['x-queue-mode'] == 'lazy'
+
+        q = self.Queue('test_queue_args')
+        assert q.queue.queue_arguments == {}
+
+    def test_exchange_opts(self):
+        q = self.Queue('test_exchange_opts_a',
+                       exchange_opts={'durable': True, 'type': 'fanout',
+                                      'delivery_mode': 'persistent'})
+        assert q.queue.exchange.type == 'fanout'
+        assert q.queue.exchange.durable
+        assert not q.queue.exchange.auto_delete
+        delivery_mode_code = q.queue.exchange.PERSISTENT_DELIVERY_MODE
+        assert q.queue.exchange.delivery_mode == delivery_mode_code
+
+        q = self.Queue('test_exchange_opts_b')
+        assert q.queue.exchange.type == 'direct'
+        assert q.queue.exchange.durable
+        assert not q.queue.exchange.auto_delete
+
+    def test_queue_opts(self):
+        q = self.Queue('test_queue_opts', queue_opts={'auto_delete': False})
+        assert not q.queue.auto_delete
 
 
 class test_SimpleBuffer(SimpleBase):
@@ -121,3 +143,32 @@ class test_SimpleBuffer(SimpleBase):
     def test_is_no_ack(self):
         q = self.Queue('test_is_no_ack')
         assert q.no_ack
+
+    def test_queue_args(self):
+        q = self.Queue('test_queue_args', queue_args={'x-queue-mode': 'lazy'})
+        assert len(q.queue.queue_arguments) == 1
+        assert q.queue.queue_arguments['x-queue-mode'] == 'lazy'
+
+    def test_exchange_opts(self):
+        q = self.Queue('test_exchange_opts_a',
+                       exchange_opts={'durable': True, 'auto_delete': True,
+                                      'delivery_mode': 'persistent'})
+        assert q.queue.exchange.type == 'direct'
+        assert q.queue.exchange.durable
+        assert q.queue.exchange.auto_delete
+        delivery_mode_code = q.queue.exchange.PERSISTENT_DELIVERY_MODE
+        assert q.queue.exchange.delivery_mode == delivery_mode_code
+
+        q = self.Queue('test_exchange_opts_b')
+        assert q.queue.exchange.type == 'direct'
+        assert not q.queue.exchange.durable
+        assert q.queue.exchange.auto_delete
+
+    def test_queue_opts(self):
+        q = self.Queue('test_queue_opts', queue_opts={'auto_delete': False})
+        assert not q.queue.durable
+        assert not q.queue.auto_delete
+
+        q = self.Queue('test_queue_opts')
+        assert not q.queue.durable
+        assert q.queue.auto_delete


### PR DESCRIPTION
When using SimpleBuffer from kombu.connection, exchange_opts are not filled with the parameters desired.

`queue_args` parameter was introduced in `kombu.simple.SimpleQueue` and at the same time in
`kombu.connection.SimpleQueue` method. However, `kombu.connection.SimpleBuffer`
was not updated in the same way as the other method.

As `kombu.connection.SimpleBuffer` is using positional arguments to create a
`kombu.simple.SimpleBuffer` object, the values of that instance will not have the expected values:
- `queue_args` would get the value of `exchange_opts` from kombu.connection.SimpleBuffer, because that variable is set the third one.
- `exchange_opts` would get the default value None since none was provided by the caller.

Here is the call from SimpleBuffer method and the SimpleQueue class definition:
kombu.connection.SimpleBuffer
```
    def SimpleBuffer(self, name, no_ack=None, queue_opts=None,
                     exchange_opts=None, channel=None, **kwargs):
        ...
        from .simple import SimpleBuffer
        return SimpleBuffer(channel or self, name, no_ack, queue_opts,
                            exchange_opts, **kwargs)
```

kombu.simple.SimpleBuffer
```
class SimpleQueue(SimpleBase):
    """Simple API for persistent queues."""

    ...
    def __init__(self, channel, name, no_ack=None, queue_opts=None,
                 queue_args=None, exchange_opts=None, serializer=None,
                 compression=None, **kwargs):

class SimpleBuffer(SimpleQueue):
    ...
```

In this Pull Request, it's added the same `queue_args` parameter followiing the same approach as in the method `kombu.connection.SimpleQueue`.