### PR TITLE
disable python2 appveyor builds because they are premenently broken

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,11 +6,6 @@ environment:
       WITH_COMPILER: "cmd /E:ON /V:ON /C .\\extra\\appveyor\\run_with_compiler.cmd"
 
   matrix:
-    - TOXENV: "2.7"
-      TOX_APPVEYOR_X64: 0
-      PYTHON_VERSION: "2.7.x"
-      PYTHON_ARCH: "32"
-
     - TOXENV: "3.5"
       TOX_APPVEYOR_X64: 0
       PYTHON_VERSION: "3.5.x"
@@ -25,12 +20,6 @@ environment:
       TOX_APPVEYOR_X64: 0
       PYTHON_VERSION: "3.7.x"
       PYTHON_ARCH: "32"
-
-    - TOXENV: "2.7"
-      TOX_APPVEYOR_X64: 1
-      PYTHON_VERSION: "2.7.x"
-      PYTHON_ARCH: "64"
-      WINDOWS_SDK_VERSION: "v7.0"
 
     - TOXENV: "3.5"
       TOX_APPVEYOR_X64: 1

--- a/requirements/extras/zstd.txt
+++ b/requirements/extras/zstd.txt
@@ -1,1 +1,1 @@
-zstandard
+zstandard;python_version<"3.8"

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps=
     apicheck,2.7,pypy,pypy3,3.5,3.6,3.7-linux,3.7-windows,3.8-linux,3.8-windows: -r{toxinidir}/requirements/test.txt
     apicheck,2.7,pypy,pypy3,3.5,3.6,3.7-linux,3.8-linux: -r{toxinidir}/requirements/test-ci.txt
     2.7,pypy: -r{toxinidir}/requirements/test-ci-py2.txt
-    3.7-windows: -r{toxinidir}/requirements/test-ci-windows.txt
+    3.7-windows,3.8-windows: -r{toxinidir}/requirements/test-ci-windows.txt
 
     apicheck,linkcheck: -r{toxinidir}/requirements/docs.txt
     flake8,flakeplus,pydocstyle: -r{toxinidir}/requirements/pkgutils.txt


### PR DESCRIPTION
Python 2 is EOL on January 1st 2020 and this removes trying to build it on Appveyor because it always fails.
The appveyor builds for py2 always fail on:

> `    C:\Users\appveyor\AppData\Local\Programs\Common\Microsoft\Visual C++ for Python\9.0\VC\Bin\cl.exe /c /nologo /Ox /MD /W3 /GS- /DNDEBUG -IC:\projects\kombu\.tox\2.7\include -IC:\Users\appveyor\include -I/opt/local/include -I/usr/local/include -IC:\Python27\include -IC:\projects\kombu\.tox\2.7\PC /Tcbackports/lzma/_lzmamodule.c /Fobuild\temp.win32-2.7\Release\backports/lzma/_lzmamodule.obj
    _lzmamodule.c
    backports/lzma/_lzmamodule.c(32) : warning C4273: 'PyErr_NewExceptionWithDoc' : inconsistent dll linkage
            C:\projects\kombu\.tox\2.7\include\pyerrors.h(226) : see previous definition of 'PyErr_NewExceptionWithDoc'
    backports/lzma/_lzmamodule.c(115) : fatal error C1083: Cannot open include file: 'lzma.h': No such file or directory
    error: command 'C:\\Users\\appveyor\\AppData\\Local\\Programs\\Common\\Microsoft\\Visual C++ for Python\\9.0\\VC\\Bin\\cl.exe' failed with exit status 2`