### PR TITLE
Support standard values for ssl_cert_reqs query parameter.

### DIFF
--- a/kombu/utils/url.py
+++ b/kombu/utils/url.py
@@ -49,10 +49,8 @@ def parse_url(url):
         keys = [key for key in query.keys() if key.startswith('ssl_')]
         for key in keys:
             if key == 'ssl_cert_reqs':
-                if ssl_available:
-                    query[key] = getattr(ssl, query[key])
-                else:
-                    query[key] = None
+                query[key] = parse_ssl_cert_reqs(query[key])
+                if query[key] is None:
                     logger.warning('Defaulting to insecure SSL behaviour.')
 
             if 'ssl' not in query:
@@ -120,3 +118,20 @@ def maybe_sanitize_url(url, mask='**'):
     if isinstance(url, string_t) and '://' in url:
         return sanitize_url(url, mask)
     return url
+
+
+def parse_ssl_cert_reqs(query_value):
+    # type: (str) -> Any
+    """Given the query parameter for ssl_cert_reqs, return the SSL constant or None."""
+    if ssl_available:
+        query_value_to_constant = {
+            'CERT_REQUIRED': ssl.CERT_REQUIRED,
+            'CERT_OPTIONAL': ssl.CERT_OPTIONAL,
+            'CERT_NONE': ssl.CERT_NONE,
+            'required': ssl.CERT_REQUIRED,
+            'optional': ssl.CERT_OPTIONAL,
+            'none': ssl.CERT_NONE,
+        }
+        return query_value_to_constant[query_value]
+    else:
+        return None

--- a/t/unit/utils/test_url.py
+++ b/t/unit/utils/test_url.py
@@ -11,7 +11,7 @@ import ssl
 import pytest
 
 import kombu.utils.url
-from kombu.utils.url import as_url, parse_url, maybe_sanitize_url
+from kombu.utils.url import as_url, parse_url, maybe_sanitize_url, parse_ssl_cert_reqs
 
 
 def test_parse_url():
@@ -51,7 +51,7 @@ def test_maybe_sanitize_url(url, expected):
 def test_ssl_parameters():
     url = 'rediss://user:password@host:6379/0?'
     querystring = urlencode({
-        'ssl_cert_reqs': 'CERT_REQUIRED',
+        'ssl_cert_reqs': 'required',
         'ssl_ca_certs': '/var/ssl/myca.pem',
         'ssl_certfile': '/var/ssl/server-cert.pem',
         'ssl_keyfile': '/var/ssl/priv/worker-key.pem',
@@ -69,3 +69,24 @@ def test_ssl_parameters():
     assert kwargs['ssl']['ssl_cert_reqs'] is None
 
     kombu.utils.url.ssl_available = True
+
+
+@pytest.mark.parametrize('query_param,ssl_available,expected', [
+    ('CERT_REQUIRED', True, ssl.CERT_REQUIRED),
+    ('CERT_OPTIONAL', True, ssl.CERT_OPTIONAL),
+    ('CERT_NONE', True, ssl.CERT_NONE),
+    ('required', True, ssl.CERT_REQUIRED),
+    ('optional', True, ssl.CERT_OPTIONAL),
+    ('none', True, ssl.CERT_NONE),
+    ('CERT_REQUIRED', None, None),
+])
+def test_parse_ssl_cert_reqs(query_param, ssl_available, expected):
+    kombu.utils.url.ssl_available = ssl_available
+    result = parse_ssl_cert_reqs(query_param)
+    kombu.utils.url.ssl_available = True
+    assert result == expected
+
+
+def test_parse_ssl_cert_reqs_bad_value():
+    with pytest.raises(KeyError):
+        parse_ssl_cert_reqs('badvalue')

--- a/t/unit/utils/test_url.py
+++ b/t/unit/utils/test_url.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, unicode_literals
 
 try:
     from urllib.parse import urlencode
-
 except ImportError:
     from urllib import urlencode
 
@@ -11,7 +10,8 @@ import ssl
 import pytest
 
 import kombu.utils.url
-from kombu.utils.url import as_url, parse_url, maybe_sanitize_url, parse_ssl_cert_reqs
+from kombu.utils.url import as_url, parse_url, maybe_sanitize_url
+from kombu.utils.url import parse_ssl_cert_reqs
 
 
 def test_parse_url():


### PR DESCRIPTION
@auvipy 

Follow up to https://github.com/celery/celery/pull/5703 in which we teach `kombu` to accept the standard `redis-py` values for the `ssl_cert_reqs` query parameter for secure `rediss://` URLs.

Tested by adding unit tests and using this version of `kombu` and `celery` 4.4.0 to connect to an AWS ElastiCache instance of Redis configured to use SSL and then launching Celery tasks successfully.