### PR TITLE
Issue 701

### DIFF
--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -124,7 +124,7 @@ def Mutex(client, name, expire):
             try:
                 with client.pipeline(True) as pipe:
                     pipe.watch(name)
-                    if pipe.get(name) == lock_id:
+                    if bytes_to_str(pipe.get(name)) == lock_id:
                         pipe.multi()
                         pipe.delete(name)
                         pipe.execute()

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -14,6 +14,7 @@ from kombu.exceptions import InconsistencyError, VersionMismatch
 from kombu.five import Empty, Queue as _Queue, bytes_if_py2
 from kombu.transport import virtual
 from kombu.utils import eventio  # patch poll
+from kombu.utils.encoding import str_to_bytes
 from kombu.utils.json import dumps
 
 
@@ -1311,13 +1312,13 @@ class test_Mutex:
             client.setnx.return_value = True
             client.pipeline = ContextMock()
             pipe = client.pipeline.return_value
-            pipe.get.return_value = lock_id
+            pipe.get.return_value = str_to_bytes(lock_id)  # redis gives bytes
             held = False
             with redis.Mutex(client, 'foo1', 100):
                 held = True
             assert held
             client.setnx.assert_called_with('foo1', lock_id)
-            pipe.get.return_value = 'yyy'
+            pipe.get.return_value = b'yyy'
             held = False
             with redis.Mutex(client, 'foo1', 100):
                 held = True
@@ -1325,7 +1326,7 @@ class test_Mutex:
 
             # Did not win
             client.expire.reset_mock()
-            pipe.get.return_value = lock_id
+            pipe.get.return_value = str_to_bytes(lock_id)
             client.setnx.return_value = False
             with pytest.raises(redis.MutexHeld):
                 held = False

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ deps=
     flake8,flakeplus,pydocstyle: -r{toxinidir}/requirements/pkgutils.txt
 
 commands = pip install -U -r{toxinidir}/requirements/dev.txt
-           pytest -rxs -xv --cov=kombu --cov-report=xml --no-cov-on-fail {posargs}
+           python -bb -m pytest -rxs -xv --cov=kombu --cov-report=xml --no-cov-on-fail {posargs}
 
 basepython =
     2.7,flakeplus,flake8,linkcheck,cov: python2.7


### PR DESCRIPTION
Hi,

I include here two commits that handle issue #701 which was closed a few months ago but is in fact still very much present.

This PR includes:
- A commit that changes the tests so that the relevant Redis-mocking operations are more true to the behavior of modern py-redis; and adds the Python `-bb` flag to the test run, for stricter checking of str-vs-bytes issues
- A commit which fixes the operational code to resolve the problem
Thanks, Shai.

(This PR courtesy of [Matific](https://www.matific.com/))