### PR TITLE
Adding retry_on_timeout parameter

### DIFF
--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -427,6 +427,7 @@ class Channel(virtual.Channel):
     socket_connect_timeout = None
     socket_keepalive = None
     socket_keepalive_options = None
+    retry_on_timeout = None
     max_connections = 10
     health_check_interval = DEFAULT_HEALTH_CHECK_INTERVAL
     #: Transport option to disable fanout keyprefix.
@@ -493,6 +494,7 @@ class Channel(virtual.Channel):
          'queue_order_strategy',
          'max_connections',
          'health_check_interval',
+         'retry_on_timeout',
          'priority_steps')  # <-- do not add comma here!
     )
 
@@ -907,6 +909,7 @@ class Channel(virtual.Channel):
             'socket_keepalive': self.socket_keepalive,
             'socket_keepalive_options': self.socket_keepalive_options,
             'health_check_interval': self.health_check_interval,
+            'retry_on_timeout': self.retry_on_timeout,
         }
 
         conn_class = self.connection_class

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,4 +2,4 @@ pytz>dev
 case>=1.5.2
 pytest
 pytest-sugar
-https://github.com/irmen/Pyro4/zipball/master
+Pyro4

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,4 +2,4 @@ pytz>dev
 case>=1.5.2
 pytest
 pytest-sugar
-Pyro4
+https://github.com/irmen/Pyro4/zipball/master

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -1441,7 +1441,8 @@ class test_RedisSentinel:
                 connection_class=mock.ANY, db=0, max_connections=10,
                 min_other_sentinels=0, password=None, sentinel_kwargs=None,
                 socket_connect_timeout=None, socket_keepalive=None,
-                socket_keepalive_options=None, socket_timeout=None)
+                socket_keepalive_options=None, socket_timeout=None,
+                retry_on_timeout=None)
 
             master_for = patched.return_value.master_for
             master_for.assert_called()
@@ -1463,7 +1464,8 @@ class test_RedisSentinel:
                 connection_class=mock.ANY, db=0, max_connections=10,
                 min_other_sentinels=0, password=None, sentinel_kwargs=None,
                 socket_connect_timeout=None, socket_keepalive=None,
-                socket_keepalive_options=None, socket_timeout=None)
+                socket_keepalive_options=None, socket_timeout=None,
+                retry_on_timeout=None)
 
             master_for = patched.return_value.master_for
             master_for.assert_called()


### PR DESCRIPTION
resolve #1148 
I suggest adding `retry_on_timeout` as able parameter for Redis connection. 
This parameter is providing since version 2.1 of redis-py.