### PR TITLE
Use README.rst content as the PyPI long_description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -100,12 +100,17 @@ class pytest(setuptools.command.test.test):
         sys.exit(pytest.main(self.pytest_args))
 
 
+def readme():
+    with open('README.rst') as f:
+        return f.read()
+
+
 setup(
     name='kombu',
     packages=setuptools.find_packages(exclude=['t', 't.*']),
     version=meta['version'],
     description=meta['doc'],
-    # long_description=long_description,
+    long_description=readme(),
     keywords='messaging message amqp rabbitmq redis actor producer consumer',
     author=meta['author'],
     author_email=meta['contact'],


### PR DESCRIPTION
Use the ideas in https://python-packaging.readthedocs.io/en/latest/metadata.html to replace the __long_description__ at https://pypi.org/project/kombu with something cooler than:
`The author of this package has not provided a project description`.

Travis CI failure is fixed in #1159