### PR TITLE
Another possible fix for #1174

### DIFF
--- a/kombu/entity.py
+++ b/kombu/entity.py
@@ -245,9 +245,11 @@ class Exchange(MaybeChannelBound):
 
             headers (Dict): Message headers.
         """
-        # XXX This method is unused by kombu itself AFAICT [ask].
         properties = {} if properties is None else properties
         properties['delivery_mode'] = maybe_delivery_mode(self.delivery_mode)
+        if (isinstance(body, string_t) and
+                properties.get('content_encoding', None)) is None:
+            kwargs['content_encoding'] = 'utf-8'
         return self.channel.prepare_message(
             body,
             properties=properties,


### PR DESCRIPTION
Flake8 compliant this time.

Unit test to follow if possible but see no unit testing infrastructure in the repo. Fail behaviour on this is Exchange.publish(text) crashes with an encoding error.  A Pass is that the message is published, which can be confirmed with Queue.get() and comparing the payload with that which was published. Requires a running RabbitMQ instance to test (as that is the context of the crash).

A unit test though, while holding value is of the functionality of Exchange.publish() - currently broken for text messages, is not central to the value of fixing this break.

ref: https://github.com/celery/kombu/issues/1174

Apologies for a new request, inadvertently deleted the prior one (cutting my teeth with gitkraken, github and more).