### PR TITLE
Fix: eliminate remaining race conditions from SQLAlchemy Channel

### DIFF
--- a/kombu/transport/sqlalchemy/__init__.py
+++ b/kombu/transport/sqlalchemy/__init__.py
@@ -22,7 +22,7 @@ from .models import (ModelBase, Queue as QueueBase, Message as MessageBase,
 VERSION = (1, 1, 0)
 __version__ = '.'.join(map(str, VERSION))
 
-_MUTEX = threading.Lock()
+_MUTEX = threading.RLock()
 
 
 class Channel(virtual.Channel):
@@ -56,10 +56,17 @@ class Channel(virtual.Channel):
     def _open(self):
         conninfo = self.connection.client
         if conninfo.hostname not in self._engines:
-            engine = self._engine_from_config()
-            Session = sessionmaker(bind=engine)
-            metadata.create_all(engine)
-            self._engines[conninfo.hostname] = engine, Session
+            with _MUTEX:
+                if conninfo.hostname in self._engines:
+                    # Engine was created while we were waiting to
+                    # acquire the lock.
+                    return self._engines[conninfo.hostname]
+
+                engine = self._engine_from_config()
+                Session = sessionmaker(bind=engine)
+                metadata.create_all(engine)
+                self._engines[conninfo.hostname] = engine, Session
+
         return self._engines[conninfo.hostname]
 
     @property
@@ -73,12 +80,21 @@ class Channel(virtual.Channel):
         obj = self.session.query(self.queue_cls) \
             .filter(self.queue_cls.name == queue).first()
         if not obj:
-            obj = self.queue_cls(queue)
-            self.session.add(obj)
-            try:
-                self.session.commit()
-            except OperationalError:
-                self.session.rollback()
+            with _MUTEX:
+                obj = self.session.query(self.queue_cls) \
+                    .filter(self.queue_cls.name == queue).first()
+                if obj:
+                    # Queue was created while we were waiting to
+                    # acquire the lock.
+                    return obj
+
+                obj = self.queue_cls(queue)
+                self.session.add(obj)
+                try:
+                    self.session.commit()
+                except OperationalError:
+                    self.session.rollback()
+
         return obj
 
     def _new_queue(self, queue, **kwargs):
@@ -130,10 +146,16 @@ class Channel(virtual.Channel):
         return self._query_all(queue).count()
 
     def _declarative_cls(self, name, base, ns):
-        with _MUTEX:
-            if name in class_registry:
-                return class_registry[name]
-            return type(str(name), (base, ModelBase), ns)
+        if name not in class_registry:
+            with _MUTEX:
+                if name in class_registry:
+                    # Class was registered while we were waiting to
+                    # acquire the lock.
+                    return class_registry[name]
+
+                return type(str(name), (base, ModelBase), ns)
+
+        return class_registry[name]
 
     @cached_property
     def queue_cls(self):


### PR DESCRIPTION
Although a race condition in the SQLAlchmey Channel class was fixed in
a recent commit [0], a few other methods are also susceptible to race
conditions.

Indeed, if multiple threads call the class' `_open` method, a conflict
can occur with the `metadata.create_all` call which creates the schema
in the database, resulting in an exception which can look like this:

```
sqlalchemy.exc.IntegrityError: (psycopg2.errors.UniqueViolation)
duplicate key value violates unique constraint
"pg_type_typname_nsp_index" DETAIL: Key (typname,
typnamespace)=(queue_id_sequence, 2200) already exists.
```

Similarly, `_get_or_create` is susceptible to a race condition if two
threads try to create the unique queue object in the database at the
same time, resulting in this kind of exception:

```
sqlalchemy.exc.IntegrityError: (psycopg2.errors.UniqueViolation)
duplicate key value violates unique constraint "kombu_queue_name_key"
DETAIL: Key (name)=(celery) already exists.

[SQL: INSERT INTO kombu_queue (id, name) VALUES
(nextval('queue_id_sequence'), %(name)s) RETURNING kombu_queue.id]
[parameters: {'name': 'celery'}]
```

By using the mutex, we can ensure that only one thread at a time
executes these critical sections, eliminating the race conditions.

The mutex has been made re-entrant since `_open` can be called from
`_get_or_create`, which would cause a deadlock if a simple `Lock` was
used instead of `RLock`.

[0] 8f1de37a08318d388a048341ddca12af30019bf3

Signed-off-by: Antoine Busque <antoinebusque@gmail.com>