### PR TITLE
fix 100% cpu usage on linux while using sqs

### DIFF
--- a/kombu/asynchronous/http/curl.py
+++ b/kombu/asynchronous/http/curl.py
@@ -75,36 +75,47 @@ class CurlClient(BaseClient):
         self._set_timeout(0)
         return request
 
+    # the next two methods are used for linux/epoll workaround:
+    # we temporarily remove all curl fds from hub, so curl cannot
+    # close a fd which is still inside epoll
+    def _pop_from_hub(self):
+        for fd in self._fds:
+            self.hub.remove(fd)
+
+    def _push_to_hub(self):
+        for fd, events in self._fds.items():
+            if events & READ:
+                self.hub.add_reader(fd, self.on_readable, fd)
+            if events & WRITE:
+                self.hub.add_writer(fd, self.on_writable, fd)
+
     def _handle_socket(self, event, fd, multi, data, _pycurl=pycurl):
         if event == _pycurl.POLL_REMOVE:
             if fd in self._fds:
-                self.hub.remove(fd)
                 self._fds.pop(fd, None)
         else:
-            if fd in self._fds:
-                self.hub.remove(fd)
             if event == _pycurl.POLL_IN:
-                self.hub.add_reader(fd, self.on_readable, fd)
                 self._fds[fd] = READ
             elif event == _pycurl.POLL_OUT:
-                self.hub.add_writer(fd, self.on_writable, fd)
                 self._fds[fd] = WRITE
             elif event == _pycurl.POLL_INOUT:
-                self.hub.add_reader(fd, self.on_readable, fd)
-                self.hub.add_writer(fd, self.on_writable, fd)
                 self._fds[fd] = READ | WRITE
 
     def _set_timeout(self, msecs):
         pass  # TODO
 
     def _timeout_check(self, _pycurl=pycurl):
-        while 1:
-            try:
-                ret, _ = self._multi.socket_all()
-            except pycurl.error as exc:
-                ret = exc.args[0]
-            if ret != _pycurl.E_CALL_MULTI_PERFORM:
-                break
+        self._pop_from_hub()
+        try:
+            while 1:
+                try:
+                    ret, _ = self._multi.socket_all()
+                except pycurl.error as exc:
+                    ret = exc.args[0]
+                if ret != _pycurl.E_CALL_MULTI_PERFORM:
+                    break
+        finally:
+            self._push_to_hub()
         self._process_pending_requests()
 
     def on_readable(self, fd, _pycurl=pycurl):
@@ -114,13 +125,17 @@ class CurlClient(BaseClient):
         return self._on_event(fd, _pycurl.CSELECT_OUT)
 
     def _on_event(self, fd, event, _pycurl=pycurl):
-        while 1:
-            try:
-                ret, _ = self._socket_action(fd, event)
-            except pycurl.error as exc:
-                ret = exc.args[0]
-            if ret != _pycurl.E_CALL_MULTI_PERFORM:
-                break
+        self._pop_from_hub()
+        try:
+            while 1:
+                try:
+                    ret, _ = self._socket_action(fd, event)
+                except pycurl.error as exc:
+                    ret = exc.args[0]
+                if ret != _pycurl.E_CALL_MULTI_PERFORM:
+                    break
+        finally:
+            self._push_to_hub()
         self._process_pending_requests()
 
     def _process_pending_requests(self):


### PR DESCRIPTION
fix https://github.com/celery/celery/issues/5299

kombu uses cURL [`multi_socket`](https://curl.haxx.se/libcurl/c/libcurl-multi.html) API, which is non-blocking callback-based API. But it doesn't work well in linux, because of [epoll weird file descriptor management](https://idea.popcount.org/2017-03-20-epoll-is-fundamentally-broken-22/). When you use epoll, you must always remove FD from epoll before closing FD, but when curl decides that it doesn't need some particular socket, it will close that socket and _after that_ it will inform you that the socket is closed - so you don't have a chance to remove it from epoll in time. See https://curl.haxx.se/libcurl/c/curl_multi_socket_action.html for more info about this API.

In our case we periodically query an SQS queue, and curl performs the queries via keep-alive https connection. But sometimes (about once per minute or two) SQS sends a response with `Connection: close` header, then curl closes the socket.

I suggest this workaround: before every curl invocation, let's remove from our selector every curl-related file descriptor. And after we get control back from curl, we insert those back (most of the time curl will update socket states, so we should not forget to consider it). So as a result we are going to work with epoll in old-fashioned select/poll way.