### PR TITLE
Ensure connection when connecting to broker

### DIFF
--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -280,7 +280,7 @@ class Connection(object):
     def connect(self):
         """Establish connection to server immediately."""
         conn_opts = self._extract_failover_opts()
-        return self.ensure_connection(**conn_opts)
+        return self._ensure_connection(**conn_opts)
 
     def channel(self):
         """Create and return a new channel."""
@@ -380,10 +380,20 @@ class Connection(object):
         self._close()
     close = release
 
-    def ensure_connection(self, errback=None, max_retries=None,
-                          interval_start=2, interval_step=2, interval_max=30,
-                          callback=None, reraise_as_library_errors=True,
-                          timeout=None):
+    def ensure_connection(self, *args, **kwargs):
+        """Public interface of _ensure_connection for retro-compatibility.
+
+        Returns kombu.Connection instance.
+        """
+        self._ensure_connection(*args, **kwargs)
+        return self
+
+    def _ensure_connection(
+        self, errback=None, max_retries=None,
+        interval_start=2, interval_step=2, interval_max=30,
+        callback=None, reraise_as_library_errors=True,
+        timeout=None
+    ):
         """Ensure we have a connection to the server.
 
         If not retry establishing the connection with the settings
@@ -533,7 +543,7 @@ class Connection(object):
                         remaining_retries = None
                         if max_retries is not None:
                             remaining_retries = max(max_retries - retries, 1)
-                        self.ensure_connection(
+                        self._ensure_connection(
                             errback,
                             remaining_retries,
                             interval_start, interval_step, interval_max,
@@ -850,7 +860,7 @@ class Connection(object):
         if not self._closed:
             if not self.connected:
                 conn_opts = self._extract_failover_opts()
-                self._connection = self.ensure_connection(**conn_opts)
+                self._connection = self._ensure_connection(**conn_opts)
             return self._connection
 
     def _connection_factory(self):

--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -279,8 +279,8 @@ class Connection(object):
 
     def connect(self):
         """Establish connection to server immediately."""
-        self._closed = False
-        return self.connection
+        conn_opts = self._extract_failover_opts()
+        return self.ensure_connection(**conn_opts)
 
     def channel(self):
         """Create and return a new channel."""
@@ -424,11 +424,12 @@ class Connection(object):
         if not reraise_as_library_errors:
             ctx = self._dummy_context
         with ctx():
-            retry_over_time(self.connect, self.recoverable_connection_errors,
-                            (), {}, on_error, max_retries,
-                            interval_start, interval_step, interval_max,
-                            callback, timeout=timeout)
-        return self
+            return retry_over_time(
+                self._connection_factory, self.recoverable_connection_errors,
+                (), {}, on_error, max_retries,
+                interval_start, interval_step, interval_max,
+                callback, timeout=timeout
+            )
 
     @contextmanager
     def _reraise_as_library_errors(
@@ -817,6 +818,20 @@ class Connection(object):
     def qos_semantics_matches_spec(self):
         return self.transport.qos_semantics_matches_spec(self.connection)
 
+    def _extract_failover_opts(self):
+        conn_opts = {}
+        transport_opts = self.transport_options
+        if transport_opts:
+            if 'max_retries' in transport_opts:
+                conn_opts['max_retries'] = transport_opts['max_retries']
+            if 'interval_start' in transport_opts:
+                conn_opts['interval_start'] = transport_opts['interval_start']
+            if 'interval_step' in transport_opts:
+                conn_opts['interval_step'] = transport_opts['interval_step']
+            if 'interval_max' in transport_opts:
+                conn_opts['interval_max'] = transport_opts['interval_max']
+        return conn_opts
+
     @property
     def connected(self):
         """Return true if the connection has been established."""
@@ -834,11 +849,16 @@ class Connection(object):
         """
         if not self._closed:
             if not self.connected:
-                self.declared_entities.clear()
-                self._default_channel = None
-                self._connection = self._establish_connection()
-                self._closed = False
+                conn_opts = self._extract_failover_opts()
+                self._connection = self.ensure_connection(**conn_opts)
             return self._connection
+
+    def _connection_factory(self):
+        self.declared_entities.clear()
+        self._default_channel = None
+        connection = self._establish_connection()
+        self._closed = False
+        return connection
 
     @property
     def default_channel(self):
@@ -852,20 +872,6 @@ class Connection(object):
             a connection is passed instead of a channel, to functions that
             require a channel.
         """
-        conn_opts = {}
-        transport_opts = self.transport_options
-        if transport_opts:
-            if 'max_retries' in transport_opts:
-                conn_opts['max_retries'] = transport_opts['max_retries']
-            if 'interval_start' in transport_opts:
-                conn_opts['interval_start'] = transport_opts['interval_start']
-            if 'interval_step' in transport_opts:
-                conn_opts['interval_step'] = transport_opts['interval_step']
-            if 'interval_max' in transport_opts:
-                conn_opts['interval_max'] = transport_opts['interval_max']
-
-        # make sure we're still connected, and if not refresh.
-        self.ensure_connection(**conn_opts)
         if self._default_channel is None:
             self._default_channel = self.channel()
         return self._default_channel

--- a/t/integration/common.py
+++ b/t/integration/common.py
@@ -337,3 +337,20 @@ class BasePriority(object):
                     msg = buf.get(timeout=1)
                     msg.ack()
                     assert msg.payload == data
+
+
+class BaseFailover(BasicFunctionality):
+
+    def test_connect(self, failover_connection):
+        super(BaseFailover, self).test_connect(failover_connection)
+
+    def test_publish_consume(self, failover_connection):
+        super(BaseFailover, self).test_publish_consume(failover_connection)
+
+    def test_consume_empty_queue(self, failover_connection):
+        super(BaseFailover, self).test_consume_empty_queue(failover_connection)
+
+    def test_simple_buffer_publish_consume(self, failover_connection):
+        super(BaseFailover, self).test_simple_buffer_publish_consume(
+            failover_connection
+        )

--- a/t/integration/test_py_amqp.py
+++ b/t/integration/test_py_amqp.py
@@ -7,19 +7,34 @@ import kombu
 
 from .common import (
     BasicFunctionality, BaseExchangeTypes,
-    BaseTimeToLive, BasePriority
+    BaseTimeToLive, BasePriority, BaseFailover
 )
 
 
-def get_connection(
-        hostname, port, vhost):
+def get_connection(hostname, port, vhost):
     return kombu.Connection('pyamqp://{}:{}'.format(hostname, port))
+
+
+def get_failover_connection(hostname, port, vhost):
+    return kombu.Connection(
+        'pyamqp://localhost:12345;pyamqp://{}:{}'.format(hostname, port)
+    )
 
 
 @pytest.fixture()
 def connection(request):
-    # this fixture yields plain connections to broker and TLS encrypted
     return get_connection(
+        hostname=os.environ.get('RABBITMQ_HOST', 'localhost'),
+        port=os.environ.get('RABBITMQ_5672_TCP', '5672'),
+        vhost=getattr(
+            request.config, "slaveinput", {}
+        ).get("slaveid", None),
+    )
+
+
+@pytest.fixture()
+def failover_connection(request):
+    return get_failover_connection(
         hostname=os.environ.get('RABBITMQ_HOST', 'localhost'),
         port=os.environ.get('RABBITMQ_5672_TCP', '5672'),
         vhost=getattr(
@@ -49,4 +64,10 @@ class test_PyAMQPTimeToLive(BaseTimeToLive):
 @pytest.mark.env('py-amqp')
 @pytest.mark.flaky(reruns=5, reruns_delay=2)
 class test_PyAMQPPriority(BasePriority):
+    pass
+
+
+@pytest.mark.env('py-amqp')
+@pytest.mark.flaky(reruns=5, reruns_delay=2)
+class test_PyAMQPFailover(BaseFailover):
     pass

--- a/t/unit/test_connection.py
+++ b/t/unit/test_connection.py
@@ -142,6 +142,32 @@ class test_Connection:
         assert not _connection.connected
         assert isinstance(conn.transport, Transport)
 
+    def test_connect_no_transport_options(self):
+        conn = self.conn
+        conn.ensure_connection = Mock()
+
+        conn.connect()
+        conn.ensure_connection.assert_called_with()
+
+    def test_connect_transport_options(self):
+        conn = self.conn
+        conn.transport_options = options = {
+            'max_retries': 1,
+            'interval_start': 2,
+            'interval_step': 3,
+            'interval_max': 4,
+            'ignore_this': True
+        }
+        conn.ensure_connection = Mock()
+
+        conn.connect()
+        conn.ensure_connection.assert_called_with(**{
+            k: v for k, v in options.items()
+            if k in ['max_retries',
+                     'interval_start',
+                     'interval_step',
+                     'interval_max']})
+
     def test_multiple_urls(self):
         conn1 = Connection('amqp://foo;amqp://bar')
         assert conn1.hostname == 'foo'
@@ -405,32 +431,6 @@ class test_Connection:
 
         defchan.close.assert_called_with()
         assert conn._default_channel is None
-
-    def test_default_channel_no_transport_options(self):
-        conn = self.conn
-        conn.ensure_connection = Mock()
-
-        assert conn.default_channel
-        conn.ensure_connection.assert_called_with()
-
-    def test_default_channel_transport_options(self):
-        conn = self.conn
-        conn.transport_options = options = {
-            'max_retries': 1,
-            'interval_start': 2,
-            'interval_step': 3,
-            'interval_max': 4,
-            'ignore_this': True
-        }
-        conn.ensure_connection = Mock()
-
-        assert conn.default_channel
-        conn.ensure_connection.assert_called_with(**{
-            k: v for k, v in options.items()
-            if k in ['max_retries',
-                     'interval_start',
-                     'interval_step',
-                     'interval_max']})
 
     def test_ensure_connection(self):
         assert self.conn.ensure_connection()

--- a/t/unit/test_connection.py
+++ b/t/unit/test_connection.py
@@ -144,10 +144,10 @@ class test_Connection:
 
     def test_connect_no_transport_options(self):
         conn = self.conn
-        conn.ensure_connection = Mock()
+        conn._ensure_connection = Mock()
 
         conn.connect()
-        conn.ensure_connection.assert_called_with()
+        conn._ensure_connection.assert_called_with()
 
     def test_connect_transport_options(self):
         conn = self.conn
@@ -158,10 +158,10 @@ class test_Connection:
             'interval_max': 4,
             'ignore_this': True
         }
-        conn.ensure_connection = Mock()
+        conn._ensure_connection = Mock()
 
         conn.connect()
-        conn.ensure_connection.assert_called_with(**{
+        conn._ensure_connection.assert_called_with(**{
             k: v for k, v in options.items()
             if k in ['max_retries',
                      'interval_start',


### PR DESCRIPTION
This PR moves connection ensuring functionality into the connection factories to have consistent functionality across all API. As side efect it unifies `Connection.channel()` and `Connection.default_channel`:
1.  Now both channel factories blocks till connection is created + both provide possibility to configure this via `transport_options` parameter
2. Now both channel factories raises consistently the same exception on connection error: `kombu.exceptons.OperationalError`

Hence this change breaks backward compatibility for users which rely on this API.

Fixes #1179