### PR TITLE
set _connection in _ensure_connection

### DIFF
--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -434,12 +434,13 @@ class Connection(object):
         if not reraise_as_library_errors:
             ctx = self._dummy_context
         with ctx():
-            return retry_over_time(
+            self._connection = retry_over_time(
                 self._connection_factory, self.recoverable_connection_errors,
                 (), {}, on_error, max_retries,
                 interval_start, interval_step, interval_max,
                 callback, timeout=timeout
             )
+            return self._connection
 
     @contextmanager
     def _reraise_as_library_errors(
@@ -860,7 +861,7 @@ class Connection(object):
         if not self._closed:
             if not self.connected:
                 conn_opts = self._extract_failover_opts()
-                self._connection = self._ensure_connection(**conn_opts)
+                self._ensure_connection(**conn_opts)
             return self._connection
 
     def _connection_factory(self):

--- a/t/unit/test_connection.py
+++ b/t/unit/test_connection.py
@@ -131,7 +131,9 @@ class test_Connection:
 
     def test_establish_connection(self):
         conn = self.conn
+        assert not conn.connected
         conn.connect()
+        assert conn.connected
         assert conn.connection.connected
         assert conn.host == 'localhost:5672'
         channel = conn.channel()


### PR DESCRIPTION
Since #1193 `Connection.connect()` creates a new connection without saving to `Connection._connection`.

```
conn = Connection(...)
conn.connect()
conn.connected -> False
```