### PR TITLE
Reuse connection

### DIFF
--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -434,7 +434,7 @@ class Connection(object):
         if not reraise_as_library_errors:
             ctx = self._dummy_context
         with ctx():
-            self._connection = retry_over_time(
+            self._connection = self._connection or retry_over_time(
                 self._connection_factory, self.recoverable_connection_errors,
                 (), {}, on_error, max_retries,
                 interval_start, interval_step, interval_max,

--- a/t/unit/test_connection.py
+++ b/t/unit/test_connection.py
@@ -144,6 +144,10 @@ class test_Connection:
         assert not _connection.connected
         assert isinstance(conn.transport, Transport)
 
+    def test_reuse_connection(self):
+        conn = self.conn
+        assert conn.connect() is conn.connection is conn.connect()
+
     def test_connect_no_transport_options(self):
         conn = self.conn
         conn._ensure_connection = Mock()


### PR DESCRIPTION
#1205 recreates connection on every call to `Connection.connection` property.
```
conn.connection is not conn.connection
```