### PR TITLE
default_channel should reconnect automatically

### DIFF
--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -883,6 +883,8 @@ class Connection(object):
             a connection is passed instead of a channel, to functions that
             require a channel.
         """
+        # make sure we're still connected, and if not refresh.
+        self.connect()
         if self._default_channel is None:
             self._default_channel = self.channel()
         return self._default_channel

--- a/t/integration/common.py
+++ b/t/integration/common.py
@@ -14,6 +14,11 @@ class BasicFunctionality(object):
         connection.connect()
         connection.close()
 
+    def test_default_channel_autoconnect(self, connection):
+        connection.connect()
+        connection.close()
+        connection.default_channel
+
     def test_publish_consume(self, connection):
         test_queue = kombu.Queue('test', routing_key='test')
 

--- a/t/unit/test_connection.py
+++ b/t/unit/test_connection.py
@@ -415,6 +415,18 @@ class test_Connection:
         conn._close()
         conn._default_channel.close.assert_called_with()
 
+    def test_auto_reconnect_default_channel(self):
+        # tests GH issue: #1208
+        # Tests that default_channel automatically reconnects when connection
+        # closed
+        c = Connection('memory://')
+        c._closed = True
+        with patch.object(
+            c, '_connection_factory', side_effect=c._connection_factory
+        ) as cf_mock:
+            c.default_channel
+            cf_mock.assert_called_once_with()
+
     def test_close_when_default_channel_close_raises(self):
 
         class Conn(Connection):


### PR DESCRIPTION
After PR #1193 kombu does not reconnect automatically in Connection.default_channel property. This PR adds reconnect when this property is called. Fixes #1208
