### PR TITLE
tox.ini: Lint on Python, not on legacy Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ jobs:
     - python: '3.8'
       env: TOXENV=flake8
       stage: lint
-    - python: '3.8'
+    - python: '2.7'
       env: TOXENV=flakeplus
       stage: lint
     - python: '3.6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 os: linux
+dist: xenial
 language: python
 cache: pip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,13 +40,13 @@ jobs:
       env: TOXENV=3.8-linux-unit
     - python: pypy2.7-7.1.1
       env: TOXENV=pypy-unit
-      dist: xenial
     - python: pypy3.5-7.0
       env: TOXENV=pypy3-unit
-      dist: xenial
-    - env: TOXENV=flake8
+    - python: '3.8'
+      env: TOXENV=flake8
       stage: lint
-    - env: TOXENV=flakeplus
+    - python: '3.8'
+      env: TOXENV=flakeplus
       stage: lint
     - python: '3.6'
       env: TOXENV=apicheck

--- a/tox.ini
+++ b/tox.ini
@@ -31,11 +31,11 @@ commands =
     integration-redis: py.test -xv -E redis t/integration {posargs:-n2}
 
 basepython =
-    2.7: python2.7
+    2.7,flakeplus: python2.7
     3.5: python3.5
     3.6,apicheck,pydocstyle: python3.6
     3.7: python3.7
-    3.8,flakeplus,flake8,linkcheck,cov: python3.8
+    3.8,flake8,linkcheck,cov: python3.8
     pypy,pypy3: pypy
 
 install_command = python -m pip --disable-pip-version-check install {opts} {packages}

--- a/tox.ini
+++ b/tox.ini
@@ -31,11 +31,11 @@ commands =
     integration-redis: py.test -xv -E redis t/integration {posargs:-n2}
 
 basepython =
-    2.7,flakeplus,flake8,linkcheck,cov: python2.7
+    2.7: python2.7
     3.5: python3.5
     3.6,apicheck,pydocstyle: python3.6
     3.7: python3.7
-    3.8: python3.8
+    3.8,flakeplus,flake8,linkcheck,cov: python3.8
     pypy,pypy3: pypy
 
 install_command = python -m pip --disable-pip-version-check install {opts} {packages}


### PR DESCRIPTION
buffer(), cmp(), and unicode() were all removed in Python 3
```
kombu/transport/qpid.py:1126:27: F821 undefined name 'buffer'
kombu/utils/encoding.py:79:26: F821 undefined name 'unicode'
kombu/utils/encoding.py:93:16: F821 undefined name 'unicode'
kombu/utils/encoding.py:95:13: F821 undefined name 'unicode'
kombu/utils/encoding.py:133:30: F821 undefined name 'unicode'
kombu/utils/encoding.py:136:20: F821 undefined name 'unicode'
kombu/utils/functional.py:239:25: F821 undefined name 'cmp'
kombu/utils/functional.py:240:20: F821 undefined name 'cmp'
t/unit/utils/test_json.py:86:22: F821 undefined name 'buffer'
```