### PR TITLE
buffer() was removed in Python 3 so use bytes

### DIFF
--- a/kombu/transport/qpid.py
+++ b/kombu/transport/qpid.py
@@ -116,7 +116,7 @@ except ImportError:  # pragma: no cover
     qpid = None
 
 
-from kombu.five import buffer, Empty, items, monotonic, PY3
+from kombu.five import buffer_t, Empty, items, monotonic, PY3
 from kombu.log import get_logger
 from kombu.transport.virtual import Base64, Message
 from kombu.transport import base, virtual
@@ -1096,7 +1096,7 @@ class Channel(base.StdChannel):
         following ways before sending:
 
         - encodes the body using :meth:`encode_body`
-        - wraps the body as a buffer object, so that
+        - wraps the body as a buffer_t object, so that
             :class:`qpid.messaging.endpoints.Sender` uses a content type
             that can support arbitrarily large messages.
         - sets delivery_tag to a random uuid.UUID
@@ -1122,7 +1122,7 @@ class Channel(base.StdChannel):
         message['body'], body_encoding = self.encode_body(
             message['body'], self.body_encoding,
         )
-        message['body'] = buffer(message['body'])
+        message['body'] = buffer_t(message['body'])
         props = message['properties']
         props.update(
             body_encoding=body_encoding,

--- a/kombu/transport/qpid.py
+++ b/kombu/transport/qpid.py
@@ -116,19 +116,13 @@ except ImportError:  # pragma: no cover
     qpid = None
 
 
-from kombu.five import Empty, items, monotonic, PY3
+from kombu.five import buffer, Empty, items, monotonic, PY3
 from kombu.log import get_logger
 from kombu.transport.virtual import Base64, Message
 from kombu.transport import base, virtual
 
 
 logger = get_logger(__name__)
-
-try:
-    buffer
-except NameError:
-    buffer = bytes
-
 
 OBJECT_ALREADY_EXISTS_STRING = 'object already exists'
 

--- a/kombu/transport/qpid.py
+++ b/kombu/transport/qpid.py
@@ -124,6 +124,11 @@ from kombu.transport import base, virtual
 
 logger = get_logger(__name__)
 
+try:
+    buffer
+except NameError:
+    buffer = bytes
+
 
 OBJECT_ALREADY_EXISTS_STRING = 'object already exists'
 
@@ -1123,7 +1128,7 @@ class Channel(base.StdChannel):
         message['body'], body_encoding = self.encode_body(
             message['body'], self.body_encoding,
         )
-        message['body'] = memoryview(message['body'])
+        message['body'] = buffer(message['body'])
         props = message['properties']
         props.update(
             body_encoding=body_encoding,

--- a/kombu/transport/qpid.py
+++ b/kombu/transport/qpid.py
@@ -116,13 +116,18 @@ except ImportError:  # pragma: no cover
     qpid = None
 
 
-from kombu.five import buffer_t, Empty, items, monotonic, PY3
+from kombu.five import Empty, items, monotonic, PY3
 from kombu.log import get_logger
 from kombu.transport.virtual import Base64, Message
 from kombu.transport import base, virtual
 
 
 logger = get_logger(__name__)
+
+try:
+    buffer
+except NameError:
+    buffer = bytes
 
 OBJECT_ALREADY_EXISTS_STRING = 'object already exists'
 
@@ -1096,7 +1101,7 @@ class Channel(base.StdChannel):
         following ways before sending:
 
         - encodes the body using :meth:`encode_body`
-        - wraps the body as a buffer_t object, so that
+        - wraps the body as a buffer object, so that
             :class:`qpid.messaging.endpoints.Sender` uses a content type
             that can support arbitrarily large messages.
         - sets delivery_tag to a random uuid.UUID
@@ -1122,7 +1127,7 @@ class Channel(base.StdChannel):
         message['body'], body_encoding = self.encode_body(
             message['body'], self.body_encoding,
         )
-        message['body'] = buffer_t(message['body'])
+        message['body'] = buffer(message['body'])
         props = message['properties']
         props.update(
             body_encoding=body_encoding,

--- a/kombu/transport/qpid.py
+++ b/kombu/transport/qpid.py
@@ -1123,7 +1123,7 @@ class Channel(base.StdChannel):
         message['body'], body_encoding = self.encode_body(
             message['body'], self.body_encoding,
         )
-        message['body'] = buffer(message['body'])
+        message['body'] = memoryview(message['body'])
         props = message['properties']
         props.update(
             body_encoding=body_encoding,

--- a/t/unit/transport/test_qpid.py
+++ b/t/unit/transport/test_qpid.py
@@ -19,7 +19,7 @@ from itertools import count
 
 from case import Mock, call, patch, skip
 
-from kombu.five import Empty, range, monotonic
+from kombu.five import buffer_t, Empty, range, monotonic
 from kombu.transport.qpid import (AuthenticationFailure, Channel, Connection,
                                   ConnectionError, Message, NotFound, QoS,
                                   Transport)
@@ -1231,7 +1231,7 @@ class test_Channel(object):
         assert (mock_priority is
                 result['properties']['delivery_info']['priority'])
 
-    @patch('__builtin__.buffer')
+    @patch('buffer_t')
     @patch(QPID_MODULE + '.Channel.body_encoding')
     @patch(QPID_MODULE + '.Channel.encode_body')
     @patch(QPID_MODULE + '.Channel._put')

--- a/t/unit/transport/test_qpid.py
+++ b/t/unit/transport/test_qpid.py
@@ -1231,7 +1231,7 @@ class test_Channel(object):
         assert (mock_priority is
                 result['properties']['delivery_info']['priority'])
 
-    @patch('kombu.five.buffer_t')
+    @patch('__builtin__.buffer')
     @patch(QPID_MODULE + '.Channel.body_encoding')
     @patch(QPID_MODULE + '.Channel.encode_body')
     @patch(QPID_MODULE + '.Channel._put')

--- a/t/unit/transport/test_qpid.py
+++ b/t/unit/transport/test_qpid.py
@@ -19,7 +19,7 @@ from itertools import count
 
 from case import Mock, call, patch, skip
 
-from kombu.five import buffer_t, Empty, range, monotonic
+from kombu.five import Empty, range, monotonic
 from kombu.transport.qpid import (AuthenticationFailure, Channel, Connection,
                                   ConnectionError, Message, NotFound, QoS,
                                   Transport)
@@ -1231,7 +1231,7 @@ class test_Channel(object):
         assert (mock_priority is
                 result['properties']['delivery_info']['priority'])
 
-    @patch('buffer_t')
+    @patch('kombu.five.buffer_t')
     @patch(QPID_MODULE + '.Channel.body_encoding')
     @patch(QPID_MODULE + '.Channel.encode_body')
     @patch(QPID_MODULE + '.Channel._put')


### PR DESCRIPTION
https://docs.python.org/2.7/library/stdtypes.html#memoryview-type

https://portingguide.readthedocs.io/en/latest/etc.html#raw-buffer-protocol-buffer-and-memoryview