### PR TITLE
Add an SQS transport option for custom botocore config

### DIFF
--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -58,6 +58,19 @@ Other Features supported by this transport:
         },
       }
     }
+
+  Client config:
+    In some cases you may need to override the botocore config. You can do it
+    as follows:
+
+    transport_option = {
+      'client-config': {
+          'connect_timeout': 5,
+       },
+    }
+
+    For a complete list of settings you can adjust using this option see
+    https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html
 """  # noqa: E501
 
 from __future__ import absolute_import, unicode_literals
@@ -67,6 +80,7 @@ import socket
 import string
 import uuid
 
+from botocore.client import Config
 from botocore.exceptions import ClientError
 from vine import transform, ensure_promise, promise
 
@@ -518,7 +532,9 @@ class Channel(virtual.Channel):
         }
         if self.endpoint_url is not None:
             client_kwargs['endpoint_url'] = self.endpoint_url
-        return session.client('sqs', **client_kwargs)
+        client_config = self.transport_options.get('client-config') or {}
+        config = Config(**client_config)
+        return session.client('sqs', config=config, **client_kwargs)
 
     def sqs(self, queue=None):
         if queue is not None and self.predefined_queues:

--- a/t/unit/transport/test_SQS.py
+++ b/t/unit/transport/test_SQS.py
@@ -275,6 +275,19 @@ class test_Channel:
         # For cleanup purposes, delete the queue and the queue file
         self.channel._delete(queue_name)
 
+    def test_botocore_config_override(self):
+        expected_connect_timeout = 5
+        client_config = {'connect_timeout': expected_connect_timeout}
+        self.connection = Connection(
+            transport=SQS.Transport,
+            transport_options={'client-config': client_config},
+        )
+        self.channel = self.connection.channel()
+        self.channel._sqs = None
+        boto3_sqs = SQS_Channel_sqs.__get__(self.channel, SQS.Channel)
+        botocore_config = boto3_sqs()._client_config
+        assert botocore_config.connect_timeout == expected_connect_timeout
+
     def test_dont_create_duplicate_new_queue(self):
         # All queue names start with "q", except "unittest_queue".
         # which is definitely out of cache when get_all_queues returns the


### PR DESCRIPTION
We have experienced some problems with the client not being able to connect to SQS and reaching the wsgi worker time limit (60s) and thus terminating. The default connect timeout for botocore is 60s and we want to be able to adjust it, so that we can handle this issue more gracefully. This PR implements a way of doing just that.