### PR TITLE
Stop automatically converting the amqp:// prefix to librabbitmq:// + refactored test

### DIFF
--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -248,8 +248,6 @@ class Connection(object):
                      insist, ssl, transport, connect_timeout,
                      login_method, heartbeat):
         transport = transport or 'amqp'
-        if transport == 'amqp' and supports_librabbitmq():
-            transport = 'librabbitmq'
         if transport == 'rediss' and ssl_available and not ssl:
             logger.warning(
                 'Secure redis scheme specified (rediss) with no ssl '

--- a/t/unit/test_connection.py
+++ b/t/unit/test_connection.py
@@ -203,12 +203,12 @@ class test_Connection:
         assert connection._transport is None
         assert connection._connection is None
 
-    def test_prefer_librabbitmq_over_amqp_when_available(self):
+    def test_stop_converting_amqp_to_librabbitmq_when_available(self):
         with patch('kombu.connection.supports_librabbitmq',
                    return_value=True):
             connection = Connection('amqp://')
 
-        assert connection.transport_cls == 'librabbitmq'
+        assert connection.transport_cls == 'amqp'
 
     def test_select_amqp_when_librabbitmq_is_not_available(self):
         with patch('kombu.connection.supports_librabbitmq',


### PR DESCRIPTION
Based on issue [#4693](https://github.com/celery/celery/issues/4693#issuecomment-390771991) on celery repo, librabbitmq is no longer the recommended package, but the code in kombu does not follow this recommendation.
It's also been discussed in [PR #5873](https://github.com/celery/celery/pull/5873).
This PR removes the code where `kombu.Connection()`'s `__init__()` method automatically converts the amqp:// prefix to librabbitmq://.
Also `test_prefer_librabbitmq_over_amqp_when_available()` was rewritten to `test_stop_converting_amqp_to_librabbitmq_when_available()`.