### PR TITLE
flake8: noqa the Python 2-only builtins

### DIFF
--- a/kombu/utils/encoding.py
+++ b/kombu/utils/encoding.py
@@ -76,7 +76,7 @@ else:
 
     def str_to_bytes(s):                # noqa
         """Convert str to bytes."""
-        if isinstance(s, unicode):
+        if isinstance(s, unicode):  # noqa: F821
             return s.encode()
         return s
 
@@ -90,9 +90,9 @@ else:
 
     def default_encode(obj, file=None):            # noqa
         """Get default encoding."""
-        return unicode(obj, default_encoding(file))
+        return unicode(obj, default_encoding(file))  # noqa: F821
 
-    str_t = unicode
+    str_t = unicode  # noqa: F821
     ensure_bytes = str_to_bytes
 
 
@@ -130,10 +130,10 @@ else:
     def _safe_str(s, errors='replace', file=None):  # noqa
         encoding = default_encoding(file)
         try:
-            if isinstance(s, unicode):
+            if isinstance(s, unicode):  # noqa: F821
                 return _ensure_str(s.encode(encoding, errors),
                                    encoding, errors)
-            return unicode(s, encoding, errors)
+            return unicode(s, encoding, errors)  # noqa: F821
         except Exception as exc:
             return '<Unrepresentable {0!r}: {1!r} {2!r}>'.format(
                 type(s), exc, '\n'.join(traceback.format_stack()))

--- a/kombu/utils/functional.py
+++ b/kombu/utils/functional.py
@@ -236,8 +236,8 @@ class lazy(object):
 
         def __cmp__(self, rhs):
             if isinstance(rhs, self.__class__):
-                return -cmp(rhs, self())
-            return cmp(self(), rhs)
+                return -cmp(rhs, self())  # noqa: F821
+            return cmp(self(), rhs)  # noqa: F821
 
 
 def maybe_evaluate(value):

--- a/t/unit/utils/test_json.py
+++ b/t/unit/utils/test_json.py
@@ -83,7 +83,7 @@ class test_dumps_loads:
 
     @skip.if_python3()
     def test_loads_buffer(self):
-        assert loads(buffer(dumps({'x': 'z'}))) == {'x': 'z'}
+        assert loads(buffer(dumps({'x': 'z'}))) == {'x': 'z'}  # noqa: F821
 
     def test_loads_DecodeError(self):
         _loads = Mock(name='_loads')


### PR DESCRIPTION
buffer(), cmp(), and unicode() were all removed in Python 3 so mark instances with the flake8 linter directive `noqa: F821` so that it does not complain of undefined names.