### PR TITLE
fix: raise BrokenPipeError exit on brokenpipe instead of hanging around

### DIFF
--- a/kombu/message.py
+++ b/kombu/message.py
@@ -129,6 +129,10 @@ class Message(object):
     def ack_log_error(self, logger, errors, multiple=False):
         try:
             self.ack(multiple=multiple)
+        except BrokenPipeError as exc:
+            logger.critical("Couldn't ack %r, reason:%r",
+                            self.delivery_tag, exc, exc_info=True)
+            raise
         except errors as exc:
             logger.critical("Couldn't ack %r, reason:%r",
                             self.delivery_tag, exc, exc_info=True)


### PR DESCRIPTION
related to this https://github.com/celery/celery/pull/5581

 #5581