### PR TITLE
Make `utils.functional.retry_over_time` appear in rendered docs

### DIFF
--- a/kombu/utils/functional.py
+++ b/kombu/utils/functional.py
@@ -16,7 +16,7 @@ from .encoding import safe_repr as _safe_repr
 
 __all__ = (
     'LRUCache', 'memoize', 'lazy', 'maybe_evaluate',
-    'is_list', 'maybe_list', 'dictfilter',
+    'is_list', 'maybe_list', 'dictfilter', 'retry_over_time',
 )
 
 KEYWORD_MARK = object()


### PR DESCRIPTION
Since this module has `__all__`, autodoc will (by default) only show docs for those
members, meaning retry_over_time is not shown in the rendered docs.

This function is used by the Redis result backend in Celery, and it has a doc
comment so it should be "public".