### PR TITLE
Redis Transport: Small improvements of `SentinelChannel`

### DIFF
--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -1149,6 +1149,11 @@ class SentinelChannel(Channel):
 
         master_name = getattr(self, 'master_name', None)
 
+        if master_name is None:
+            raise ValueError(
+                "'master_name' transport option must be specified."
+            )
+
         return sentinel_inst.master_for(
             master_name,
             self.Client,

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -1134,7 +1134,8 @@ class SentinelChannel(Channel):
         for url in self.connection.client.alt:
             url = _parse_url(url)
             if url.scheme == 'sentinel':
-                sentinels.append((url.hostname, url.port))
+                port = url.port or self.connection.default_port
+                sentinels.append((url.hostname, port))
 
         # Fallback for when only one sentinel is provided.
         if not sentinels:

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -1410,6 +1410,7 @@ class test_RedisSentinel:
     def test_getting_master_from_sentinel(self):
         with patch('redis.sentinel.Sentinel') as patched:
             connection = Connection(
+                'sentinel://localhost/;'
                 'sentinel://localhost:65532/;'
                 'sentinel://user@localhost:65533/;'
                 'sentinel://:password@localhost:65534/;'
@@ -1422,6 +1423,7 @@ class test_RedisSentinel:
             connection.channel()
             patched.assert_called_once_with(
                 [
+                    ('localhost', 26379),
                     ('localhost', 65532),
                     ('localhost', 65533),
                     ('localhost', 65534),

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -1474,3 +1474,13 @@ class test_RedisSentinel:
         )
         with pytest.raises(ConnectionError):
             connection.channel()
+
+    def test_missing_master_name_transport_option(self):
+        connection = Connection(
+            'sentinel://localhost:65534/',
+        )
+        with patch('redis.sentinel.Sentinel'),  \
+             pytest.raises(ValueError) as excinfo:
+            connection.connect()
+        expected = "'master_name' transport option must be specified."
+        assert expected == excinfo.value.args[0]


### PR DESCRIPTION
This PR contains 2 small improvements of `SentinelChannel`:
1. Sentinel connection string now supports default port 26379:

BEFORE:
```python
>>> import kombu
>>> c = kombu.Connection('sentinel://localhost', transport_options={'master_name': 'mymaster'})
>>>
>>> c.connect()
Traceback (most recent call last):
  // STACKTRACE OMITTED
  File "/home/environments/kombu/lib/python3.7/site-packages/redis/connection.py", line 502, in __init__
    self.port = int(port)
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'
```           

AFTER

```python
>>> import kombu
>>> c = kombu.Connection('sentinel://localhost', transport_options={'master_name': 'mymaster'})
>>>
>>> c.connect()
```
2. Connection with Sentinel connection string missing `master_name` transport option now raises `ValueError` with information about missing parameter:

BEFORE:

```python
>>> import kombu
>>> c = kombu.Connection('sentinel://localhost:26379')
>>>
>>> c.connect()
Traceback (most recent call last):
  // STACKTRACE OMITTED
  File "/home/environments/kombu/lib/python3.7/site-packages/redis/sentinel.py", line 212, in discover_master
    raise MasterNotFoundError("No master found for %r" % (service_name,))
redis.sentinel.MasterNotFoundError: No master found for None
```

AFTER

```python
>>> import kombu
>>> c = kombu.Connection('sentinel://localhost:26379')
>>>
>>> c.connect()
Traceback (most recent call last):
  // STACKTRACE OMITTED
  File "/home/dev/kombu/kombu/transport/redis.py", line 1154, in _sentinel_managed_pool
    "'master_name' transport option must be specified."
ValueError: 'master_name' transport option must be specified.
```