### PR TITLE
Revert "on worker restart - restore visible regardless to time (#905)"

### DIFF
--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -20,7 +20,6 @@ from kombu.utils.json import loads, dumps
 from kombu.utils.objects import cached_property
 from kombu.utils.scheduling import cycle_by_name
 from kombu.utils.url import _parse_url
-from kombu.utils.compat import _detect_environment
 from kombu.utils.functional import accepts_argument
 
 from . import virtual
@@ -194,9 +193,6 @@ class QoS(virtual.QoS):
             try:
                 with Mutex(client, self.unacked_mutex_key,
                            self.unacked_mutex_expire):
-                    env = _detect_environment()
-                    if env == 'gevent':
-                        ceil = time()
                     visible = client.zrevrangebyscore(
                         self.unacked_index_key, ceil, 0,
                         start=num and start, num=num, withscores=True)

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -1132,25 +1132,6 @@ class test_MultiChannelPoller:
             num=chan1.unacked_restore_limit,
         )
 
-    def test_restore_visible_with_gevent(self):
-        with patch('kombu.transport.redis.time') as time:
-            with patch('kombu.transport.redis._detect_environment') as env:
-                timeout = 3600
-                time.return_value = timeout
-                env.return_value = 'gevent'
-                chan1 = Mock(name='chan1')
-                redis_ctx_mock = Mock()
-                redis_client_mock = Mock(name='redis_client_mock')
-                redis_ctx_mock.__exit__ = Mock()
-                redis_ctx_mock.__enter__ = Mock(return_value=redis_client_mock)
-                chan1.conn_or_acquire.return_value = redis_ctx_mock
-                qos = redis.QoS(chan1)
-                qos.visibility_timeout = timeout
-                qos.restore_visible()
-                redis_client_mock.zrevrangebyscore\
-                    .assert_called_with(chan1.unacked_index_key, timeout, 0,
-                                        start=0, num=10, withscores=True)
-
     def test_handle_event(self):
         p = self.Poller()
         chan = Mock(name='chan')


### PR DESCRIPTION
This reverts commit a307726faa8b64a71e04932b762498f51c1d7208.

Ref: https://github.com/celery/celery/issues/4976#issuecomment-707974799