### PR TITLE
Add vine to install dependencies

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,3 +1,3 @@
 importlib-metadata>=0.18; python_version<"3.8"
 amqp>=5.0.0,<6.0.0
-
+vine


### PR DESCRIPTION
I noticed that `vine` is directly used in a lot of places such as

https://github.com/celery/kombu/blob/10887dc88e62fe2ba51ecf09c96e7036aee93842/kombu/utils/functional.py#L13

but it's not listed as a direct dependency in the setuptools metadata.