### PR TITLE
Remove ca_certs for pyamqp

### DIFF
--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -61,7 +61,6 @@ class Connection:
 
         >>> import ssl
         >>> Connection('amqp://', login_method='EXTERNAL', ssl={
-        ...    'ca_certs': '/etc/pki/tls/certs/something.crt',
         ...    'keyfile': '/etc/something/system.key',
         ...    'certfile': '/etc/something/system.cert',
         ...    'cert_reqs': ssl.CERT_REQUIRED,

--- a/t/unit/transport/test_pyamqp.py
+++ b/t/unit/transport/test_pyamqp.py
@@ -91,7 +91,6 @@ class test_Transport:
 
     def test_ssl_cert_passed(self):
         ssl_dict = {
-            'ca_certs': '/etc/pki/tls/certs/something.crt',
             'cert_reqs': "ssl.CERT_REQUIRED",
         }
         ssl_dict_copy = {k: ssl_dict[k] for k in ssl_dict}


### PR DESCRIPTION
This param was recently removed in py-amqp (https://github.com/celery/py-amqp/pull/327/), these changes update related documentation and test.

Will fix #1266