### PR TITLE
docs: fix simple typo, propery -> property

### DIFF
--- a/kombu/asynchronous/http/base.py
+++ b/kombu/asynchronous/http/base.py
@@ -191,7 +191,7 @@ class Response:
         """The full contents of the response body.
 
         Note:
-            Accessing this propery will evaluate the buffer
+            Accessing this property will evaluate the buffer
             and subsequent accesses will be cached.
         """
         if self._body is None:


### PR DESCRIPTION
There is a small typo in kombu/asynchronous/http/base.py.

Should read `property` rather than `propery`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md