### PR TITLE
Fix Azure Service Bus URL parsing

### DIFF
--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -661,11 +661,16 @@ class Connection:
 
     def as_uri(self, include_password=False, mask='**',
                getfields=itemgetter('port', 'userid', 'password',
-                                    'virtual_host', 'transport')):
+                                    'virtual_host', 'transport')) -> str:
         """Convert connection parameters to URL form."""
         hostname = self.hostname or 'localhost'
         if self.transport.can_parse_url:
             connection_as_uri = self.hostname
+            try:
+                return self.transport.as_uri(connection_as_uri, include_password, mask)
+            except NotImplementedError:
+                pass
+
             if self.uri_prefix:
                 connection_as_uri = f'{self.uri_prefix}+{hostname}'
             if not include_password:

--- a/kombu/transport/base.py
+++ b/kombu/transport/base.py
@@ -234,6 +234,12 @@ class Transport:
             reader = self.__reader = self._make_reader(connection)
         reader(loop)
 
+    def as_uri(self, uri: str, include_password=False, mask='**') -> str:
+        """
+        Customise the display format of the URI
+        """
+        raise NotImplementedError()
+
     @property
     def default_connection_params(self):
         return {}

--- a/t/unit/transport/test_azureservicebus.py
+++ b/t/unit/transport/test_azureservicebus.py
@@ -68,7 +68,7 @@ class ASBMock:
     def get_queue_receiver(self, queue_name, **kwargs):
         return self.queues[queue_name].get_receiver(kwargs)
 
-    def get_queue_sender(self, queue_name):
+    def get_queue_sender(self, queue_name, **kwargs):
         return self.queues[queue_name].get_sender()
 
 


### PR DESCRIPTION
Firstly, it turns out `as_uri` is used by celery to generate a displayable URI with the password masked in the worker banner. ASB uri's can be incompatible with urllib.parse as they might have extra slashes because they contain base64 data. Added an optional `as_uri` method to the transport class so custom url formatting can be done if really required.

Secondly, it seems Celery sometimes does not explicitly close a Channel object, which leads to the Azure uAMQP library leaving a thread running (because its not marked as a daemon thread :/). Added some documentation about this, will raise an issue against the azure library next, though might be easier to add some logic into Celery.

Exposed some options to tune how the queue is used.

Fixed an issue when ack'ing messages when a queue isnt bound to an exchange.

@AndreCimander you mind giving this a test for me? Unescaped url's should work now. Also the options you linked me on the previous PR, they have defaults which have been mirrored to this PR.

@matusvalo Azure provide connection strings via the portal and their api's like this `Endpoint=sb://queuename.servicebus.windows.net/;SharedAccessKeyName=policyname;SharedAccessKey=base64string`, do you have any objection to me adding support to using this as a URI, should be easy enough to detect the transport from this and would make using azure transports easier as their SDK directly accepts this for authentication. I think this would be nicer than users having to regenerate keys with slashes in them or converting this into the azureservicebus:: type uri.