### PR TITLE
http/curl: missing _set_timeout

### DIFF
--- a/kombu/asynchronous/http/curl.py
+++ b/kombu/asynchronous/http/curl.py
@@ -100,7 +100,7 @@ class CurlClient(BaseClient):
                 self._fds[fd] = READ | WRITE
 
     def _set_timeout(self, msecs):
-        pass  # TODO
+        self.hub.call_later(msecs, self._timeout_check)
 
     def _timeout_check(self, _pycurl=pycurl):
         self._pop_from_hub()

--- a/t/unit/asynchronous/http/test_curl.py
+++ b/t/unit/asynchronous/http/test_curl.py
@@ -95,8 +95,10 @@ class test_CurlClient:
             x._handle_socket(0xff3f, fd, x._multi, None, _pycurl)
 
     def test_set_timeout(self):
-        x = self.Client()
+        hub = Mock(name='hub')
+        x = self.Client(hub)
         x._set_timeout(100)
+        hub.call_later.assert_called_with(100, x._timeout_check)
 
     def test_timeout_check(self):
         with patch('kombu.asynchronous.http.curl.pycurl') as _pycurl:


### PR DESCRIPTION
Fixes https://github.com/celery/celery/issues/6352

CurlClient was missing the implementation for `_set_timeout`, causing a throughput limitation on Celery Worker when using SQS Broker.

---

As `add_request` calls `_set_timeout(0)` and it had no effect, requests were not starting on schedule.
https://github.com/celery/kombu/blob/ff48da68b7fd40d2d835bcc95ddd798269e92562/kombu/asynchronous/http/curl.py#L70-L74

With Curl default `max_clients=10` and the `_timeout_check` executing only once every second, it resulted in a hard limit of 10 requests per second, despite of increasing concurrency or worker_prefetch_multiplier. https://github.com/celery/kombu/blob/ff48da68b7fd40d2d835bcc95ddd798269e92562/kombu/asynchronous/http/curl.py#L55-L57

---

## Tests on Celery Worker
> celery==5.0.5
> kombu==5.0.2

Script:
```python
# celery-test.py
from celery import Celery
from kombu import Queue
import os

# Celery
app = Celery('celery-test', broker="sqs://")
app.conf.task_serializer = 'json'
QUEUE = "mytest"
app.conf.task_queues = (Queue(QUEUE, routing_key='nothing.#'),)

@app.task(queue=QUEUE)
def nothing():
  pass

if os.getenv("GENERATE"):
  for x in range(int(os.getenv('GENERATE', 0))):
    print(nothing.delay())
```

## Results:
Running tests in a container on EC2 instance and connecting to SQS on same region.

### Test 1 - Time to process 10k jobs:
Worker running with `--concurrency 1` and `app.conf.worker_prefetch_multiplier = 20`:
- Before: 17 minutes @ 580 rpm (~10/s)
- After: 1 minute and 50 seconds @ 5280 rpm (88/s)

SQS metrics (requests per minute):
![image](https://user-images.githubusercontent.com/739640/107702818-90cbbf00-6c99-11eb-8b9c-cffd577fb244.png)


### Test 2 - Increasing concurrency:
Generating 20k jobs, and processing with concurrency [1, 2, 4, 8], each running for 5 minutes.

```bash
GENERATE=20000 python celery-test.py
timeout 5m celery -A celery-test worker --concurrency 1 -Q mytest; sleep 1m
timeout 5m celery -A celery-test worker --concurrency 2 -Q mytest; sleep 1m
timeout 5m celery -A celery-test worker --concurrency 4 -Q mytest; sleep 1m
timeout 5m celery -A celery-test worker --concurrency 8 -Q mytest
```

### Results with current version:
> Concurrency: 8
> 590 requests per minute 
> CPU: 35 mcores
> Memory: 188 MB

SQS metrics (requests per minute):
![image](https://user-images.githubusercontent.com/739640/107711651-bf03cb80-6ca6-11eb-9b23-0f7157cddc45.png)
![image](https://user-images.githubusercontent.com/739640/107725788-cb4b5100-6cc5-11eb-935a-8736bb125b6a.png)
![image](https://user-images.githubusercontent.com/739640/107725924-2f6e1500-6cc6-11eb-942b-a3bdbe3b76ff.png)


### Results after applying this PR:
> Concurrency: 8
> 5800 requests per minute
> CPU: 300 mcores
> Memory: 198 MB

SQS metrics (requests per minute):
![image](https://user-images.githubusercontent.com/739640/107715591-60dae680-6cae-11eb-9f13-70162b9c6bc3.png)
![image](https://user-images.githubusercontent.com/739640/107725852-f766d200-6cc5-11eb-9ce7-874771910d7c.png)
![image](https://user-images.githubusercontent.com/739640/107725954-414fb800-6cc6-11eb-9b33-a35c66700e6d.png)
