### PR TITLE
Stop treating namedtuple as an object when using simplejson

### DIFF
--- a/kombu/utils/json.py
+++ b/kombu/utils/json.py
@@ -14,7 +14,10 @@ except ImportError:  # pragma: no cover
 try:
     import simplejson as json
     from simplejson.decoder import JSONDecodeError as _DecodeError
-    _json_extra_kwargs = {'use_decimal': False}
+    _json_extra_kwargs = {
+        'use_decimal': False,
+        'namedtuple_as_object': False,
+    }
 except ImportError:                 # pragma: no cover
     import json                     # noqa
     _json_extra_kwargs = {}           # noqa

--- a/t/unit/utils/test_json.py
+++ b/t/unit/utils/test_json.py
@@ -1,6 +1,7 @@
 import pytest
 import pytz
 
+from collections import namedtuple
 from datetime import datetime
 from decimal import Decimal
 from uuid import uuid4
@@ -42,6 +43,10 @@ class test_JSONEncoder:
     def test_Decimal(self):
         d = Decimal('3314132.13363235235324234123213213214134')
         assert loads(dumps({'d': d})), {'d': str(d)}
+
+    def test_namedtuple(self):
+        Foo = namedtuple('Foo', ['bar'])
+        assert loads(dumps(Foo(123))) == [123]
 
     def test_UUID(self):
         id = uuid4()


### PR DESCRIPTION
By default, [simplejson converts namedtuple to JSON object](https://simplejson.readthedocs.io/en/latest/#simplejson.dumps) but json converts that to JSON array. 

This causes unpredictable serialization depends on installation of simplejson. So I added an option for disabling simplejson specific feature.