### PR TITLE
Add Github Actions CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
         run: tox -v -e py-apicheck -- -v
   #################### Unittests ####################
   unittest:
-    # needs: lint
+    needs: lint
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -45,30 +45,27 @@ jobs:
       - name: Install dependencies
         run: pip install --upgrade pip setuptools wheel tox tox-docker
       - name: Run unittest
-        run: tox -v -e ${{ matrix.python-version }}-unit -- -v
-#  #################### Integration tests ####################
-#  integration:
-#    needs: [lint, unittest]
-#    runs-on: ubuntu-latest
-#    strategy:
-#      matrix:
-#        python-version: [3.6,3.7,3.8,pypy3]
-#    steps:
-#      - name: Check out code from GitHub
-#        uses: actions/checkout@v2.3.4
-#      - name: Build rabbitmq:tls container
-#        run: docker build -t rabbitmq:tls .
-#      - name: Set up Python ${{ matrix.python-version }}
-#        id: python
-#        uses: actions/setup-python@v2.2.1
-#        with:
-#          python-version: ${{ matrix.python-version }}
-#      - name: Install dependencies
-#        run: pip install --upgrade pip setuptools wheel tox tox-docker
-#      - name: Run integration tests
-#        run: tox -v -e ${{ matrix.python-version }}-integration-rabbitmq -- -v
-#      - name: Run integration tests with speedups enabled
-#        run: |
-#          CELERY_ENABLE_SPEEDUPS=1 python setup.py develop
-#          tox -v -e ${{ matrix.python-version }}-integration-rabbitmq -- -v
-#        if: ${{ matrix.python-version != 'pypy3'}}
+        run: tox -v -e ${{ matrix.python-version }}-linux-unit -- -v
+  #################### Integration tests ####################
+  integration:
+    needs: [lint, unittest]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6,3.7,3.8,pypy3]
+    steps:
+      - name: Install system packages
+        run: sudo apt-get install libcurl4-openssl-dev libssl-dev
+      - name: Check out code from GitHub
+        uses: actions/checkout@v2.3.4
+      - name: Set up Python ${{ matrix.python-version }}
+        id: python
+        uses: actions/setup-python@v2.2.1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: pip install --upgrade pip setuptools wheel tox tox-docker
+      - name: Run AMQP integration tests
+        run: tox -v -e ${{ matrix.python-version }}-linux-integration-py-amqp -- -v
+      - name: Run redis integration tests
+        run: tox -v -e ${{ matrix.python-version }}-linux-integration-py-redis -- -v

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6,3.7,3.8,pypy3]
+        python-version: [3.6,3.7,3.8]
     steps:
       - name: Install system packages
         run: sudo apt-get install libcurl4-openssl-dev libssl-dev

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,74 @@
+name: CI
+on: [pull_request, push]
+jobs:
+  #################### Linters and checkers ####################
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+    steps:
+      - name: Install system packages
+        run: sudo apt-get install libcurl4-openssl-dev libssl-dev
+      - name: Check out code from GitHub
+        uses: actions/checkout@v2.3.4
+      - name: Set up Python ${{ matrix.python-version }}
+        id: python
+        uses: actions/setup-python@v2.2.1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: pip install --upgrade pip setuptools wheel tox tox-docker
+      - name: Run flake8
+        run: tox -v -e py-flake8 -- -v
+      - name: Run pydocstyle
+        run: tox -v -e py-pydocstyle -- -v
+      - name: Run apicheck
+        run: tox -v -e py-apicheck -- -v
+  #################### Unittests ####################
+  unittest:
+    # needs: lint
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6,3.7,3.8,pypy3]
+    steps:
+      - name: Install system packages
+        run: sudo apt-get install libcurl4-openssl-dev libssl-dev
+      - name: Check out code from GitHub
+        uses: actions/checkout@v2.3.4
+      - name: Set up Python ${{ matrix.python-version }}
+        id: python
+        uses: actions/setup-python@v2.2.1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: pip install --upgrade pip setuptools wheel tox tox-docker
+      - name: Run unittest
+        run: tox -v -e ${{ matrix.python-version }}-unit -- -v
+#  #################### Integration tests ####################
+#  integration:
+#    needs: [lint, unittest]
+#    runs-on: ubuntu-latest
+#    strategy:
+#      matrix:
+#        python-version: [3.6,3.7,3.8,pypy3]
+#    steps:
+#      - name: Check out code from GitHub
+#        uses: actions/checkout@v2.3.4
+#      - name: Build rabbitmq:tls container
+#        run: docker build -t rabbitmq:tls .
+#      - name: Set up Python ${{ matrix.python-version }}
+#        id: python
+#        uses: actions/setup-python@v2.2.1
+#        with:
+#          python-version: ${{ matrix.python-version }}
+#      - name: Install dependencies
+#        run: pip install --upgrade pip setuptools wheel tox tox-docker
+#      - name: Run integration tests
+#        run: tox -v -e ${{ matrix.python-version }}-integration-rabbitmq -- -v
+#      - name: Run integration tests with speedups enabled
+#        run: |
+#          CELERY_ENABLE_SPEEDUPS=1 python setup.py develop
+#          tox -v -e ${{ matrix.python-version }}-integration-rabbitmq -- -v
+#        if: ${{ matrix.python-version != 'pypy3'}}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,29 +6,29 @@ environment:
       WITH_COMPILER: "cmd /E:ON /V:ON /C .\\extra\\appveyor\\run_with_compiler.cmd"
 
   matrix:
-    - TOXENV: "3.6"
+    - TOXENV: "3.6-windows-unit"
       TOX_APPVEYOR_X64: 0
       PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "32"
 
-    - TOXENV: "3.7-windows"
+    - TOXENV: "3.7-windows-unit"
       TOX_APPVEYOR_X64: 0
       PYTHON_VERSION: "3.7.x"
       PYTHON_ARCH: "32"
 
-    - TOXENV: "3.6"
+    - TOXENV: "3.6-windows-unit"
       TOX_APPVEYOR_X64: 1
       PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "64"
       WINDOWS_SDK_VERSION: "v7.1"
 
-    - TOXENV: "3.7-windows"
+    - TOXENV: "3.7-windows-unit"
       TOX_APPVEYOR_X64: 1
       PYTHON_VERSION: "3.7.x"
       PYTHON_ARCH: "64"
       WINDOWS_SDK_VERSION: "v7.1"
 
-    - TOXENV: "3.8-windows"
+    - TOXENV: "3.8-windows-unit"
       TOX_APPVEYOR_X64: 1
       PYTHON_VERSION: "3.8"
       PYTHON_ARCH: "64"

--- a/requirements/test-ci.txt
+++ b/requirements/test-ci.txt
@@ -8,7 +8,6 @@ codecov
 -r extras/azurestoragequeues.txt
 -r extras/sqs.txt
 -r extras/consul.txt
-# -r extras/librabbitmq.txt
 -r extras/zookeeper.txt
 -r extras/brotli.txt
 -r extras/zstd.txt

--- a/requirements/test-ci.txt
+++ b/requirements/test-ci.txt
@@ -8,7 +8,7 @@ codecov
 -r extras/azurestoragequeues.txt
 -r extras/sqs.txt
 -r extras/consul.txt
--r extras/librabbitmq.txt
+# -r extras/librabbitmq.txt
 -r extras/zookeeper.txt
 -r extras/brotli.txt
 -r extras/zstd.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    {pypy3,3.6,3.7-{linux,windows},3.8-{linux,windows}}-unit
-    {pypy3,3.6,3.7-{linux,windows},3.8-{linux,windows}}-integration-py-amqp
-    {pypy3,3.6,3.7-{linux,windows},3.8-{linux,windows}}-integration-redis
+    {pypy3,3.6,3.7,3.8}-unit
+    {pypy3,3.6,3.7,3.8}-integration-py-amqp
+    {pypy3,3.6,3.7,3.8}-integration-redis
     flake8
     flakeplus
     apicheck
@@ -17,9 +17,9 @@ passenv =
   DISTUTILS_USE_SDK
 deps=
     -r{toxinidir}/requirements/dev.txt
-    apicheck,pypy3,3.6,3.7-linux,3.7-windows,3.8-linux,3.8-windows: -r{toxinidir}/requirements/default.txt
-    apicheck,pypy3,3.6,3.7-linux,3.7-windows,3.8-linux,3.8-windows: -r{toxinidir}/requirements/test.txt
-    apicheck,pypy3,3.6,3.7-linux,3.8-linux: -r{toxinidir}/requirements/test-ci.txt
+    apicheck,pypy3,3.6,3.7,3.8: -r{toxinidir}/requirements/default.txt
+    apicheck,pypy3,3.6,3.7,3.8: -r{toxinidir}/requirements/test.txt
+    apicheck,pypy3,3.6,3.7,3.8: -r{toxinidir}/requirements/test-ci.txt
     3.7-windows: -r{toxinidir}/requirements/test-ci-windows.txt
     apicheck,linkcheck: -r{toxinidir}/requirements/docs.txt
     flake8,flakeplus,pydocstyle: -r{toxinidir}/requirements/pkgutils.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
     {pypy3,3.6,3.7,3.8}-unit
-    {pypy3,3.6,3.7,3.8}-integration-py-amqp
-    {pypy3,3.6,3.7,3.8}-integration-redis
+    {pypy3,3.6,3.7,3.8}-linux-integration-py-amqp
+    {pypy3,3.6,3.7,3.8}-linux-integration-redis
     flake8
     flakeplus
     apicheck
@@ -19,8 +19,8 @@ deps=
     -r{toxinidir}/requirements/dev.txt
     apicheck,pypy3,3.6,3.7,3.8: -r{toxinidir}/requirements/default.txt
     apicheck,pypy3,3.6,3.7,3.8: -r{toxinidir}/requirements/test.txt
-    apicheck,pypy3,3.6,3.7,3.8: -r{toxinidir}/requirements/test-ci.txt
-    3.7-windows: -r{toxinidir}/requirements/test-ci-windows.txt
+    apicheck,pypy3,3.6,3.7-linux,3.8-linux: -r{toxinidir}/requirements/test-ci.txt
+    3.7-windows,3.8-windows: -r{toxinidir}/requirements/test-ci-windows.txt
     apicheck,linkcheck: -r{toxinidir}/requirements/docs.txt
     flake8,flakeplus,pydocstyle: -r{toxinidir}/requirements/pkgutils.txt
 


### PR DESCRIPTION
This PR adds 1:1 support for GH Actions CI comparing to old Travis*. PR also removes requirement for librabbitmq in CI since it is not used directly by unittests/integration tests and introduced complexity to CI + building it was timeconsuming.

* The only missing point is running unittests over pypy3 due failing unittests with complex errors (e.g. crasing in CAPI emulation layer of pypy)

﻿- Implement CI is github actions
- Skip failing pypy3 unittests
- Added integration tests
