### PR TITLE
Update default pickle protocol version to 4

### DIFF
--- a/kombu/serialization.py
+++ b/kombu/serialization.py
@@ -35,9 +35,8 @@ else:
 pickle = cpickle or pypickle
 pickle_load = pickle.load
 
-#: Kombu requires Python 2.5 or later so we use protocol 2 by default.
-#: There's a new protocol (3) but this is only supported by Python 3.
-pickle_protocol = int(os.environ.get('PICKLE_PROTOCOL', 2))
+#: We have to use protocol 4 until we drop support for Python 3.6 and 3.7.
+pickle_protocol = int(os.environ.get('PICKLE_PROTOCOL', 4))
 
 codec = namedtuple('codec', ('content_type', 'content_encoding', 'encoder'))
 


### PR DESCRIPTION
Protocol version 4 was added in Python 3.4 and is supported by all Python versions that kombu supports.

https://docs.python.org/3.9/library/pickle.html#data-stream-format

Fixes #1070