### PR TITLE
Drop obsolete code importing pickle

### DIFF
--- a/kombu/serialization.py
+++ b/kombu/serialization.py
@@ -2,13 +2,8 @@
 
 import codecs
 import os
+import pickle
 import sys
-
-import pickle as pypickle
-try:
-    import cPickle as cpickle
-except ImportError:  # pragma: no cover
-    cpickle = None  # noqa
 
 from collections import namedtuple
 from contextlib import contextmanager
@@ -32,7 +27,6 @@ if sys.platform.startswith('java'):  # pragma: no cover
 else:
     _decode = codecs.decode
 
-pickle = cpickle or pypickle
 pickle_load = pickle.load
 
 #: Kombu requires Python 2.5 or later so we use protocol 2 by default.


### PR DESCRIPTION
https://docs.python.org/3.9/whatsnew/3.0.html#library-changes

> A common pattern in Python 2.x is to have one version of a module implemented in pure Python, with an optional accelerated version implemented as a C extension; for example, pickle and cPickle. This places the burden of importing the accelerated version and falling back on the pure Python version on each user of these modules. In Python 3.0, the accelerated versions are considered implementation details of the pure Python versions. Users should always import the standard version, which attempts to import the accelerated version and falls back to the pure Python version. The pickle / cPickle pair received this treatment.