### PR TITLE
SQS Broker - handle STS authentication with AWS

### DIFF
--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -74,8 +74,8 @@ exist in AWS) you can tell this transport about them as follows:
 backoff_policy & backoff_tasks are optional arguments. These arguments automatically change the message visibility timeout, in order to have different times between specific task
 retries. This would apply after task failure.
 
-AWS STS authentication is supported, by using sts_role_arn, and sts_token_timeout. sts_role_arn is the assumed IAM role ARN we are trying to access with. 
-sts_token_timeout is the token timeout, defaults (and minimum) to 900 seconds. After the mentioned period, a new token will be created. 
+AWS STS authentication is supported, by using sts_role_arn, and sts_token_timeout. sts_role_arn is the assumed IAM role ARN we are trying to access with.
+sts_token_timeout is the token timeout, defaults (and minimum) to 900 seconds. After the mentioned period, a new token will be created.
 
 
 If you authenticate using Okta_ (e.g. calling |gac|_), you can also specify

--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -633,8 +633,8 @@ class Channel(virtual.Channel):
     def sqs(self, queue=None):
         if queue is not None and self.predefined_queues:
             if queue not in self.predefined_queues:
-                raise UndefinedQueueException(("Queue with name '{}' must be defined in "
-                                               "'predefined_queues'.").format(queue))
+                raise UndefinedQueueException((f"Queue with name '{queue}' must be defined"
+                                               f" in 'predefined_queues'."))
             q = self.predefined_queues[queue]
             if not self.transport_options.get('sts_role_arn'):
                 if queue in self._predefined_queue_clients:

--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -67,10 +67,16 @@ exist in AWS) you can tell this transport about them as follows:
           'backoff_tasks': ['svc.tasks.tasks.task2'] # optional
         },
       }
+    'sts_role_arn': 'arn:aws:iam::<xxx>:role/STSTest', # optional
+    'sts_token_timeout': 900 # optional
     }
     
 backoff_policy & backoff_tasks are optional arguments. These arguments automatically change the message visibility timeout, in order to have different times between specific task
 retries. This would apply after task failure.
+
+AWS STS authentication is supported, by using sts_role_arn, and sts_token_timeout. sts_role_arn is the assumed IAM role ARN we are trying to access with. 
+sts_token_timeout is the token timeout, defaults (and minimum) to 900 seconds. After the mentioned period, a new token will be created. 
+
 
 If you authenticate using Okta_ (e.g. calling |gac|_), you can also specify
 a 'session_token' to connect to a queue. Note that those tokens have a

--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -638,7 +638,7 @@ class Channel(virtual.Channel):
                                                                      " in 'predefined_queues'.")
             q = self.predefined_queues[queue]
             if self.transport_options.get('sts_role_arn'):
-                return self.handle_sts_session(queue, q)
+                return self._handle_sts_session(queue, q)
             if not self.transport_options.get('sts_role_arn'):
                 if queue in self._predefined_queue_clients:
                     return self._predefined_queue_clients[queue]
@@ -659,7 +659,7 @@ class Channel(virtual.Channel):
         )
         return c
 
-    def handle_sts_session(self, queue, q):
+    def _handle_sts_session(self, queue, q):
         if not hasattr(self, 'sts_expiration'):  # STS token - token init
             sts_creds = self.generate_sts_session_token(self.transport_options.get('sts_role_arn'),
                                                         self.transport_options.get('sts_token_timeout', 900))


### PR DESCRIPTION
STS token requires being refreshed after certain period of time. 

In the PR I added the functionality of creating the token and refreshing it once timeout reached   

Link to issue: https://github.com/celery/kombu/issues/1321