### PR TITLE
Azure Service Bus - versatile queue names fix

### DIFF
--- a/kombu/transport/azureservicebus.py
+++ b/kombu/transport/azureservicebus.py
@@ -66,9 +66,10 @@ from azure.servicebus.management import ServiceBusAdministrationClient
 from . import virtual
 
 # dots are replaced by dash, all other punctuation replaced by underscore.
+PUNCTUATIONS_TO_REPLACE = set(string.punctuation) - {'_', '.', '-'}
 CHARS_REPLACE_TABLE = {
     ord('.'): ord('-'),
-    **{ord(c): ord('_') for c in string.punctuation if c not in ['_', '.', '-']}
+    **{ord(c): ord('_') for c in PUNCTUATIONS_TO_REPLACE}
 }
 
 

--- a/kombu/transport/azureservicebus.py
+++ b/kombu/transport/azureservicebus.py
@@ -67,7 +67,8 @@ from . import virtual
 
 # dots are replaced by dash, all other punctuation replaced by underscore.
 CHARS_REPLACE_TABLE = {
-    ord(c): 0x5f for c in string.punctuation if c not in '_'
+    ord('.'): ord('-'),
+    **{ord(c): ord('_') for c in string.punctuation if c not in ['_', '.', '-']}
 }
 
 

--- a/t/unit/transport/test_azureservicebus.py
+++ b/t/unit/transport/test_azureservicebus.py
@@ -278,8 +278,11 @@ def test_purge(mock_queue: MockQueue):
 
 
 def test_custom_queue_name_prefix():
-    conn = Connection(URL_CREDS, transport=azureservicebus.Transport,
-                      transport_options={'queue_name_prefix': 'test-queue'})
+    conn = Connection(
+        URL_CREDS,
+        transport=azureservicebus.Transport,
+        transport_options={'queue_name_prefix': 'test-queue'}
+    )
     channel = conn.channel()
 
     assert channel.queue_name_prefix == 'test-queue'

--- a/t/unit/transport/test_azureservicebus.py
+++ b/t/unit/transport/test_azureservicebus.py
@@ -275,3 +275,25 @@ def test_purge(mock_queue: MockQueue):
     size = mock_queue.channel._size(mock_queue.queue_name)
     assert size == 0
     assert len(mock_queue.asb.queues[mock_queue.queue_name].waiting_ack) == 0
+
+
+def test_custom_queue_name_prefix():
+    conn = Connection(URL_CREDS, transport=azureservicebus.Transport,
+                      transport_options={'queue_name_prefix': 'test-queue'})
+    channel = conn.channel()
+
+    assert channel.queue_name_prefix == 'test-queue'
+
+
+def test_custom_entity_name():
+    conn = Connection(URL_CREDS, transport=azureservicebus.Transport)
+    channel = conn.channel()
+
+    # dashes allowed and dots replaced by dashes
+    assert channel.entity_name('test-celery') == 'test-celery'
+    assert channel.entity_name('test.celery') == 'test-celery'
+
+    # all other punctuations replaced by underscores
+    assert channel.entity_name('test_celery') == 'test_celery'
+    assert channel.entity_name('test:celery') == 'test_celery'
+    assert channel.entity_name('test+celery') == 'test_celery'


### PR DESCRIPTION
## Fixes #1323 

In current implementation it is not possible to use dashes (`-`) in queue names. All punctuations are converted into underscores (`_`). Although the old commentary text says that dots are replaced by dashes - it wasn't working this way . 

Provided fix allows to use dashes in queue names, translates dots into dashes and translates other punctuations to underscores - just like specified in the comment above the translation table.

## How to verify:
to test/investigate the issue you have to pass `queue_name_prefix` into `broker_transport_options` setting dict on celery.