### PR TITLE
Add support for SQLAlchemy 1.4

### DIFF
--- a/kombu/transport/sqlalchemy/models.py
+++ b/kombu/transport/sqlalchemy/models.py
@@ -4,9 +4,14 @@ import datetime
 
 from sqlalchemy import (Column, Integer, String, Text, DateTime,
                         Sequence, Boolean, ForeignKey, SmallInteger, Index)
-from sqlalchemy.ext.declarative import declarative_base, declared_attr
 from sqlalchemy.orm import relation
 from sqlalchemy.schema import MetaData
+
+try:
+    from sqlalchemy.orm import declarative_base, declared_attr
+except ImportError:
+    # TODO: Remove this once we drop support for SQLAlchemy < 1.4.
+    from sqlalchemy.ext.declarative import declarative_base, declared_attr
 
 class_registry = {}
 metadata = MetaData()


### PR DESCRIPTION
Following the changes in SQLAlchemy 1.4, the declarative base is no longer an extension.
Importing it from sqlalchemy.ext.declarative is deprecated and will be removed in SQLAlchemy 2.0.
This PR adds support for the newer versions of SQLAlchemy while maintaining backwards compatibility for previous versions.

Superceeds #1318.