### PR TITLE
Coerce seconds argument to a floating point number.

### DIFF
--- a/kombu/asynchronous/timer.py
+++ b/kombu/asynchronous/timer.py
@@ -155,7 +155,7 @@ class Timer:
         return self._enter(eta, priority, entry)
 
     def enter_after(self, secs, entry, priority=0, time=monotonic):
-        return self.enter_at(entry, time() + secs, priority)
+        return self.enter_at(entry, time() + float(secs), priority)
 
     def _enter(self, eta, priority, entry, push=heapq.heappush):
         push(self._queue, scheduled(eta, priority, entry))


### PR DESCRIPTION
Celery does not coerce configuration values into the right type (See celery/celery#6696).
This is a workaround. This bug will be fixed in Celery NextGen when we will refactor our configuration subsystem.