### PR TITLE
Ignore kombu.transport.librabbitmq in apicheck.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,6 +22,7 @@ globals().update(conf.build_config(
         'kombu.asynchronous.aws.ext',
         'kombu.asynchronous.aws.sqs.ext',
         'kombu.transport.qpid_patches',
+        'kombu.transport.librabbitmq',
         'kombu.utils',
         'kombu.transport.virtual.base',
     ],


### PR DESCRIPTION
We are ignoring kombu.transport.librabbitmq because apicheck is failing
due missing librabbitmq library.