### PR TITLE
prepare_accept_content() now raises SerializerNotInstalled instead of KeyError

### DIFF
--- a/kombu/serialization.py
+++ b/kombu/serialization.py
@@ -445,7 +445,17 @@ for ep, args in entrypoints('kombu.serializers'):  # pragma: no cover
 
 
 def prepare_accept_content(content_types, name_to_type=None):
+    """Replace aliases of content_types with full names from registry.
+
+    Raises:
+        SerializerNotInstalled: If the serialization method
+            requested is not available.
+    """
     name_to_type = registry.name_to_type if not name_to_type else name_to_type
     if content_types is not None:
-        return {n if '/' in n else name_to_type[n] for n in content_types}
+        try:
+            return {n if '/' in n else name_to_type[n] for n in content_types}
+        except KeyError as e:
+            raise SerializerNotInstalled(
+                f'No encoder/decoder installed for {e.args[0]}')
     return content_types

--- a/kombu/utils/compat.py
+++ b/kombu/utils/compat.py
@@ -130,7 +130,7 @@ def nested(*managers):  # pragma: no cover
             while exits:
                 exit = exits.pop()
                 try:
-                    if sys.exit(*exc):
+                    if exit(*exc):
                         exc = (None, None, None)
                 except:
                     exc = sys.exc_info()

--- a/t/unit/test_serialization.py
+++ b/t/unit/test_serialization.py
@@ -13,7 +13,7 @@ from kombu.serialization import (
     raw_encode, register_yaml, register_msgpack,
     dumps, loads, pickle, pickle_protocol,
     unregister, register_pickle, enable_insecure_serializers,
-    disable_insecure_serializers,
+    disable_insecure_serializers, prepare_accept_content
 )
 from kombu.utils.encoding import str_to_bytes
 
@@ -307,3 +307,12 @@ class test_Serialization:
         register_msgpack()
         with pytest.raises(SerializerNotInstalled):
             loads('foo', 'application/x-msgpack', 'utf-8')
+
+    def test_prepare_accept_content(self):
+        assert {'application/json'} == prepare_accept_content(['json'])
+        assert {'application/json'} == prepare_accept_content(
+            ['application/json'])
+
+    def test_prepare_accept_content_bad_serializer(self):
+        with pytest.raises(SerializerNotInstalled):
+            prepare_accept_content(['bad_serializer'])


### PR DESCRIPTION
When wrong serializer is passed to as accept parameter currently `KeyError` is raised. This can be misleading and confusing. Other calls uses `SerializerNotInstalled` when wrong serializer is used. This PR replaces  `KeyError` with `SerializerNotInstalled`.

After this patch all API calls providing accept parameter will raise `SerializerNotInstalled` instead of `KeyError`.