### PR TITLE
 Move pytest.importorskip to run earlier

### DIFF
--- a/t/unit/transport/test_azureservicebus.py
+++ b/t/unit/transport/test_azureservicebus.py
@@ -10,10 +10,9 @@ from kombu import messaging
 from kombu import Connection, Exchange, Queue
 
 pytest.importorskip('azure.servicebus')
-from kombu.transport import azureservicebus
-import azure.servicebus.exceptions
-import azure.core.exceptions
-
+from kombu.transport import azureservicebus   # noqa 
+import azure.servicebus.exceptions   # noqa
+import azure.core.exceptions   # noqa
 from azure.servicebus import ServiceBusMessage, ServiceBusReceiveMode   # noqa
 
 

--- a/t/unit/transport/test_azureservicebus.py
+++ b/t/unit/transport/test_azureservicebus.py
@@ -9,10 +9,10 @@ from collections import namedtuple
 from kombu import messaging
 from kombu import Connection, Exchange, Queue
 
+pytest.importorskip('azure.servicebus')
 from kombu.transport import azureservicebus
 import azure.servicebus.exceptions
 import azure.core.exceptions
-pytest.importorskip('azure.servicebus')
 
 from azure.servicebus import ServiceBusMessage, ServiceBusReceiveMode   # noqa
 


### PR DESCRIPTION
Currently pytest fails to collect tests when `azure` is not present. Moving the pytest.importorskip clause before `from kombu.transport import azureservicebus` fixes it.

```
==================================== ERRORS ====================================
__________ ERROR collecting t/unit/transport/test_azureservicebus.py ___________
ImportError while importing test module '/build/python-kombu/src/kombu-5.1.0/t/unit/transport/test_azureservicebus.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.9/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
t/unit/transport/test_azureservicebus.py:12: in <module>
    from kombu.transport import azureservicebus
kombu/transport/azureservicebus.py:66: in <module>
    import azure.core.exceptions
E   ModuleNotFoundError: No module named 'azure'
```