### PR TITLE
Add global key prefix for keys set by Redis transporter

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -53,6 +53,7 @@ Fernando Jorge Mota <f.j.mota13@gmail.com>
 Flavio [FlaPer87] Percoco Premoli <flaper87@flaper87.org>
 Florian Munz <surf@theflow.de>
 Franck Cuny <fcuny@saymedia.com>
+Gábor Boros <gabor.brs@gmail.com>
 Germán M. Bravo <german.mb@gmail.com>
 Gregory Haskins <greg@greghaskins.com>
 Hank John <jindongh@gmail.com>

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -249,6 +249,7 @@ class GlobalKeyPrefixMixin:
             key = key[len(self.global_keyprefix):]
             return key, value
         return ret
+
     def execute_command(self, *args, **kwargs):
         return super().execute_command(*self._prefix_args(args), **kwargs)
 

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -238,7 +238,7 @@ class GlobalKeyPrefixMixin:
         return [command, *args]
 
     def parse_response(self, connection, command_name, **options):
-        """Parses a response from the Redis server.
+        """Parse a response from the Redis server.
 
         Method wraps ``redis.parse_response()`` to remove prefixes of keys
         returned by redis command.

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -237,6 +237,18 @@ class GlobalKeyPrefixMixin:
 
         return [command, *args]
 
+    def parse_response(self, connection, command_name, **options):
+        """Parses a response from the Redis server.
+
+        Method wraps ``redis.parse_response()`` to remove prefixes of keys
+        returned by redis command.
+        """
+        ret = super().parse_response(connection, command_name, **options)
+        if command_name == 'BRPOP' and ret:
+            key, value = ret
+            key = key[len(self.global_keyprefix):]
+            return key, value
+        return ret
     def execute_command(self, *args, **kwargs):
         return super().execute_command(*self._prefix_args(args), **kwargs)
 

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -12,6 +12,7 @@ from case import ContextMock, mock
 from kombu import Connection, Consumer, Exchange, Producer, Queue
 from kombu.exceptions import InconsistencyError, VersionMismatch
 from kombu.transport import virtual
+from kombu.transport.redis import GlobalKeyPrefixMixin
 from kombu.utils import eventio  # patch poll
 from kombu.utils.json import dumps
 
@@ -746,7 +747,7 @@ class test_Channel:
     def test_get_client(self):
         import redis as R
         KombuRedis = redis.Channel._get_client(self.channel)
-        assert KombuRedis
+        assert isinstance(KombuRedis(), R.StrictRedis)
 
         Rv = getattr(R, 'VERSION', None)
         try:
@@ -756,6 +757,12 @@ class test_Channel:
         finally:
             if Rv is not None:
                 R.VERSION = Rv
+
+    def test_get_prefixed_client(self):
+        from kombu.transport.redis import PrefixedStrictRedis
+        self.channel.global_keyprefix = "test_"
+        PrefixedRedis = redis.Channel._get_client(self.channel)
+        assert isinstance(PrefixedRedis(), PrefixedStrictRedis)
 
     def test_get_response_error(self):
         from redis.exceptions import ResponseError
@@ -926,27 +933,41 @@ class test_Channel:
                 ('celery', '', 'celery'),
             ]
 
-    def test_global_keyprefix(self):
-        with Connection(transport=Transport, transport_options={
-            'global_keyprefix': 'foo',
-        }) as conn:
+    @patch("redis.StrictRedis.execute_command")
+    def test_global_keyprefix(self, mock_execute_command):
+        from kombu.transport.redis import PrefixedStrictRedis
+
+        with Connection(transport=Transport) as conn:
+            client = PrefixedStrictRedis(global_keyprefix='foo_')
+
             channel = conn.channel()
-            c = channel._create_client = Mock()
+            channel._create_client = Mock()
+            channel._create_client.return_value = client
 
             body = {'hello': 'world'}
             channel._put_fanout('exchange', body, '')
-            c().publish.assert_called_with('foo/{db}.exchange', dumps(body))
+            mock_execute_command.assert_called_with(
+                'PUBLISH',
+                'foo_/{db}.exchange',
+                dumps(body)
+            )
 
-    def test_global_keyprefix_queue_bind(self):
-        with Connection(transport=Transport, transport_options={
-            'global_keyprefix': 'foo',
-        }) as conn:
+    @patch("redis.StrictRedis.execute_command")
+    def test_global_keyprefix_queue_bind(self, mock_execute_command):
+        from kombu.transport.redis import PrefixedStrictRedis
+
+        with Connection(transport=Transport) as conn:
+            client = PrefixedStrictRedis(global_keyprefix='foo_')
+
             channel = conn.channel()
-            c = channel._create_client = Mock()
+            channel._create_client = Mock()
+            channel._create_client.return_value = client
+
             channel._queue_bind('default', '', None, 'queue')
-            c().sadd.assert_called_with(
-                'foo_kombu.binding.default',
-                '\x06\x16\x06\x16fooqueue'
+            mock_execute_command.assert_called_with(
+                'SADD',
+                'foo__kombu.binding.default',
+                '\x06\x16\x06\x16queue'
             )
 
 
@@ -1523,3 +1544,50 @@ class test_RedisSentinel:
                 from kombu.transport.redis import SentinelManagedSSLConnection
                 assert (params['connection_class'] is
                         SentinelManagedSSLConnection)
+
+
+class test_GlobalKeyPrefixMixin:
+
+    global_keyprefix = "prefix_"
+    mixin = GlobalKeyPrefixMixin()
+    mixin.global_keyprefix = global_keyprefix
+
+    def test_prefix_simple_args(self):
+        for command in GlobalKeyPrefixMixin.PREFIXED_SIMPLE_COMMANDS:
+            prefixed_args = self.mixin._prefix_args([command, "fake_key"])
+            assert prefixed_args == [
+                command,
+                f"{self.global_keyprefix}fake_key"
+            ]
+
+    def test_prefix_brpop_args(self):
+        prefixed_args = self.mixin._prefix_args([
+            "BRPOP",
+            "fake_key",
+            "fake_key2",
+            "not_prefixed"
+        ])
+
+        assert prefixed_args == [
+            "BRPOP",
+            f"{self.global_keyprefix}fake_key",
+            f"{self.global_keyprefix}fake_key2",
+            "not_prefixed",
+        ]
+
+    def test_prefix_evalsha_args(self):
+        prefixed_args = self.mixin._prefix_args([
+            "EVALSHA",
+            "not_prefixed",
+            "not_prefixed",
+            "fake_key",
+            "not_prefixed",
+        ])
+
+        assert prefixed_args == [
+            "EVALSHA",
+            "not_prefixed",
+            "not_prefixed",
+            f"{self.global_keyprefix}fake_key",
+            "not_prefixed",
+        ]

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -12,7 +12,6 @@ from case import ContextMock, mock
 from kombu import Connection, Consumer, Exchange, Producer, Queue
 from kombu.exceptions import InconsistencyError, VersionMismatch
 from kombu.transport import virtual
-from kombu.transport.redis import GlobalKeyPrefixMixin
 from kombu.utils import eventio  # patch poll
 from kombu.utils.json import dumps
 
@@ -1548,12 +1547,14 @@ class test_RedisSentinel:
 
 class test_GlobalKeyPrefixMixin:
 
+    from kombu.transport.redis import GlobalKeyPrefixMixin
+
     global_keyprefix = "prefix_"
     mixin = GlobalKeyPrefixMixin()
     mixin.global_keyprefix = global_keyprefix
 
     def test_prefix_simple_args(self):
-        for command in GlobalKeyPrefixMixin.PREFIXED_SIMPLE_COMMANDS:
+        for command in self.mixin.PREFIXED_SIMPLE_COMMANDS:
             prefixed_args = self.mixin._prefix_args([command, "fake_key"])
             assert prefixed_args == [
                 command,

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -926,6 +926,29 @@ class test_Channel:
                 ('celery', '', 'celery'),
             ]
 
+    def test_global_keyprefix(self):
+        with Connection(transport=Transport, transport_options={
+            'global_keyprefix': 'foo',
+        }) as conn:
+            channel = conn.channel()
+            c = channel._create_client = Mock()
+
+            body = {'hello': 'world'}
+            channel._put_fanout('exchange', body, '')
+            c().publish.assert_called_with('foo/{db}.exchange', dumps(body))
+
+    def test_global_keyprefix_queue_bind(self):
+        with Connection(transport=Transport, transport_options={
+            'global_keyprefix': 'foo',
+        }) as conn:
+            channel = conn.channel()
+            c = channel._create_client = Mock()
+            channel._queue_bind('default', '', None, 'queue')
+            c().sadd.assert_called_with(
+                'foo_kombu.binding.default',
+                '\x06\x16\x06\x16fooqueue'
+            )
+
 
 class test_Redis:
 


### PR DESCRIPTION
This PR continues the [work of @wetneb](https://github.com/celery/kombu/pull/912), adding a global key prefix to queue names addressing https://github.com/celery/kombu/issues/853. In the original PR, there were some unresolved issues that are resolved by this PR.

I believe most of the comments in the original approach were answered/resolved but https://github.com/celery/kombu/pull/912#pullrequestreview-166952378.

By adding the global key prefix to the `unacked_key `, `unacked_index_key`, `unacked_mutex_key` the prefix is applied for the `unacked` and `unacked_index` keys as well when the message is not ack'ed.

Also, the implementation adds the global key prefix even to the queue received by producer. Meaning that in the following example, the Redis transport will handle `a_queue_name` as `<prefix>a_queue_name`.

```python
queue = Queue('a_queue_name', exchange=Exchange('default'))
producer.publish('message_1', exchange=queue.exchange, declare=[queue])
```

**Discussions**:

* https://github.com/celery/kombu/pull/912#pullrequestreview-166952378
* https://github.com/celery/kombu/issues/853

**Dependencies**: None

**Testing instructions**:

1. Start Redis (using docker: `docker run --name kombu_redis --rm -it -p 6379:6379 redis:latest`)
2. Connect to redis using redis-cli in a separate terminal window (`docker exec -it kombu_redis redis-cli`)
3. List all keys (`KEYS *`) and validate empty array returned
4. Run snippet "example 1" (defined below) and validate the message object is printed
5. List all keys (`KEYS *`) and validate (only) `_prefixed__kombu.binding.default` is listed
6. Flush all keys (`FLUSHALL`)
7. Run snippet "example 2" (defined below) in an `ipython` shell and validate the message object is printed
8. List all keys (`KEYS *`) and validate (only) `_prefixed_unacked`, `_prefixed_unacked_index`, and `_prefixed__kombu.binding.default` are listed
9. Quit the shell and list the keys again (`KEYS *`) and validate that the `_prefixed_a_queue_name` is restored and `_prefixed__kombu.binding.default` is still listed
10. Run `SMEMBERS _prefixed__kombu.binding.default` and validate that `1) "\x06\x16\x06\x16_prefixed_a_queue_name"` is present

_Example 1_

```python
from kombu import Exchange, Queue, Producer, Connection, Consumer
connection = Connection('redis://', transport_options={'global_keyprefix': '_prefixed_'})
channel = connection.channel()
producer = Producer(channel)
queue = Queue('a_queue_name', exchange=Exchange('default'))

# Publish a message
producer.publish('message_1', exchange=queue.exchange, declare=[queue])

def printer(message):
    print(message)
    # Remove the line below for unacknowledged behavior
    message.ack()

with Consumer(connection, [queue], on_message=printer):
    connection.drain_events()
```

_Example 2_

```python
from kombu import Exchange, Queue, Producer, Connection, Consumer
connection = Connection('redis://', transport_options={'global_keyprefix': '_prefixed_'})
channel = connection.channel()
producer = Producer(channel)
queue = Queue('a_queue_name', exchange=Exchange('default'))

# Publish a message
producer.publish('message_1', exchange=queue.exchange, declare=[queue])

def printer(message):
    print(message)

with Consumer(connection, [queue], on_message=printer):
    connection.drain_events()
```

**Author notes and concerns**:

The original PR listed some maintainer concerns, but -- as I mentioned -- I believe those were "discussed" though not confirmed. In case any questions from the original PR are still open and not addressed by this PR, please let me know.