### PR TITLE
Add support for setting redis username

### DIFF
--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -944,6 +944,7 @@ class Channel(virtual.Channel):
             'host': conninfo.hostname or '127.0.0.1',
             'port': conninfo.port or self.connection.default_port,
             'virtual_host': conninfo.virtual_host,
+            'username': conninfo.userid,
             'password': conninfo.password,
             'max_connections': self.max_connections,
             'socket_timeout': self.socket_timeout,
@@ -974,7 +975,7 @@ class Channel(virtual.Channel):
                 pass
         host = connparams['host']
         if '://' in host:
-            scheme, _, _, _, password, path, query = _parse_url(host)
+            scheme, _, _, username, password, path, query = _parse_url(host)
             if scheme == 'socket':
                 connparams = self._filter_tcp_connparams(**connparams)
                 connparams.update({
@@ -984,6 +985,7 @@ class Channel(virtual.Channel):
                 connparams.pop('socket_connect_timeout', None)
                 connparams.pop('socket_keepalive', None)
                 connparams.pop('socket_keepalive_options', None)
+            connparams['username'] = username
             connparams['password'] = password
 
             connparams.pop('host', None)

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -695,6 +695,10 @@ class test_Channel:
         self.channel.connection.client.hostname = 'george.vandelay.com'
         assert self.channel._connparams()['host'] == 'george.vandelay.com'
 
+    def test_connparams_username(self):
+        self.channel.connection.client.userid = 'kombu'
+        assert self.channel._connparams()['username'] == 'kombu'
+
     def test_connparams_password_for_unix_socket(self):
         self.channel.connection.client.hostname = \
             'socket://:foo@/var/run/redis.sock'
@@ -1414,7 +1418,7 @@ class test_RedisSentinel:
                 min_other_sentinels=0, password=None, sentinel_kwargs=None,
                 socket_connect_timeout=None, socket_keepalive=None,
                 socket_keepalive_options=None, socket_timeout=None,
-                retry_on_timeout=None)
+                username=None, retry_on_timeout=None)
 
             master_for = patched.return_value.master_for
             master_for.assert_called()
@@ -1437,7 +1441,7 @@ class test_RedisSentinel:
                 min_other_sentinels=0, password=None, sentinel_kwargs=None,
                 socket_connect_timeout=None, socket_keepalive=None,
                 socket_keepalive_options=None, socket_timeout=None,
-                retry_on_timeout=None)
+                username=None, retry_on_timeout=None)
 
             master_for = patched.return_value.master_for
             master_for.assert_called()

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -699,6 +699,14 @@ class test_Channel:
         self.channel.connection.client.userid = 'kombu'
         assert self.channel._connparams()['username'] == 'kombu'
 
+    def test_connparams_client_credentials(self):
+        self.channel.connection.client.hostname = \
+            'redis://foo:bar@127.0.0.1:6379/0'
+        connection_parameters = self.channel._connparams()
+
+        assert connection_parameters['username'] == 'foo'
+        assert connection_parameters['password'] == 'bar'
+
     def test_connparams_password_for_unix_socket(self):
         self.channel.connection.client.hostname = \
             'socket://:foo@/var/run/redis.sock'


### PR DESCRIPTION
Although the underlying Redis package supports setting username for connections, the connection params for username are not passed to the `Redis` client.

This PR extracts the `userid` from connection info (or host) if and passes to Redis client ensuring the connection can be established for other users than the default `default` user (set when username is `None`).

**Dependencies**: None

**Testing instructions**:

1. Start Redis (using docker: `docker run --name kombu_redis --rm -it -p 6379:6379 redis:latest`)
2. Connect to redis using redis-cli in a separate terminal window (`docker exec -it kombu_redis redis-cli`)
3. List ACLs (`ACL LIST`) and validate only `default` user is listed
4. Run snippet "example 1" (defined below) and validate the message object is printed
5. Set a new password for `default` by running ` acl setuser default on >securepass`
6. List ACLs (`ACL LIST`) and validate `default` user now has a password hash set 
7. Set a new user by running ` acl setuser testuser on >password allcommands`
8. List ACLs (`ACL LIST`) and validate `testuser` is created with a password hash
9. Run snippet "example 2" (defined below) and validate the message object is printed

_Example 1_

```python
from kombu import Exchange, Queue, Producer, Connection, Consumer
connection = Connection('redis://')
channel = connection.channel()
producer = Producer(channel)
queue = Queue('a_queue_name', exchange=Exchange('default'))

# Publish a message
producer.publish('message_1', exchange=queue.exchange, declare=[queue])

def printer(message):
    print(message)
    # Remove the line below for unacknowledged behavior
    message.ack()

with Consumer(connection, [queue], on_message=printer):
    connection.drain_events()
```

_Example 2_

```python
from kombu import Exchange, Queue, Producer, Connection, Consumer
connection = Connection('redis://testuser:password@127.0.0.1:6379/0')
channel = connection.channel()
producer = Producer(channel)
queue = Queue('queue_name', exchange=Exchange('default'))

# Publish a message
producer.publish('message_1', exchange=queue.exchange, declare=[queue])

def printer(message):
    print(message)
    # Remove the line below for unacknowledged behavior
    message.ack()

with Consumer(connection, [queue], on_message=printer):                      
    connection.drain_events()
```

**Author notes and concerns**:

Redis' "new" ACL features released as part of Redis 6 introduced the possibility of defining additional users identified by passwords. Therefore it would be a great achievement if Kombu (and Celery) would support connecting to Redis using an ACL limited user.