### PR TITLE
Use hostname from URI when server_host is None

### DIFF
--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -73,7 +73,8 @@ class Connection:
         URL (str, Sequence): Broker URL, or a list of URLs.
 
     Keyword Arguments:
-        ssl (bool): Use SSL to connect to the server. Default is ``False``.
+        ssl (bool/dict): Use SSL to connect to the server.
+            Default is ``False``.
             May not be supported by the specified transport.
         transport (Transport): Default transport if not specified in the URL.
         connect_timeout (float): Timeout in seconds for connecting to the

--- a/t/unit/transport/test_pyamqp.py
+++ b/t/unit/transport/test_pyamqp.py
@@ -1,10 +1,10 @@
 import sys
 from itertools import count
-from unittest.mock import Mock, patch, MagicMock
-
-from case import mock
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+from case import mock
+
 from kombu import Connection
 from kombu.transport import pyamqp
 


### PR DESCRIPTION
Add support for using hostname from URI in `server_hostname` SSL parameter when `server_hostname=None. This is usefull when URI with multiple brokers is used.

Superseeds: #744
