### PR TITLE
SQS Channel.predefined_queues should be `{}` if not defined

### DIFF
--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -762,7 +762,7 @@ class Channel(virtual.Channel):
     @cached_property
     def predefined_queues(self):
         """Map of queue_name to predefined queue settings."""
-        return self.transport_options.get('predefined_queues', None)
+        return self.transport_options.get('predefined_queues', {})
 
     @cached_property
     def queue_name_prefix(self):


### PR DESCRIPTION
Previously, calling `reject` when `predefined_queues` was not configured would cause `AttributeError` to be raised from `_extract_backoff_policy_configuration_and_message`. That exception could crash the whole Celery worker and force it to exit early because `AttributeError` is not excepted in the nearby call stack.

I work on a Red Hat project [cloudigrade](https://github.com/cloudigrade/cloudigrade/) that has been using Celery/Kombu with SQS for the last couple years, and a few days ago we saw a surprise catastrophic failure in a Celery worker that I tracked down to this problem. We had some old messages lingering in the default `celery` SQS queue for a task function that we recently removed, and normally I would expect the Celery worker to reject the message and log a warning for it, but instead the Celery worker completely crashed (or in some cases I haven't dug into, instead of crashing it just stopped reading any new messages until restart). We worked around this problem by temporarily restoring placeholder functions that would allow the tasks to "run" and dequeue as expected.

This PR simply makes the SQS Channel's `predefined_queues` default to `{}` instead of `None` when it is not configured. That seemed to resolve our problem when I tested it locally.

I added a unit test here that I _think_ is appropriate, but this is my first time committing to Kombu, and I'd welcome any suggestions or feedback or corrections if you believe this is not a good fix.

I also created a minimal one-off Django project with instructions of how to reproduce this problem at [infinitewarp/kombu-sqs-reject-bug](https://github.com/infinitewarp/kombu-sqs-reject-bug), and [I posted an asciinema recording](https://asciinema.org/a/431428) of me going through the steps I outlined in that repo's README.