### PR TITLE
Add support for custom yaml encoding

### DIFF
--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -101,3 +101,4 @@ Kombu utils
     kombu.utils.time
     kombu.utils.url
     kombu.utils.uuid
+    kombu.utils.yaml

--- a/docs/reference/kombu.utils.yaml.rst
+++ b/docs/reference/kombu.utils.yaml.rst
@@ -1,0 +1,12 @@
+==========================================================
+ Yaml Utilities - ``kombu.utils.yaml``
+==========================================================
+
+.. contents::
+    :local:
+.. currentmodule:: kombu.utils.yaml
+
+.. automodule:: kombu.utils.yaml
+    :members:
+    :undoc-members:
+

--- a/kombu/utils/yaml.py
+++ b/kombu/utils/yaml.py
@@ -1,0 +1,43 @@
+from typing import Type
+
+from yaml import SafeDumper
+
+
+def register_yaml_decoder(type_: Type):
+    """
+    Register class known to deserialize themselves as yaml.
+
+    Expect the __yaml__ mnethod to be implemented on the instance.
+
+    Arguments:
+        type_ (Type): The type of the data to be serialized
+
+    Returns:
+        Type: the type_ argument
+
+    Examples:
+        >>> from kombu.utils.yaml import register_yaml_decoders
+        >>> from kombu.serialization import dumps
+
+
+        >>> @register_yaml_decoder
+        ... class Custom:
+        ...     def __init__(self, a):
+        ...         self.a = a
+        ...     def __yaml__(self):
+        ...         return {'a': self.a}
+        ...
+        >>>
+
+        >>> dumps({'my_obj': Custom(a=1)}, serializer='yaml')
+        ('application/x-yaml', 'utf-8', 'my_obj:\n  a: 1\n')
+
+
+    """
+    assert hasattr(type_, '__yaml__')
+    SafeDumper.add_representer(type_, represent__yaml__)
+    return type_
+
+
+def represent__yaml__(self, data):
+    return self.represent_dict(data.__yaml__())

--- a/kombu/utils/yaml.py
+++ b/kombu/utils/yaml.py
@@ -1,19 +1,21 @@
+"""Yaml Serialization Utilities."""
+
 from typing import Type
 
 from yaml import SafeDumper
 
 
 def register_yaml_decoder(type_: Type):
-    """
-    Register class known to deserialize themselves as yaml.
+    r"""Register class known to deserialize themselves as yaml.
 
-    Expect the __yaml__ mnethod to be implemented on the instance.
+    It expect the __yaml__ method to be implemented on the instances
+    of the given type.
 
     Arguments:
-        type_ (Type): The type of the data to be serialized
+        type_ (Type): The type of the data to be serialized.
 
     Returns:
-        Type: the type_ argument
+        Type: the type_ argument.
 
     Examples:
         >>> from kombu.utils.yaml import register_yaml_decoders
@@ -31,8 +33,6 @@ def register_yaml_decoder(type_: Type):
 
         >>> dumps({'my_obj': Custom(a=1)}, serializer='yaml')
         ('application/x-yaml', 'utf-8', 'my_obj:\n  a: 1\n')
-
-
     """
     assert hasattr(type_, '__yaml__')
     SafeDumper.add_representer(type_, represent__yaml__)
@@ -40,13 +40,15 @@ def register_yaml_decoder(type_: Type):
 
 
 def represent__yaml__(self, data):
-    """
-    Custom representer for yaml dumper
-    https://pyyaml.org/wiki/PyYAMLDocumentationhttps://pyyaml.org/wiki/PyYAMLDocumentation
+    """Represent any object implementing __yaml__().
+
+    See Also:
+        https://pyyaml.org/wiki/PyYAMLDocumentation .
 
     Arguments:
-        self (yaml.Dumper): dumper being executed
+        self (yaml.Dumper): dumper being executed.
+
         data (Any): data being serializer into yaml.
-                    We expect to find a method __yaml__ on this object.
+            We expect to find a method __yaml__ on this object.
     """
     return self.represent_dict(data.__yaml__())

--- a/kombu/utils/yaml.py
+++ b/kombu/utils/yaml.py
@@ -40,4 +40,13 @@ def register_yaml_decoder(type_: Type):
 
 
 def represent__yaml__(self, data):
+    """
+    Custom representer for yaml dumper
+    https://pyyaml.org/wiki/PyYAMLDocumentationhttps://pyyaml.org/wiki/PyYAMLDocumentation
+
+    Arguments:
+        self (yaml.Dumper): dumper being executed
+        data (Any): data being serializer into yaml.
+                    We expect to find a method __yaml__ on this object.
+    """
     return self.represent_dict(data.__yaml__())

--- a/t/unit/test_serialization.py
+++ b/t/unit/test_serialization.py
@@ -240,6 +240,25 @@ class test_Serialization:
         )
         assert a == b
 
+    def test_yaml_dumps__yaml__(self):
+        pytest.importorskip('yaml')
+        register_yaml()
+        from kombu.utils.yaml import register_yaml_decoder
+
+        @register_yaml_decoder
+        class Custom:
+            def __init__(self, a):
+                self.a = a
+
+            def __yaml__(self):
+                return {'a': self.a}
+
+        custom = Custom(a=1)
+        test_data = py_data.copy()
+        test_data['custom'] = custom
+        _, _, yaml_str = dumps(test_data, serializer='yaml')
+        assert 'custom:\n  a: 1\n' in yaml_str
+
     def test_pickle_loads(self):
         assert loads(
             pickle_data,


### PR DESCRIPTION
if `__yaml__` method is implemented, then use it
to instruct the yaml Encoder on how to perform arbitrary custom instances.

Related to https://github.com/celery/celery/issues/6901