### PR TITLE
[FAL-2030] fix: add missing commands to prefix

### DIFF
--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -197,7 +197,10 @@ class GlobalKeyPrefixMixin:
         "LLEN",
         "LPUSH",
         "PUBLISH",
+        "RPUSH",
+        "RPOP",
         "SADD",
+        "SREM",
         "SET",
         "SMEMBERS",
         "ZADD",
@@ -206,6 +209,7 @@ class GlobalKeyPrefixMixin:
     ]
 
     PREFIXED_COMPLEX_COMMANDS = {
+        "DEL": {"args_start": 0, "args_end": None},
         "BRPOP": {"args_start": 0, "args_end": -1},
         "EVALSHA": {"args_start": 2, "args_end": 3},
     }
@@ -222,13 +226,10 @@ class GlobalKeyPrefixMixin:
             args_end = self.PREFIXED_COMPLEX_COMMANDS[command]["args_end"]
 
             pre_args = args[:args_start] if args_start > 0 else []
+            post_args = []
 
             if args_end is not None:
                 post_args = args[args_end:]
-            elif args_end < 0:
-                post_args = args[len(args):]
-            else:
-                post_args = []
 
             args = pre_args + [
                 self.global_keyprefix + str(arg)

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -1561,6 +1561,21 @@ class test_GlobalKeyPrefixMixin:
                 f"{self.global_keyprefix}fake_key"
             ]
 
+    def test_prefix_delete_args(self):
+        prefixed_args = self.mixin._prefix_args([
+            "DEL",
+            "fake_key",
+            "fake_key2",
+            "fake_key3"
+        ])
+
+        assert prefixed_args == [
+            "DEL",
+            f"{self.global_keyprefix}fake_key",
+            f"{self.global_keyprefix}fake_key2",
+            f"{self.global_keyprefix}fake_key3",
+        ]
+
     def test_prefix_brpop_args(self):
         prefixed_args = self.mixin._prefix_args([
             "BRPOP",


### PR DESCRIPTION
## Description

Although https://github.com/celery/kombu/pull/1349 introduced key prefixing, it turned out that some commands were missed during the refactoring of the approach. This PR adds missing DEL, RPUSH, RPOP, and SREM commands to the list of commands to prefix. Also, this patch refactors the prefixing logic a bit to make it simpler.

## Testing instructions

Run the new unit tests.

## Deadline

Sooner is better