### PR TITLE
Make BrokerState Transport specific

### DIFF
--- a/kombu/transport/filesystem.py
+++ b/kombu/transport/filesystem.py
@@ -271,10 +271,15 @@ class Transport(virtual.Transport):
     """Filesystem Transport."""
 
     Channel = Channel
-
+    # filesystem backend state is global.
+    global_state = virtual.BrokerState()
     default_port = 0
     driver_type = 'filesystem'
     driver_name = 'filesystem'
+
+    def __init__(self, client, **kwargs):
+        super().__init__(client, **kwargs)
+        self.state = self.global_state
 
     def driver_version(self):
         return 'N/A'

--- a/kombu/transport/memory.py
+++ b/kombu/transport/memory.py
@@ -89,12 +89,16 @@ class Transport(virtual.Transport):
     Channel = Channel
 
     #: memory backend state is global.
-    state = virtual.BrokerState()
+    global_state = virtual.BrokerState()
 
     implements = base.Transport.implements
 
     driver_type = 'memory'
     driver_name = 'memory'
+
+    def __init__(self, client, **kwargs):
+        super().__init__(client, **kwargs)
+        self.state = self.global_state
 
     def driver_version(self):
         return 'N/A'

--- a/kombu/transport/pyro.py
+++ b/kombu/transport/pyro.py
@@ -113,11 +113,16 @@ class Transport(virtual.Transport):
     Channel = Channel
 
     #: memory backend state is global.
-    state = virtual.BrokerState()
+    # TODO: To be checked whether state can be per-Transport
+    global_state = virtual.BrokerState()
 
     default_port = DEFAULT_PORT
 
     driver_type = driver_name = 'pyro'
+
+    def __init__(self, client, **kwargs):
+        super().__init__(client, **kwargs)
+        self.state = self.global_state
 
     def _open(self):
         logger.debug("trying Pyro nameserver to find the broker daemon")

--- a/kombu/transport/virtual/base.py
+++ b/kombu/transport/virtual/base.py
@@ -871,9 +871,6 @@ class Transport(base.Transport):
     Cycle = FairCycle
     Management = Management
 
-    #: Global :class:`BrokerState` containing declared exchanges and bindings.
-    state = BrokerState()
-
     #: :class:`~kombu.utils.scheduling.FairCycle` instance
     #: used to fairly drain events from channels (set by constructor).
     cycle = None
@@ -901,6 +898,8 @@ class Transport(base.Transport):
 
     def __init__(self, client, **kwargs):
         self.client = client
+        # :class:`BrokerState` containing declared exchanges and bindings.
+        self.state = BrokerState()
         self.channels = []
         self._avail_channels = []
         self._callbacks = {}

--- a/t/unit/transport/virtual/test_base.py
+++ b/t/unit/transport/virtual/test_base.py
@@ -550,6 +550,13 @@ class test_Transport:
     def setup(self):
         self.transport = client().transport
 
+    def test_state_is_transport_specific(self):
+        # Tests that each Transport of Connection instance
+        # has own state attribute
+        conn1 = client()
+        conn2 = client()
+        assert conn1.transport.state != conn2.transport.state
+
     def test_custom_polling_interval(self):
         x = client(transport_options={'polling_interval': 32.3})
         assert x.transport.polling_interval == 32.3


### PR DESCRIPTION
This PR changes BrokerState from being global to be Transport specific. This fixes issues when client is reconnecting and old BrokerState is used not matching the actual broker state. Memory and filesystem transport are still keeping global state since the implementation is not compatibile with per-transport broker state. Pyro transport is kept with global broker state for backward compatibility. Pyro transport should be retested and ported to per-transport state.

Fixes: #1377
