### PR TITLE
Fix PyPy CI jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,9 @@ jobs:
         python-version: [3.7,3.8,3.9]
         experimental: [false]
         include:
-          - python-version: pypy3
+          - python-version: pypy-3.7
+            experimental: true
+          - python-version: pypy-3.8
             experimental: true
     steps:
       - name: Install system packages
@@ -46,10 +48,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: pip install --upgrade pip setuptools wheel tox tox-docker
+      # Tox fails if a Python versions contains a hyphen, this changes "pypy-3.8" to "pypy3.8".
+      - name: Determine Python version
+        run: echo PYTHON_VERSION=$(echo ${{ matrix.python-version }} | sed s/-//) >> $GITHUB_ENV
       - name: Run AMQP integration tests
-        run: tox -v -e ${{ matrix.python-version }}-linux-integration-py-amqp -- -v
+        run: tox -v -e ${{ env.PYTHON_VERSION }}-linux-integration-py-amqp -- -v
       - name: Run redis integration tests
-        run: tox -v -e ${{ matrix.python-version }}-linux-integration-py-redis -- -v
+        run: tox -v -e ${{ env.PYTHON_VERSION }}-linux-integration-py-redis -- -v
 
   #################### Linters and checkers ####################
   lint:

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    {pypy3,3.7,3.8,3.9,3.10}-unit
-    {pypy3,3.7,3.8,3.9,3.10}-linux-integration-py-amqp
-    {pypy3,3.7,3.8,3.9,3.10}-linux-integration-redis
+    {pypy3.7,pypy3.8,3.7,3.8,3.9,3.10}-unit
+    {pypy3.7,pypy3.8,3.7,3.8,3.9,3.10}-linux-integration-py-amqp
+    {pypy3.7,pypy3.8,3.7,3.8,3.9,3.10}-linux-integration-redis
     flake8
     flakeplus
     apicheck
@@ -17,9 +17,9 @@ passenv =
   DISTUTILS_USE_SDK
 deps=
     -r{toxinidir}/requirements/dev.txt
-    apicheck,pypy3,3.7,3.8,3.9,3.10: -r{toxinidir}/requirements/default.txt
-    apicheck,pypy3,3.7,3.8,3.9,3.10: -r{toxinidir}/requirements/test.txt
-    apicheck,pypy3,3.7-linux,3.8-linux,3.9-linux,3.10-linux: -r{toxinidir}/requirements/test-ci.txt
+    apicheck,pypy3.7,pypy3.8,3.7,3.8,3.9,3.10: -r{toxinidir}/requirements/default.txt
+    apicheck,pypy3.7,pypy3.8,3.7,3.8,3.9,3.10: -r{toxinidir}/requirements/test.txt
+    apicheck,pypy3.7,pypy3.8,3.7-linux,3.8-linux,3.9-linux,3.10-linux: -r{toxinidir}/requirements/test-ci.txt
     3.7-windows,3.8-windows,3.9-windows,3.10-windows: -r{toxinidir}/requirements/test-ci-windows.txt
     apicheck,linkcheck: -r{toxinidir}/requirements/docs.txt
     flake8,flakeplus,pydocstyle: -r{toxinidir}/requirements/pkgutils.txt
@@ -30,10 +30,11 @@ commands =
     integration-redis: py.test -xv -E redis t/integration {posargs:-n2}
 
 basepython =
+    pypy3.7: pypy3.7
+    pypy3.8: pypy3.8
     3.7: python3.7
     3.8: python3.8
     3.9,apicheck,pydocstyle,flake8,linkcheck,cov: python3.9
-    pypy3: pypy3.7
     3.10: python3.10
 
 install_command = python -m pip --disable-pip-version-check install {opts} {packages}


### PR DESCRIPTION
`setup-python` install PyPy 3.6.12 as `pypy3`. I replaced it with `pypy-3.7` and `pypy-3.8`.
Unfortunately, Tox did not want to accept `pypy-3.7` and `pypy-3.8`, that is why I added one more step removing a hyphen from a version.