### PR TITLE
Ensure that restore is atomic in redis transport (#1444)

### DIFF
--- a/kombu/tests/transport/test_redis.py
+++ b/kombu/tests/transport/test_redis.py
@@ -374,38 +374,56 @@ class test_Channel(Case):
             )
             self.assertTrue(crit.called)
 
-    def test_restore(self):
+    def test_restore_no_messages(self):
         message = Mock(name='message')
+
         with patch('kombu.transport.redis.loads') as loads:
-            loads.return_value = 'M', 'EX', 'RK'
+            def transaction_handler(restore_transaction, unacked_key):
+                assert unacked_key == self.channel.unacked_key
+                pipe = Mock(name='pipe')
+                pipe.hget.return_value = None
+
+                restore_transaction(pipe)
+
+                pipe.multi.assert_called_once_with()
+                pipe.hdel.assert_called_once_with(
+                        unacked_key, message.delivery_tag)
+                loads.assert_not_called()
+
             client = self.channel._create_client = Mock(name='client')
             client = client()
-            client.pipeline = ContextMock()
-            restore = self.channel._do_restore_message = Mock(
-                name='_do_restore_message',
-            )
-            pipe = client.pipeline.return_value
-            pipe_hget = Mock(name='pipe.hget')
-            pipe.hget.return_value = pipe_hget
-            pipe_hget_hdel = Mock(name='pipe.hget.hdel')
-            pipe_hget.hdel.return_value = pipe_hget_hdel
-            result = Mock(name='result')
-            pipe_hget_hdel.execute.return_value = None, None
-
+            client.transaction.side_effect = transaction_handler
             self.channel._restore(message)
-            client.pipeline.assert_called_with()
-            unacked_key = self.channel.unacked_key
-            self.assertFalse(loads.called)
+            client.transaction.assert_called()
 
-            tag = message.delivery_tag
-            pipe.hget.assert_called_with(unacked_key, tag)
-            pipe_hget.hdel.assert_called_with(unacked_key, tag)
-            pipe_hget_hdel.execute.assert_called_with()
+    def test_restore_messages(self):
+        message = Mock(name='message')
 
-            pipe_hget_hdel.execute.return_value = result, None
+        with patch('kombu.transport.redis.loads') as loads:
+
+            def transaction_handler(restore_transaction, unacked_key):
+                assert unacked_key == self.channel.unacked_key
+                restore = self.channel._do_restore_message = Mock(
+                    name='_do_restore_message',
+                )
+                result = Mock(name='result')
+                loads.return_value = 'M', 'EX', 'RK'
+                pipe = Mock(name='pipe')
+                pipe.hget.return_value = result
+
+                restore_transaction(pipe)
+
+                loads.assert_called_with(result)
+                pipe.multi.assert_called_once_with()
+                pipe.hdel.assert_called_once_with(
+                        unacked_key, message.delivery_tag)
+                loads.assert_called()
+                restore.assert_called_with('M', 'EX', 'RK', pipe, False)
+
+            client = self.channel._create_client = Mock(name='client')
+            client = client()
+            client.transaction.side_effect = transaction_handler
             self.channel._restore(message)
-            loads.assert_called_with(result)
-            restore.assert_called_with('M', 'EX', 'RK', client, False)
 
     def test_qos_restore_visible(self):
         client = self.channel._create_client = Mock(name='client')

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -195,13 +195,17 @@ class QoS(virtual.QoS):
                 pass
 
     def restore_by_tag(self, tag, client=None, leftmost=False):
-        with self.channel.conn_or_acquire(client) as client:
-            with client.pipeline() as pipe:
-                p, _, _ = self._remove_from_indices(
-                    tag, pipe.hget(self.unacked_key, tag)).execute()
+
+        def restore_transaction(pipe):
+            p = pipe.hget(self.unacked_key, tag)
+            pipe.multi()
+            self._remove_from_indices(tag, pipe)
             if p:
                 M, EX, RK = loads(bytes_to_str(p))  # json is unicode
-                self.channel._do_restore_message(M, EX, RK, client, leftmost)
+                self.channel._do_restore_message(M, EX, RK, pipe, leftmost)
+
+        with self.channel.conn_or_acquire(client) as client:
+            client.transaction(restore_transaction, self.unacked_key)
 
     @cached_property
     def unacked_key(self):
@@ -498,32 +502,34 @@ class Channel(virtual.Channel):
             raise get_redis_ConnectionError()
 
     def _do_restore_message(self, payload, exchange, routing_key,
-                            client=None, leftmost=False):
-        with self.conn_or_acquire(client) as client:
+                            pipe, leftmost=False):
+        try:
             try:
-                try:
-                    payload['headers']['redelivered'] = True
-                except KeyError:
-                    pass
-                for queue in self._lookup(exchange, routing_key):
-                    (client.lpush if leftmost else client.rpush)(
-                        queue, dumps(payload),
-                    )
-            except Exception:
-                crit('Could not restore message: %r', payload, exc_info=True)
+                payload['headers']['redelivered'] = True
+            except KeyError:
+                pass
+            for queue in self._lookup(exchange, routing_key):
+                (pipe.lpush if leftmost else pipe.rpush)(
+                    queue, dumps(payload),
+                )
+        except Exception:
+            crit('Could not restore message: %r', payload, exc_info=True)
 
     def _restore(self, message, leftmost=False):
         if not self.ack_emulation:
             return super(Channel, self)._restore(message)
         tag = message.delivery_tag
-        with self.conn_or_acquire() as client:
-            with client.pipeline() as pipe:
-                P, _ = pipe.hget(self.unacked_key, tag) \
-                           .hdel(self.unacked_key, tag) \
-                           .execute()
+
+        def restore_transaction(pipe):
+            P = pipe.hget(self.unacked_key, tag)
+            pipe.multi()
+            pipe.hdel(self.unacked_key, tag)
             if P:
                 M, EX, RK = loads(bytes_to_str(P))  # json is unicode
-                self._do_restore_message(M, EX, RK, client, leftmost)
+                self._do_restore_message(M, EX, RK, pipe, leftmost)
+
+        with self.conn_or_acquire() as client:
+            client.transaction(restore_transaction, self.unacked_key)
 
     def _restore_at_beginning(self, message):
         return self._restore(message, leftmost=True)


### PR DESCRIPTION
* Ensure that restore is atomic in redis transport

(cherry picked from commit 58975b2a95b213596a340c77f52a2eb94d529f54)