### PR TITLE
respect connection timeout

### DIFF
--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -837,7 +837,7 @@ class Connection:
         return self.transport.qos_semantics_matches_spec(self.connection)
 
     def _extract_failover_opts(self):
-        conn_opts = {}
+        conn_opts = {'timeout': self.connect_timeout}
         transport_opts = self.transport_options
         if transport_opts:
             if 'max_retries' in transport_opts:

--- a/t/unit/test_connection.py
+++ b/t/unit/test_connection.py
@@ -587,6 +587,16 @@ class test_Connection:
         conn = Connection('example.com;example.com;')
         assert conn.as_uri() == 'amqp://guest:**@example.com:5672//'
 
+    def test_connection_respect_its_timeout(self):
+        invalid_port = 1222
+        with Connection(
+            f'amqp://guest:guest@localhost:{invalid_port}//',
+            transport_options={'max_retries': 2},
+            connect_timeout=1
+        ) as conn:
+            with pytest.raises(OperationalError):
+                conn.default_channel
+
 
 class test_Connection_with_transport_options:
 


### PR DESCRIPTION
Consider the following code which has been copied from the README file, except that I have added `transport_options={'max_retries': 3}` and `connect_timeout=1` as parameters to Connection.

```python
from kombu import Connection, Exchange, Queue

media_exchange = Exchange('media', 'direct', durable=True)
video_queue = Queue('video', exchange=media_exchange, routing_key='video')


# connections
with Connection('amqp://guest:guest@localhost//',
                transport_options={'max_retries': 3},
                connect_timeout=1) as conn:
    # produce
    producer = conn.Producer(serializer='json')
    producer.publish({'name': '/tmp/lolcat1.avi', 'size': 1301013},
                     exchange=media_exchange, routing_key='video',
                     declare=[video_queue])
```

As it appears, this script should take 3 seconds to fail when rabbitmq is down, but with the current version of Kombu, it hangs forever. Also when I try to publish a celery task when rabbitmq is down, the same thing happens.  This commit fixes this problem which have been resided in Kombu for at least two years as far as I know.