### PR TITLE
prevent KeyError: 'purelib' 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 import os
 import re
 import sys
-from distutils.command.install import INSTALL_SCHEMES
 
 import setuptools
 import setuptools.command.test
@@ -55,9 +54,6 @@ def fullsplit(path, result=None):
         return result
     return fullsplit(head, [tail] + result)
 
-
-for scheme in list(INSTALL_SCHEMES.values()):
-    scheme['data'] = scheme['purelib']
 
 # if os.path.exists('README.rst'):
 #    long_description = codecs.open('README.rst', 'r', 'utf-8').read()


### PR DESCRIPTION
This might be another potential fix for the issues in: https://github.com/celery/kombu/pull/1462

Currently we're seeing this error:
```
Traceback (most recent call last):
File "setup.py", line 60, in
scheme['data'] = scheme['purelib']
KeyError: 'purelib'
```

This seems to describe what the code with the error is doing: https://stackoverflow.com/a/3042436

That code was added in the initial commit for kombu and `data_files` is no longer defined anymore. So, maybe the hack to copy data files to the module directory isn't necessary anymore? Or maybe this should be handled in `MANIFEST.in` instead?