### PR TITLE
reduce memory usage of Transport

### DIFF
--- a/kombu/transport/virtual/base.py
+++ b/kombu/transport/virtual/base.py
@@ -462,7 +462,8 @@ class Channel(AbstractChannel, base.StdChannel):
             typ: cls(self) for typ, cls in self.exchange_types.items()
         }
 
-        # Cast to a set for fast lookups, and keep stored as an array for lower memory usage.
+        # Cast to a set for fast lookups, and keep stored as an array
+        # for lower memory usage.
         used_channel_ids = set(self.connection._used_channel_ids)
 
         for channel_id in range(1, self.connection.channel_max + 1):

--- a/t/unit/transport/test_consul.py
+++ b/t/unit/transport/test_consul.py
@@ -1,3 +1,4 @@
+from array import array
 from queue import Empty
 from unittest.mock import Mock
 
@@ -12,6 +13,8 @@ class test_Consul:
 
     def setup(self):
         self.connection = Mock()
+        self.connection._used_channel_ids = array('H')
+        self.connection.channel_max = 65535
         self.connection.client.transport_options = {}
         self.connection.client.port = 303
         self.consul = self.patching('consul.Consul').return_value

--- a/t/unit/transport/virtual/test_base.py
+++ b/t/unit/transport/virtual/test_base.py
@@ -180,7 +180,9 @@ class test_Channel:
             self.channel._qos._on_collect.cancel()
 
     def test_init__channel_id(self):
-        """Ensure the channel_id is incremented when creating new channels on the same connection."""
+        """Ensure the channel_id is incremented when creating new channels on
+        the same connection.
+        """
         assert self.channel.channel_id == 1
         channel_2 = self.channel.connection.client.channel()
         assert channel_2.channel_id == 2
@@ -592,7 +594,9 @@ class test_Transport:
         assert self.transport.channels == [created_channel]
 
     def test_close_channel(self):
-        """Ensure close_channel actually removes the channel and updates _used_channel_ids."""
+        """Ensure close_channel actually removes the channel and updates
+        _used_channel_ids.
+        """
         assert self.transport._used_channel_ids == array('H')
         created_channel = self.transport.create_channel(self.transport)
         assert self.transport._used_channel_ids == array('H', (1,))

--- a/t/unit/transport/virtual/test_base.py
+++ b/t/unit/transport/virtual/test_base.py
@@ -179,22 +179,19 @@ class test_Channel:
         if self.channel._qos is not None:
             self.channel._qos._on_collect.cancel()
 
-    def test_init__channel_id(self):
-        """Ensure the channel_id is incremented when creating new channels on
-        the same connection.
-        """
-        assert self.channel.channel_id == 1
-        channel_2 = self.channel.connection.client.channel()
-        assert channel_2.channel_id == 2
+    def test_get_free_channel_id(self):
+        conn = client()
+        channel = conn.channel()
+        assert channel.channel_id == 1
+        assert channel._get_free_channel_id() == 2
 
-    def test_exceeds_channel_max(self):
-        c = client()
-        t = c.transport
-        c.transport.channel_max = 2
-        virtual.Channel(t)
-        virtual.Channel(t)
+    def test_get_free_channel_id__exceeds_channel_max(self):
+        conn = client()
+        conn.transport.channel_max = 2
+        channel = conn.channel()
+        channel._get_free_channel_id()
         with pytest.raises(ResourceError):
-            virtual.Channel(t)
+            channel._get_free_channel_id()
 
     def test_exchange_bind_interface(self):
         with pytest.raises(NotImplementedError):


### PR DESCRIPTION
While investigating a redis broker memory leak, I noticed the same issue as py-amqp's [#377](https://github.com/celery/py-amqp/pull/377):
```
Top 10 lines
#1: /celery_app/kombu/kombu/transport/virtual/base.py:911: 782.4 KiB
    ARRAY_TYPE_H, range(self.channel_max, 0, -1),
<truncated>
```

The array that's used to store available connection ids is taking up an unnecessary amount of memory (more than anything else while running celery), and it's making memory leaks worse.

This PR reduces the memory usage of the `Transport` by reversing that logic and turning `_avail_channel_ids` into `_used_channel_ids`. This will only store the channel ids that are currently used, which is almost always going to be a much smaller array.