### PR TITLE
prevent event loop polling on closed redis transports (and causing leak)

### DIFF
--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -1237,6 +1237,12 @@ class Transport(virtual.Transport):
         def _on_disconnect(connection):
             if connection._sock:
                 loop.remove(connection._sock)
+
+            # stop polling in the event loop
+            try:
+                loop.on_tick.remove(on_poll_start)
+            except KeyError:
+                pass
         cycle._on_connection_disconnect = _on_disconnect
 
         def on_poll_start():

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -854,6 +854,21 @@ class test_Channel:
             call(13, transport.on_readable, 13),
         ])
 
+    def test_register_with_event_loop__on_disconnect__loop_cleanup(self):
+        """Ensure event loop polling stops on disconnect."""
+        transport = self.connection.transport
+        self.connection._sock = None
+        transport.cycle = Mock(name='cycle')
+        transport.cycle.fds = {12: 'LISTEN', 13: 'BRPOP'}
+        conn = Mock(name='conn')
+        conn.client = Mock(name='client', transport_options={})
+        loop = Mock(name='loop')
+        loop.on_tick = set()
+        redis.Transport.register_with_event_loop(transport, conn, loop)
+        assert len(loop.on_tick) == 1
+        transport.cycle._on_connection_disconnect(self.connection)
+        assert loop.on_tick == set()
+
     def test_configurable_health_check(self):
         transport = self.connection.transport
         transport.cycle = Mock(name='cycle')


### PR DESCRIPTION
This is related to my comment on the celery memory leak bug: https://github.com/celery/celery/issues/4843#issuecomment-999168967

I [added some logging](https://github.com/celery/kombu/compare/master...pawl:logging_insanity?expand=1#diff-203e309d100714904255d0af4500dd295e40e4ffedfdc9295ab3b386718ca87eR1333) to `on_poll_start` in the redis `Transport`'s `register_with_event_loop`, and I noticed the event loop continues to poll on redis `Transport`s that were disconnected. This causes some leftover references to the initialized `Transport` in the event loop's `on_tick` and prevents the initialized `Transport` from being garbage collected.

This is similar to the issue @michael-lazar noticed in [bug #1 in his comment about the py-amqp memory leak](https://github.com/celery/celery/issues/4843#issuecomment-991394349). However, the code for the redis transport is very different because it uses `MultiChannelPoller`.

This PR fixes the issue by removing the disconnected redis `Transport`'s polling function from the event loop's `on_tick` when disconnection occurs (to stop the polling in the event loop on the dead Transport).

I tested the fix with [this minimal example](https://github.com/pawl/celery_pyamqp_memory_leak/tree/test_redis_fix) and was able to confirm it stopped the relevant memory leak.