### PR TITLE
prevent redis event loop stopping on 'consumer: Cannot connect'

### DIFF
--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -397,9 +397,6 @@ class MultiChannelPoller:
     #: Set of one-shot callbacks to call after reading from socket.
     after_read = None
 
-    #: Set by :meth:`on_poll_start` after successfully running once.
-    poll_started = False
-
     def __init__(self):
         # active channels
         self._channels = set()
@@ -477,7 +474,6 @@ class MultiChannelPoller:
                     self._register_BRPOP(channel)
             if channel.active_fanout_queues:    # LISTEN mode?
                 self._register_LISTEN(channel)
-        self.poll_started = True
 
     def on_poll_init(self, poller):
         self.poller = poller
@@ -1243,7 +1239,7 @@ class Transport(virtual.Transport):
                 loop.remove(connection._sock)
 
             # must have started polling or this will break reconnection
-            if cycle.poll_started:
+            if cycle.fds:
                 # stop polling in the event loop
                 try:
                     loop.on_tick.remove(on_poll_start)

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -855,7 +855,10 @@ class test_Channel:
         ])
 
     @pytest.mark.parametrize('poll_started', [True, False])
-    def test_register_with_event_loop__on_disconnect__loop_cleanup(self, poll_started):
+    def test_register_with_event_loop__on_disconnect__loop_cleanup(
+        self,
+        poll_started,
+    ):
         """Ensure event loop polling stops on disconnect (if started)."""
         transport = self.connection.transport
         self.connection._sock = None
@@ -1193,9 +1196,9 @@ class test_MultiChannelPoller:
     def test_on_poll_start(self):
         p = self.Poller()
         p._channels = []
-        assert p.poll_started == False
+        assert p.poll_started is False
         p.on_poll_start()
-        assert p.poll_started == True
+        assert p.poll_started is True
         p._register_BRPOP = Mock(name='_register_BRPOP')
         p._register_LISTEN = Mock(name='_register_LISTEN')
 

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -854,28 +854,24 @@ class test_Channel:
             call(13, transport.on_readable, 13),
         ])
 
-    @pytest.mark.parametrize('poll_started', [True, False])
-    def test_register_with_event_loop__on_disconnect__loop_cleanup(
-        self,
-        poll_started,
-    ):
+    @pytest.mark.parametrize('fds', [{12: 'LISTEN', 13: 'BRPOP'}, {}])
+    def test_register_with_event_loop__on_disconnect__loop_cleanup(self, fds):
         """Ensure event loop polling stops on disconnect (if started)."""
         transport = self.connection.transport
         self.connection._sock = None
         transport.cycle = Mock(name='cycle')
-        transport.cycle.fds = {12: 'LISTEN', 13: 'BRPOP'}
+        transport.cycle.fds = fds
         conn = Mock(name='conn')
         conn.client = Mock(name='client', transport_options={})
         loop = Mock(name='loop')
         loop.on_tick = set()
         redis.Transport.register_with_event_loop(transport, conn, loop)
         assert len(loop.on_tick) == 1
-        transport.cycle.poll_started = poll_started
         transport.cycle._on_connection_disconnect(self.connection)
-        if poll_started:
+        if fds:
             assert len(loop.on_tick) == 0
         else:
-            # on_tick shouldn't be cleared when cycle.poll_started is False
+            # on_tick shouldn't be cleared when polling hasn't started
             assert len(loop.on_tick) == 1
 
     def test_configurable_health_check(self):
@@ -1196,9 +1192,7 @@ class test_MultiChannelPoller:
     def test_on_poll_start(self):
         p = self.Poller()
         p._channels = []
-        assert p.poll_started is False
         p.on_poll_start()
-        assert p.poll_started is True
         p._register_BRPOP = Mock(name='_register_BRPOP')
         p._register_LISTEN = Mock(name='_register_LISTEN')
 


### PR DESCRIPTION
I did some more testing with the change in #1476 and noticed that the event loop will stop polling after a "consumer: Cannot connect to redis" error from `Consumer.ensure_connected._error_handler`. This will cause celery to stop processing work. You need to stop redis for more than a few seconds to make this happen.

It can still re-connect when Redis restarts after the event loop already started, but the error above seems to happen when it's starting the `Consumer` and before `on_poll_start` runs for the first time on the new consumer.

This PR fixes the issue by checking whether event loop polling has started (based on file descriptors) and will only remove `on_poll_start` from the event loop if polling has started.