### PR TITLE
Revert "try pining setuptools (#1466)"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: pip install --upgrade pip 'setuptools<59.7.0' wheel tox tox-docker
+        run: pip install --upgrade pip setuptools wheel tox tox-docker
       - name: Run unittest
         run: tox -v -e ${{ matrix.python-version }}-linux-unit -- -v
   #################### Integration tests ####################
@@ -47,7 +47,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: pip install --upgrade pip 'setuptools<59.7.0' wheel tox tox-docker
+        run: pip install --upgrade pip setuptools wheel tox tox-docker
       # Tox fails if a Python versions contains a hyphen, this changes "pypy-3.8" to "pypy3.8".
       - name: Determine Python version
         run: echo PYTHON_VERSION=$(echo ${{ matrix.python-version }} | sed s/-//) >> $GITHUB_ENV
@@ -74,7 +74,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: pip install --upgrade pip 'setuptools<59.7.0' wheel tox tox-docker
+        run: pip install --upgrade pip setuptools wheel tox tox-docker
       - name: Run flake8
         run: tox -v -e flake8 -- -v
       - name: Run pydocstyle

--- a/requirements/pkgutils.txt
+++ b/requirements/pkgutils.txt
@@ -1,4 +1,4 @@
-setuptools>=20.6.7
+setuptools>=47.0.0
 wheel>=0.29.0
 flake8>=2.5.4
 tox>=2.3.1

--- a/requirements/pkgutils.txt
+++ b/requirements/pkgutils.txt
@@ -1,4 +1,4 @@
-setuptools>=59.1.1,<59.7.0
+setuptools>=20.6.7
 wheel>=0.29.0
 flake8>=2.5.4
 tox>=2.3.1


### PR DESCRIPTION
This reverts commit 6ddf9409401e290e267c9c5041d92fdf5f47170d.

Since #1467 was merged, we no longer need to pin setuptools to `<59.7.0` to avoid this error:
```
Traceback (most recent call last):
File "setup.py", line 60, in
scheme['data'] = scheme['purelib']
KeyError: 'purelib'
```

This also fixes these issues:
* https://github.com/celery/celery/discussions/7202
* https://github.com/celery/celery/pull/7194#issuecomment-1002928015
* https://github.com/celery/celery/commit/d4b97bedc79aed0b45dd3720b683d8d8572da2a9#r63108656