### PR TITLE
All supported versions of Python define __package__.

### DIFF
--- a/kombu/__init__.py
+++ b/kombu/__init__.py
@@ -86,12 +86,6 @@ class module(ModuleType):
         return result
 
 
-# 2.5 does not define __package__
-try:
-    package = __package__
-except NameError:  # pragma: no cover
-    package = 'kombu'
-
 # keep a reference to this module so that it's not garbage collected
 old_module = sys.modules[__name__]
 
@@ -106,7 +100,7 @@ new_module.__dict__.update({
     '__contact__': __contact__,
     '__homepage__': __homepage__,
     '__docformat__': __docformat__,
-    '__package__': package,
+    '__package__': __package__,
     'version_info_t': version_info_t,
     'version_info': version_info,
     'VERSION': VERSION


### PR DESCRIPTION
https://www.python.org/dev/peps/pep-0366/ lists Python 2.6 and 3.0 as
the minimum requirements for this attribute. `sys.__dict__` contains it.

@thedrow @auvipy Can you please double check this?