### PR TITLE
Warn about missing hostname only when default one is available

### DIFF
--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -625,7 +625,7 @@ class Connection:
                 transport_cls, transport_cls)
         D = self.transport.default_connection_params
 
-        if not self.hostname:
+        if not self.hostname and D.get('hostname'):
             logger.warning(
                 "No hostname was supplied. "
                 f"Reverting to default '{D.get('hostname')}'")

--- a/t/unit/test_connection.py
+++ b/t/unit/test_connection.py
@@ -1,3 +1,4 @@
+import logging
 import pickle
 import socket
 from copy import copy, deepcopy
@@ -98,6 +99,20 @@ class test_connection_utils:
     def test_rabbitmq_example_urls(self, url, expected):
         # see Appendix A of http://www.rabbitmq.com/uri-spec.html
         self.assert_info(Connection(url), **expected)
+
+    @pytest.mark.parametrize('url,expected', [
+        ('sqs://user:pass@',
+         {'userid': None, 'password': None, 'hostname': None,
+          'port': None, 'virtual_host': '/'}),
+        ('sqs://',
+         {'userid': None, 'password': None, 'hostname': None,
+          'port': None, 'virtual_host': '/'}),
+    ])
+    def test_sqs_example_urls(self, url, expected, caplog):
+        pytest.importorskip('boto3')
+        with caplog.at_level(logging.WARNING):
+            self.assert_info(Connection('sqs://'), **expected)
+        assert not caplog.records
 
     @pytest.mark.skip('TODO: urllib cannot parse ipv6 urls')
     def test_url_IPV6(self):

--- a/t/unit/test_connection.py
+++ b/t/unit/test_connection.py
@@ -1,4 +1,3 @@
-import logging
 import pickle
 import socket
 from copy import copy, deepcopy
@@ -110,8 +109,7 @@ class test_connection_utils:
     ])
     def test_sqs_example_urls(self, url, expected, caplog):
         pytest.importorskip('boto3')
-        with caplog.at_level(logging.WARNING):
-            self.assert_info(Connection('sqs://'), **expected)
+        self.assert_info(Connection('sqs://'), **expected)
         assert not caplog.records
 
     @pytest.mark.skip('TODO: urllib cannot parse ipv6 urls')


### PR DESCRIPTION
The `No hostname was supplied` warning is affecting projects that use AWS SQS (as detailed in #1357), as a hostname is not required when setting up the broker URL. Instead, the official documentation [0] specifies that the valid broker URL formats are:

* `sqs://`
* `sqs://aws_access_key_id:aws_secret_access_key@`

With these formats, the `kombu.utils.url.parse_url` util doesn't return a hostname, and workers end up triggering the following warning:

> No hostname was supplied. Reverting to default 'None'

As the SQS transport doesn't provide a default value for hostname, this diff changes the behavior to only warn the user when the hostname hasn't been supplied but a default one is being set by the default connection parameters for the defined transport.

Fixes #1357.

[0] https://docs.celeryproject.org/en/stable/getting-started/backends-and-brokers/sqs.html#configuration