### PR TITLE
SQS: Fix message arg in backoff policy

### DIFF
--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -215,8 +215,8 @@ class QoS(virtual.QoS):
                 VisibilityTimeout=policy_value
             )
 
-    @staticmethod
-    def extract_task_name_and_number_of_retries(message):
+    def extract_task_name_and_number_of_retries(self, delivery_tag):
+        message = self._delivered[delivery_tag]
         message_headers = message.headers
         task_name = message_headers['task']
         number_of_retries = int(


### PR DESCRIPTION
Hi!

I just found an error in SQS implementation regarding backoff tasks. There was already notion of this [here](https://github.com/celery/kombu/pull/1372) or [here](https://github.com/celery/kombu/issues/1358). I still experience this problem when backoff policy is defined explicitly. [Prepared small example to reproduce issue](https://gitlab.com/amonowy/celery-sqs-reproduce). Fix is in this PR.

I'm open to comments and happy to improve this PR!
Error is here:
[err.txt](https://github.com/celery/kombu/files/8142965/err.txt)
