### PR TITLE
Documentation: Update serialization page to indicate pickle protocol version has been updated

### DIFF
--- a/docs/userguide/serialization.rst
+++ b/docs/userguide/serialization.rst
@@ -67,7 +67,7 @@ Each option has its advantages and disadvantages.
         to limit access to the broker so that untrusted
         parties do not have the ability to send messages!
 
-    By default Kombu uses pickle protocol 2, but this can be changed
+    By default Kombu uses pickle protocol 4, but this can be changed
     using the :envvar:`PICKLE_PROTOCOL` environment variable or by changing
     the global :data:`kombu.serialization.pickle_protocol` flag.
 


### PR DESCRIPTION
According to the [changelog](https://docs.celeryq.dev/projects/kombu/en/latest/changelog.html#b1) kombu now uses pickle protocol version 4 by default