### PR TITLE
Added possibility to serialize and deserialize binary messages in json

### DIFF
--- a/kombu/utils/json.py
+++ b/kombu/utils/json.py
@@ -79,7 +79,7 @@ def dumps(s, _dumps=json.dumps, cls=None, default_kwargs=None, **kwargs):
 
 
 def object_hook(dct):
-    """Hook function to perform custom deserialization"""
+    """Hook function to perform custom deserialization."""
     if "__bytes__" in dct:
         return dct["bytes"].encode("utf-8")
     if "__base64__" in dct:

--- a/kombu/utils/json.py
+++ b/kombu/utils/json.py
@@ -79,6 +79,7 @@ def dumps(s, _dumps=json.dumps, cls=None, default_kwargs=None, **kwargs):
 
 
 def object_hook(dct):
+    """Hook function to perform custom deserialization"""
     if "__bytes__" in dct:
         return dct["bytes"].encode("utf-8")
     if "__base64__" in dct:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,3 +2,4 @@ pytz>dev
 pytest~=7.0.1
 pytest-sugar
 Pyro4
+hypothesis

--- a/t/unit/utils/test_json.py
+++ b/t/unit/utils/test_json.py
@@ -9,6 +9,7 @@ import pytz
 
 from kombu.utils.encoding import str_to_bytes
 from kombu.utils.json import _DecodeError, dumps, loads
+from hypothesis import given, strategies as st, settings
 
 
 class Custom:
@@ -39,12 +40,14 @@ class test_JSONEncoder:
             'date': stripped.isoformat(),
         }
 
-    def test_binary(self):
+    @given(message=st.binary())
+    @settings(print_blob=True)
+    def test_binary(self, message):
         serialized = loads(dumps({
-            'args': (b'7a108737-0b0a-4acc-a32f-f8a5e6726775',),
+            'args': (message,),
         }))
         assert serialized == {
-            'args': [b'7a108737-0b0a-4acc-a32f-f8a5e6726775'],
+            'args': [message],
         }
 
     def test_Decimal(self):

--- a/t/unit/utils/test_json.py
+++ b/t/unit/utils/test_json.py
@@ -40,8 +40,12 @@ class test_JSONEncoder:
         }
 
     def test_binary(self):
-        serialized = loads(dumps({'args': (b'7a108737-0b0a-4acc-a32f-f8a5e6726775',)}))
-        assert serialized == {'args': [b'7a108737-0b0a-4acc-a32f-f8a5e6726775']}
+        serialized = loads(dumps({
+            'args': (b'7a108737-0b0a-4acc-a32f-f8a5e6726775',),
+        }))
+        assert serialized == {
+            'args': [b'7a108737-0b0a-4acc-a32f-f8a5e6726775'],
+        }
 
     def test_Decimal(self):
         d = Decimal('3314132.13363235235324234123213213214134')

--- a/t/unit/utils/test_json.py
+++ b/t/unit/utils/test_json.py
@@ -39,6 +39,10 @@ class test_JSONEncoder:
             'date': stripped.isoformat(),
         }
 
+    def test_binary(self):
+        serialized = loads(dumps({'args': (b'7a108737-0b0a-4acc-a32f-f8a5e6726775',)}))
+        assert serialized == {'args': [b'7a108737-0b0a-4acc-a32f-f8a5e6726775']}
+
     def test_Decimal(self):
         d = Decimal('3314132.13363235235324234123213213214134')
         assert loads(dumps({'d': d})), {'d': str(d)}


### PR DESCRIPTION
Signature args in callback_msg should be serializable, so
```
callback_msg = str(uuid.uuid4()).encode()
redis_key = str(uuid.uuid4())
callback = redis_echo.si(callback_msg, redis_key=redis_key)
```
,so should be
as they will be passed inside as_task_v2 that would return message that would be passed to a send_task_message, then to publish (kombu) and _prepare (kombu) in messaging that would cll a serialization (kombu).
```
from kombu.serialization import dumps
s = ((42,), {}, {'callbacks': [{'task': 't.integration.tasks.redis_echo', 'args': (b'7a108737-0b0a-4acc-a32f-f8a5e6726775',), 'kwargs': {'redis_key': 'ef3bc79f-a04c-4de1-88c0-f13d9d999ca8'}, 'options': {}, 'subtask_type': None, 'immutable': True}], 'errbacks': None, 'chain': None, 'chord': None})
print(dumps(s))
```
to reproduce serialization issue