### PR TITLE
Use `--py37-plus` for pyupgrade and add `__future__.annotations` import

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v2.32.0
     hooks:
       - id: pyupgrade
-        args: ["--py36-plus"]
+        args: ["--py37-plus"]
 
   - repo: https://github.com/PyCQA/flake8
     rev: 4.0.1

--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sphinx_celery import conf
 
 globals().update(conf.build_config(

--- a/examples/complete_receive.py
+++ b/examples/complete_receive.py
@@ -4,6 +4,8 @@ and exits.
 
 """
 
+from __future__ import annotations
+
 from pprint import pformat
 
 from kombu import Connection, Consumer, Exchange, Queue, eventloop

--- a/examples/complete_send.py
+++ b/examples/complete_send.py
@@ -6,6 +6,8 @@ You can use `complete_receive.py` to receive the message sent.
 
 """
 
+from __future__ import annotations
+
 from kombu import Connection, Exchange, Producer, Queue
 
 #: By default messages sent to exchanges are persistent (delivery_mode=2),

--- a/examples/experimental/async_consume.py
+++ b/examples/experimental/async_consume.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import annotations
+
 from kombu import Connection, Consumer, Exchange, Producer, Queue
 from kombu.asynchronous import Hub
 

--- a/examples/hello_consumer.py
+++ b/examples/hello_consumer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from kombu import Connection
 
 with Connection('amqp://guest:guest@localhost:5672//') as conn:

--- a/examples/hello_publisher.py
+++ b/examples/hello_publisher.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 
 from kombu import Connection

--- a/examples/memory_transport.py
+++ b/examples/memory_transport.py
@@ -1,6 +1,8 @@
 """
 Example that use memory transport for message produce.
 """
+from __future__ import annotations
+
 import time
 
 from kombu import Connection, Consumer, Exchange, Queue

--- a/examples/rpc-tut6/rpc_client.py
+++ b/examples/rpc-tut6/rpc_client.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import annotations
+
 from kombu import Connection, Consumer, Producer, Queue, uuid
 
 

--- a/examples/rpc-tut6/rpc_server.py
+++ b/examples/rpc-tut6/rpc_server.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import annotations
+
 from kombu import Connection, Queue
 from kombu.mixins import ConsumerProducerMixin
 

--- a/examples/simple_eventlet_receive.py
+++ b/examples/simple_eventlet_receive.py
@@ -7,6 +7,8 @@ message sent.
 
 """
 
+from __future__ import annotations
+
 import eventlet
 
 from kombu import Connection

--- a/examples/simple_eventlet_send.py
+++ b/examples/simple_eventlet_send.py
@@ -7,6 +7,8 @@ message sent.
 
 """
 
+from __future__ import annotations
+
 import eventlet
 
 from kombu import Connection

--- a/examples/simple_receive.py
+++ b/examples/simple_receive.py
@@ -3,6 +3,8 @@ Example receiving a message using the SimpleQueue interface.
 
 """
 
+from __future__ import annotations
+
 from kombu import Connection
 
 #: Create connection

--- a/examples/simple_send.py
+++ b/examples/simple_send.py
@@ -7,6 +7,8 @@ message sent.
 
 """
 
+from __future__ import annotations
+
 from kombu import Connection
 
 #: Create connection

--- a/examples/simple_task_queue/client.py
+++ b/examples/simple_task_queue/client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from kombu.pools import producers
 
 from .queues import task_exchange

--- a/examples/simple_task_queue/queues.py
+++ b/examples/simple_task_queue/queues.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from kombu import Exchange, Queue
 
 task_exchange = Exchange('tasks', type='direct')

--- a/examples/simple_task_queue/tasks.py
+++ b/examples/simple_task_queue/tasks.py
@@ -1,2 +1,5 @@
+from __future__ import annotations
+
+
 def hello_task(who='world'):
     print(f'Hello {who}')

--- a/examples/simple_task_queue/worker.py
+++ b/examples/simple_task_queue/worker.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from kombu.log import get_logger
 from kombu.mixins import ConsumerMixin
 from kombu.utils.functional import reprcall

--- a/kombu/__init__.py
+++ b/kombu/__init__.py
@@ -1,10 +1,12 @@
 """Messaging library for Python."""
 
+from __future__ import annotations
+
 import os
 import re
 import sys
 from collections import namedtuple
-from typing import Any, List, cast
+from typing import Any, cast
 
 __version__ = '5.2.4'
 __author__ = 'Ask Solem'
@@ -78,7 +80,7 @@ class module(ModuleType):
             return getattr(module, name)
         return ModuleType.__getattribute__(self, name)
 
-    def __dir__(self) -> List[str]:
+    def __dir__(self) -> list[str]:
         result = list(new_module.__all__)
         result.extend(('__file__', '__path__', '__doc__', '__all__',
                        '__docformat__', '__name__', '__path__', 'VERSION',

--- a/kombu/abstract.py
+++ b/kombu/abstract.py
@@ -1,5 +1,7 @@
 """Object utilities."""
 
+from __future__ import annotations
+
 from copy import copy
 
 from .connection import maybe_channel

--- a/kombu/asynchronous/__init__.py
+++ b/kombu/asynchronous/__init__.py
@@ -1,5 +1,7 @@
 """Event loop."""
 
+from __future__ import annotations
+
 from kombu.utils.eventio import ERR, READ, WRITE
 
 from .hub import Hub, get_event_loop, set_event_loop

--- a/kombu/asynchronous/aws/__init__.py
+++ b/kombu/asynchronous/aws/__init__.py
@@ -1,11 +1,13 @@
-from typing import Any, Optional
+from __future__ import annotations
+
+from typing import Any
 
 from kombu.asynchronous.aws.sqs.connection import AsyncSQSConnection
 
 
 def connect_sqs(
-    aws_access_key_id: Optional[str] = None,
-    aws_secret_access_key: Optional[str] = None,
+    aws_access_key_id: str | None = None,
+    aws_secret_access_key: str | None = None,
     **kwargs: Any
 ) -> AsyncSQSConnection:
     """Return async connection to Amazon SQS."""

--- a/kombu/asynchronous/aws/connection.py
+++ b/kombu/asynchronous/aws/connection.py
@@ -1,5 +1,7 @@
 """Amazon AWS Connection."""
 
+from __future__ import annotations
+
 from email import message_from_bytes
 from email.mime.message import MIMEMessage
 

--- a/kombu/asynchronous/aws/ext.py
+++ b/kombu/asynchronous/aws/ext.py
@@ -1,5 +1,7 @@
 """Amazon boto3 interface."""
 
+from __future__ import annotations
+
 try:
     import boto3
     from botocore import exceptions

--- a/kombu/asynchronous/aws/sqs/connection.py
+++ b/kombu/asynchronous/aws/sqs/connection.py
@@ -1,5 +1,7 @@
 """Amazon SQS Connection."""
 
+from __future__ import annotations
+
 from vine import transform
 
 from kombu.asynchronous.aws.connection import AsyncAWSQueryConnection

--- a/kombu/asynchronous/aws/sqs/ext.py
+++ b/kombu/asynchronous/aws/sqs/ext.py
@@ -1,6 +1,8 @@
 """Amazon SQS boto3 interface."""
 
 
+from __future__ import annotations
+
 try:
     import boto3
 except ImportError:

--- a/kombu/asynchronous/aws/sqs/message.py
+++ b/kombu/asynchronous/aws/sqs/message.py
@@ -1,5 +1,7 @@
 """Amazon SQS message implementation."""
 
+from __future__ import annotations
+
 import base64
 
 from kombu.message import Message

--- a/kombu/asynchronous/aws/sqs/queue.py
+++ b/kombu/asynchronous/aws/sqs/queue.py
@@ -1,5 +1,7 @@
 """Amazon SQS queue implementation."""
 
+from __future__ import annotations
+
 from vine import transform
 
 from .message import AsyncMessage

--- a/kombu/asynchronous/debug.py
+++ b/kombu/asynchronous/debug.py
@@ -1,5 +1,7 @@
 """Event-loop debugging tools."""
 
+from __future__ import annotations
+
 from kombu.utils.eventio import ERR, READ, WRITE
 from kombu.utils.functional import reprcall
 

--- a/kombu/asynchronous/http/__init__.py
+++ b/kombu/asynchronous/http/__init__.py
@@ -1,4 +1,6 @@
-from typing import TYPE_CHECKING, Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from kombu.asynchronous import get_event_loop
 from kombu.asynchronous.http.base import Headers, Request, Response
@@ -10,13 +12,13 @@ if TYPE_CHECKING:
 __all__ = ('Client', 'Headers', 'Response', 'Request')
 
 
-def Client(hub: Optional[Hub] = None, **kwargs: int) -> "CurlClient":
+def Client(hub: Hub | None = None, **kwargs: int) -> CurlClient:
     """Create new HTTP client."""
     from .curl import CurlClient
     return CurlClient(hub, **kwargs)
 
 
-def get_client(hub: Optional[Hub] = None, **kwargs: int) -> "CurlClient":
+def get_client(hub: Hub | None = None, **kwargs: int) -> CurlClient:
     """Get or create HTTP client bound to the current event loop."""
     hub = hub or get_event_loop()
     try:

--- a/kombu/asynchronous/http/base.py
+++ b/kombu/asynchronous/http/base.py
@@ -1,8 +1,10 @@
 """Base async HTTP client implementation."""
 
+from __future__ import annotations
+
 import sys
 from http.client import responses
-from typing import TYPE_CHECKING, Optional, Type
+from typing import TYPE_CHECKING
 
 from vine import Thenable, maybe_promise, promise
 
@@ -259,8 +261,8 @@ class BaseClient:
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
-        exc_val: Optional[BaseException],
-        exc_tb: Optional['TracebackType']
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None
     ) -> None:
         self.close()

--- a/kombu/asynchronous/http/curl.py
+++ b/kombu/asynchronous/http/curl.py
@@ -1,10 +1,11 @@
 """HTTP Client using pyCurl."""
 
+from __future__ import annotations
+
 from collections import deque
 from functools import partial
 from io import BytesIO
 from time import time
-from typing import Optional
 
 from kombu.asynchronous.hub import READ, WRITE, Hub, get_event_loop
 from kombu.exceptions import HttpError
@@ -37,7 +38,7 @@ class CurlClient(BaseClient):
 
     Curl = Curl
 
-    def __init__(self, hub: Optional[Hub] = None, max_clients: int = 10):
+    def __init__(self, hub: Hub | None = None, max_clients: int = 10):
         if pycurl is None:
             raise ImportError('The curl client requires the pycurl library.')
         hub = hub or get_event_loop()

--- a/kombu/asynchronous/hub.py
+++ b/kombu/asynchronous/hub.py
@@ -1,12 +1,13 @@
 """Event loop implementation."""
 
+from __future__ import annotations
+
 import errno
 import threading
 from contextlib import contextmanager
 from queue import Empty
 from time import sleep
 from types import GeneratorType as generator
-from typing import Optional
 
 from vine import Thenable, promise
 
@@ -20,7 +21,7 @@ from .timer import Timer
 __all__ = ('Hub', 'get_event_loop', 'set_event_loop')
 logger = get_logger(__name__)
 
-_current_loop: Optional["Hub"] = None
+_current_loop: Hub | None = None
 
 W_UNKNOWN_EVENT = """\
 Received unknown event %r for fd %r, please contact support!\
@@ -40,12 +41,12 @@ def _dummy_context(*args, **kwargs):
     yield
 
 
-def get_event_loop() -> Optional["Hub"]:
+def get_event_loop() -> Hub | None:
     """Get current event loop object."""
     return _current_loop
 
 
-def set_event_loop(loop: Optional["Hub"]) -> Optional["Hub"]:
+def set_event_loop(loop: Hub | None) -> Hub | None:
     """Set the current event loop object."""
     global _current_loop
     _current_loop = loop

--- a/kombu/asynchronous/semaphore.py
+++ b/kombu/asynchronous/semaphore.py
@@ -1,7 +1,9 @@
 """Semaphores and concurrency primitives."""
+from __future__ import annotations
+
 import sys
 from collections import deque
-from typing import TYPE_CHECKING, Callable, Deque, Optional, Tuple, Type
+from typing import TYPE_CHECKING, Callable, Deque
 
 if sys.version_info < (3, 10):
     from typing_extensions import ParamSpec
@@ -42,7 +44,7 @@ class LaxBoundedSemaphore:
 
     def __init__(self, value: int) -> None:
         self.initial_value = self.value = value
-        self._waiting: Deque[Tuple] = deque()
+        self._waiting: Deque[tuple] = deque()
         self._add_waiter = self._waiting.append
         self._pop_waiter = self._waiting.popleft
 
@@ -111,13 +113,13 @@ class LaxBoundedSemaphore:
 class DummyLock:
     """Pretending to be a lock."""
 
-    def __enter__(self) -> 'DummyLock':
+    def __enter__(self) -> DummyLock:
         return self
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
-        exc_val: Optional[BaseException],
-        exc_tb: Optional['TracebackType']
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None
     ) -> None:
         pass

--- a/kombu/asynchronous/timer.py
+++ b/kombu/asynchronous/timer.py
@@ -1,5 +1,7 @@
 """Timer scheduling Python callbacks."""
 
+from __future__ import annotations
+
 import heapq
 import sys
 from collections import namedtuple
@@ -7,7 +9,7 @@ from datetime import datetime
 from functools import total_ordering
 from time import monotonic
 from time import time as _time
-from typing import TYPE_CHECKING, Optional, Type
+from typing import TYPE_CHECKING
 from weakref import proxy as weakrefproxy
 
 from vine.utils import wraps
@@ -107,9 +109,9 @@ class Timer:
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
-        exc_val: Optional[BaseException],
-        exc_tb: Optional['TracebackType']
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None
     ) -> None:
         self.stop()
 

--- a/kombu/clocks.py
+++ b/kombu/clocks.py
@@ -1,5 +1,7 @@
 """Logical Clocks and Synchronization."""
 
+from __future__ import annotations
+
 from itertools import islice
 from operator import itemgetter
 from threading import Lock

--- a/kombu/common.py
+++ b/kombu/common.py
@@ -1,5 +1,7 @@
 """Common Utilities."""
 
+from __future__ import annotations
+
 import os
 import socket
 import threading

--- a/kombu/compat.py
+++ b/kombu/compat.py
@@ -3,8 +3,10 @@
 See https://pypi.org/project/carrot/ for documentation.
 """
 
+from __future__ import annotations
+
 from itertools import count
-from typing import TYPE_CHECKING, Optional, Type
+from typing import TYPE_CHECKING
 
 from . import messaging
 from .entity import Exchange, Queue
@@ -71,9 +73,9 @@ class Publisher(messaging.Producer):
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
-        exc_val: Optional[BaseException],
-        exc_tb: Optional['TracebackType']
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None
     ) -> None:
         self.close()
 
@@ -138,9 +140,9 @@ class Consumer(messaging.Consumer):
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
-        exc_val: Optional[BaseException],
-        exc_tb: Optional['TracebackType']
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None
     ) -> None:
         self.close()
 

--- a/kombu/compression.py
+++ b/kombu/compression.py
@@ -1,5 +1,7 @@
 """Compression utilities."""
 
+from __future__ import annotations
+
 import zlib
 
 from kombu.utils.encoding import ensure_bytes

--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -1,11 +1,13 @@
 """Client (Connection)."""
 
+from __future__ import annotations
+
 import os
 import socket
 from contextlib import contextmanager
 from itertools import count, cycle
 from operator import itemgetter
-from typing import TYPE_CHECKING, Optional, Type
+from typing import TYPE_CHECKING
 
 try:
     from ssl import CERT_NONE
@@ -835,9 +837,9 @@ class Connection:
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
-        exc_val: Optional[BaseException],
-        exc_tb: Optional['TracebackType']
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None
     ) -> None:
         self.release()
 

--- a/kombu/entity.py
+++ b/kombu/entity.py
@@ -1,5 +1,7 @@
 """Exchange and Queue declarations."""
 
+from __future__ import annotations
+
 import numbers
 
 from .abstract import MaybeChannelBound, Object

--- a/kombu/exceptions.py
+++ b/kombu/exceptions.py
@@ -1,5 +1,7 @@
 """Exceptions."""
 
+from __future__ import annotations
+
 from socket import timeout as TimeoutError
 
 from amqp import ChannelError, ConnectionError, ResourceError

--- a/kombu/log.py
+++ b/kombu/log.py
@@ -1,5 +1,7 @@
 """Logging Utilities."""
 
+from __future__ import annotations
+
 import logging
 import numbers
 import os

--- a/kombu/matcher.py
+++ b/kombu/matcher.py
@@ -1,5 +1,7 @@
 """Pattern matching registry."""
 
+from __future__ import annotations
+
 from fnmatch import fnmatch
 from re import match as rematch
 

--- a/kombu/message.py
+++ b/kombu/message.py
@@ -1,5 +1,7 @@
 """Message class."""
 
+from __future__ import annotations
+
 import sys
 
 from .compression import decompress

--- a/kombu/messaging.py
+++ b/kombu/messaging.py
@@ -1,7 +1,9 @@
 """Sending and receiving messages."""
 
+from __future__ import annotations
+
 from itertools import count
-from typing import TYPE_CHECKING, Optional, Type
+from typing import TYPE_CHECKING
 
 from .common import maybe_declare
 from .compression import compress
@@ -242,9 +244,9 @@ class Producer:
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
-        exc_val: Optional[BaseException],
-        exc_tb: Optional['TracebackType']
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None
     ) -> None:
         self.release()
 
@@ -446,9 +448,9 @@ class Consumer:
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
-        exc_val: Optional[BaseException],
-        exc_tb: Optional['TracebackType']
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None
     ) -> None:
         if self.channel and self.channel.connection:
             conn_errors = self.channel.connection.client.connection_errors

--- a/kombu/mixins.py
+++ b/kombu/mixins.py
@@ -1,5 +1,7 @@
 """Mixins."""
 
+from __future__ import annotations
+
 import socket
 from contextlib import contextmanager
 from functools import partial

--- a/kombu/pidbox.py
+++ b/kombu/pidbox.py
@@ -1,5 +1,7 @@
 """Generic process mailbox."""
 
+from __future__ import annotations
+
 import socket
 import warnings
 from collections import defaultdict, deque

--- a/kombu/pools.py
+++ b/kombu/pools.py
@@ -1,5 +1,7 @@
 """Public resource pools."""
 
+from __future__ import annotations
+
 import os
 from itertools import chain
 

--- a/kombu/resource.py
+++ b/kombu/resource.py
@@ -1,5 +1,7 @@
 """Generic resource pool implementation."""
 
+from __future__ import annotations
+
 import os
 from collections import deque
 from queue import Empty
@@ -199,7 +201,7 @@ class Resource:
                 self,
                 exc_type: type,
                 exc_val: Exception,
-                exc_tb: 'TracebackType'
+                exc_tb: TracebackType
             ) -> None:
                 pass
 

--- a/kombu/serialization.py
+++ b/kombu/serialization.py
@@ -1,5 +1,7 @@
 """Serialization utilities."""
 
+from __future__ import annotations
+
 import codecs
 import os
 import pickle

--- a/kombu/simple.py
+++ b/kombu/simple.py
@@ -1,10 +1,12 @@
 """Simple messaging interface."""
 
+from __future__ import annotations
+
 import socket
 from collections import deque
 from queue import Empty
 from time import monotonic
-from typing import TYPE_CHECKING, Optional, Type
+from typing import TYPE_CHECKING
 
 from . import entity, messaging
 from .connection import maybe_channel
@@ -24,9 +26,9 @@ class SimpleBase:
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
-        exc_val: Optional[BaseException],
-        exc_tb: Optional['TracebackType']
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None
     ) -> None:
         self.close()
 

--- a/kombu/transport/SLMQ.py
+++ b/kombu/transport/SLMQ.py
@@ -18,6 +18,8 @@ Transport Options
  *Unreviewed*
 """
 
+from __future__ import annotations
+
 import os
 import socket
 import string

--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -122,6 +122,8 @@ Features
 """  # noqa: E501
 
 
+from __future__ import annotations
+
 import base64
 import socket
 import string

--- a/kombu/transport/__init__.py
+++ b/kombu/transport/__init__.py
@@ -1,12 +1,12 @@
 """Built-in transports."""
 
-from typing import Optional
+from __future__ import annotations
 
 from kombu.utils.compat import _detect_environment
 from kombu.utils.imports import symbol_by_name
 
 
-def supports_librabbitmq() -> Optional[bool]:
+def supports_librabbitmq() -> bool | None:
     """Return true if :pypi:`librabbitmq` can be used."""
     if _detect_environment() == 'default':
         try:
@@ -47,7 +47,7 @@ TRANSPORT_ALIASES = {
 _transport_cache = {}
 
 
-def resolve_transport(transport: Optional[str] = None) -> Optional[str]:
+def resolve_transport(transport: str | None = None) -> str | None:
     """Get transport by name.
 
     Arguments:
@@ -74,7 +74,7 @@ def resolve_transport(transport: Optional[str] = None) -> Optional[str]:
     return transport
 
 
-def get_transport_cls(transport: Optional[str] = None) -> Optional[str]:
+def get_transport_cls(transport: str | None = None) -> str | None:
     """Get transport class by name.
 
     The transport string is the full path to a transport class, e.g.::

--- a/kombu/transport/azureservicebus.py
+++ b/kombu/transport/azureservicebus.py
@@ -53,9 +53,11 @@ Transport Options
 * ``retry_backoff_max`` - Azure SDK retry total time. Default ``120``
 """
 
+from __future__ import annotations
+
 import string
 from queue import Empty
-from typing import Any, Dict, Optional, Set, Tuple, Union
+from typing import Any, Dict, Set
 
 import azure.core.exceptions
 import azure.servicebus.exceptions
@@ -83,8 +85,8 @@ class SendReceive:
     """Container for Sender and Receiver."""
 
     def __init__(self,
-                 receiver: Optional[ServiceBusReceiver] = None,
-                 sender: Optional[ServiceBusSender] = None):
+                 receiver: ServiceBusReceiver | None = None,
+                 sender: ServiceBusSender | None = None):
         self.receiver = receiver  # type: ServiceBusReceiver
         self.sender = sender  # type: ServiceBusSender
 
@@ -160,8 +162,8 @@ class Channel(virtual.Channel):
 
     def _add_queue_to_cache(
             self, name: str,
-            receiver: Optional[ServiceBusReceiver] = None,
-            sender: Optional[ServiceBusSender] = None
+            receiver: ServiceBusReceiver | None = None,
+            sender: ServiceBusSender | None = None
     ) -> SendReceive:
         if name in self._queue_cache:
             obj = self._queue_cache[name]
@@ -183,7 +185,7 @@ class Channel(virtual.Channel):
     def _get_asb_receiver(
             self, queue: str,
             recv_mode: ServiceBusReceiveMode = ServiceBusReceiveMode.PEEK_LOCK,
-            queue_cache_key: Optional[str] = None) -> SendReceive:
+            queue_cache_key: str | None = None) -> SendReceive:
         cache_key = queue_cache_key or queue
         queue_obj = self._queue_cache.get(cache_key, None)
         if queue_obj is None or queue_obj.receiver is None:
@@ -194,7 +196,7 @@ class Channel(virtual.Channel):
         return queue_obj
 
     def entity_name(
-            self, name: str, table: Optional[Dict[int, int]] = None) -> str:
+            self, name: str, table: dict[int, int] | None = None) -> str:
         """Format AMQP queue name into a valid ServiceBus queue name."""
         return str(safe_str(name)).translate(table or CHARS_REPLACE_TABLE)
 
@@ -242,8 +244,8 @@ class Channel(virtual.Channel):
 
     def _get(
             self, queue: str,
-            timeout: Optional[Union[float, int]] = None
-    ) -> Dict[str, Any]:
+            timeout: float | int | None = None
+    ) -> dict[str, Any]:
         """Try to retrieve a single message off ``queue``."""
         # If we're not ack'ing for this queue, just change receive_mode
         recv_mode = ServiceBusReceiveMode.RECEIVE_AND_DELETE \
@@ -412,7 +414,7 @@ class Transport(virtual.Transport):
     can_parse_url = True
 
     @staticmethod
-    def parse_uri(uri: str) -> Tuple[str, str, str]:
+    def parse_uri(uri: str) -> tuple[str, str, str]:
         # URL like:
         #  azureservicebus://{SAS policy name}:{SAS key}@{ServiceBus Namespace}
         # urllib parse does not work as the sas key could contain a slash

--- a/kombu/transport/azurestoragequeues.py
+++ b/kombu/transport/azurestoragequeues.py
@@ -30,6 +30,8 @@ Transport Options
 * ``queue_name_prefix``
 """
 
+from __future__ import annotations
+
 import string
 from queue import Empty
 

--- a/kombu/transport/base.py
+++ b/kombu/transport/base.py
@@ -2,9 +2,11 @@
 # flake8: noqa
 
 
+from __future__ import annotations
+
 import errno
 import socket
-from typing import TYPE_CHECKING, Optional, Type
+from typing import TYPE_CHECKING
 
 from amqp.exceptions import RecoverableConnectionError
 
@@ -106,9 +108,9 @@ class StdChannel:
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
-        exc_val: Optional[BaseException],
-        exc_tb: Optional['TracebackType']
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None
     ) -> None:
         self.close()
 

--- a/kombu/transport/consul.py
+++ b/kombu/transport/consul.py
@@ -27,6 +27,8 @@ Connection string has the following format:
 
 """
 
+from __future__ import annotations
+
 import socket
 import uuid
 from collections import defaultdict

--- a/kombu/transport/etcd.py
+++ b/kombu/transport/etcd.py
@@ -24,6 +24,8 @@ Connection string has the following format:
 
 """
 
+from __future__ import annotations
+
 import os
 import socket
 from collections import defaultdict

--- a/kombu/transport/filesystem.py
+++ b/kombu/transport/filesystem.py
@@ -89,6 +89,8 @@ Transport Options
 * ``control_folder`` - directory where are exchange-queue table stored.
 """
 
+from __future__ import annotations
+
 import os
 import shutil
 import tempfile

--- a/kombu/transport/librabbitmq.py
+++ b/kombu/transport/librabbitmq.py
@@ -3,6 +3,8 @@
 .. _`librabbitmq`: https://pypi.org/project/librabbitmq/
 """
 
+from __future__ import annotations
+
 import os
 import socket
 import warnings

--- a/kombu/transport/memory.py
+++ b/kombu/transport/memory.py
@@ -22,6 +22,8 @@ Connection string is in the following format:
 
 """
 
+from __future__ import annotations
+
 from collections import defaultdict
 from queue import Queue
 

--- a/kombu/transport/mongodb.py
+++ b/kombu/transport/mongodb.py
@@ -33,6 +33,8 @@ Transport Options
 * ``calc_queue_size``,
 """
 
+from __future__ import annotations
+
 import datetime
 from queue import Empty
 

--- a/kombu/transport/pyamqp.py
+++ b/kombu/transport/pyamqp.py
@@ -68,6 +68,8 @@ hostname from broker URL. This is usefull when failover is used to fill
 """
 
 
+from __future__ import annotations
+
 import amqp
 
 from kombu.utils.amq_manager import get_manager

--- a/kombu/transport/pyro.py
+++ b/kombu/transport/pyro.py
@@ -32,6 +32,8 @@ Transport Options
 """
 
 
+from __future__ import annotations
+
 import sys
 from queue import Empty, Queue
 

--- a/kombu/transport/qpid.py
+++ b/kombu/transport/qpid.py
@@ -86,6 +86,8 @@ Celery, this can be accomplished by setting the
 *BROKER_TRANSPORT_OPTIONS* Celery option.
 """
 
+from __future__ import annotations
+
 import os
 import select
 import socket

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -51,6 +51,8 @@ Transport Options
 * ``priority_steps``
 """
 
+from __future__ import annotations
+
 import functools
 import numbers
 import socket

--- a/kombu/transport/sqlalchemy/__init__.py
+++ b/kombu/transport/sqlalchemy/__init__.py
@@ -50,9 +50,7 @@ Transport Options
 
 Moreover parameters of :func:`sqlalchemy.create_engine()` function can be passed as transport options.
 """
-# SQLAlchemy overrides != False to have special meaning and pep8 complains
-# flake8: noqa
-
+from __future__ import annotations
 
 import threading
 from json import dumps, loads
@@ -70,6 +68,13 @@ from .models import Message as MessageBase
 from .models import ModelBase
 from .models import Queue as QueueBase
 from .models import class_registry, metadata
+
+# SQLAlchemy overrides != False to have special meaning and pep8 complains
+# flake8: noqa
+
+
+
+
 
 VERSION = (1, 4, 1)
 __version__ = '.'.join(map(str, VERSION))

--- a/kombu/transport/sqlalchemy/models.py
+++ b/kombu/transport/sqlalchemy/models.py
@@ -1,5 +1,7 @@
 """Kombu transport using SQLAlchemy as the message store."""
 
+from __future__ import annotations
+
 import datetime
 
 from sqlalchemy import (Boolean, Column, DateTime, ForeignKey, Index, Integer,

--- a/kombu/transport/virtual/__init__.py
+++ b/kombu/transport/virtual/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .base import (AbstractChannel, Base64, BrokerState, Channel, Empty,
                    Management, Message, NotEquivalentError, QoS, Transport,
                    UndeliverableWarning, binding_key_t, queue_binding_t)

--- a/kombu/transport/virtual/base.py
+++ b/kombu/transport/virtual/base.py
@@ -3,6 +3,8 @@
 Emulates the AMQ API for non-AMQ transports.
 """
 
+from __future__ import annotations
+
 import base64
 import socket
 import sys
@@ -13,7 +15,7 @@ from itertools import count
 from multiprocessing.util import Finalize
 from queue import Empty
 from time import monotonic, sleep
-from typing import TYPE_CHECKING, Optional, Type
+from typing import TYPE_CHECKING
 
 from amqp.protocol import queue_declare_ok_t
 
@@ -806,9 +808,9 @@ class Channel(AbstractChannel, base.StdChannel):
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
-        exc_val: Optional[BaseException],
-        exc_tb: Optional['TracebackType']
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None
     ) -> None:
         self.close()
 

--- a/kombu/transport/virtual/exchange.py
+++ b/kombu/transport/virtual/exchange.py
@@ -4,6 +4,8 @@ Implementations of the standard exchanges defined
 by the AMQ protocol  (excluding the `headers` exchange).
 """
 
+from __future__ import annotations
+
 import re
 
 from kombu.utils.text import escape_regex

--- a/kombu/transport/zookeeper.py
+++ b/kombu/transport/zookeeper.py
@@ -42,6 +42,8 @@ Transport Options
 
 """
 
+from __future__ import annotations
+
 import os
 import socket
 from queue import Empty

--- a/kombu/utils/__init__.py
+++ b/kombu/utils/__init__.py
@@ -1,5 +1,7 @@
 """DEPRECATED - Import from modules below."""
 
+from __future__ import annotations
+
 from .collections import EqualityDict
 from .compat import fileno, maybe_fileno, nested, register_after_fork
 from .div import emergency_dump_state

--- a/kombu/utils/amq_manager.py
+++ b/kombu/utils/amq_manager.py
@@ -1,6 +1,9 @@
 """AMQP Management API utilities."""
 
 
+from __future__ import annotations
+
+
 def get_manager(client, hostname=None, port=None, userid=None,
                 password=None):
     """Get pyrabbit manager."""

--- a/kombu/utils/collections.py
+++ b/kombu/utils/collections.py
@@ -1,6 +1,9 @@
 """Custom maps, sequences, etc."""
 
 
+from __future__ import annotations
+
+
 class HashedSeq(list):
     """Hashed Sequence.
 

--- a/kombu/utils/compat.py
+++ b/kombu/utils/compat.py
@@ -1,5 +1,7 @@
 """Python Compatibility Utilities."""
 
+from __future__ import annotations
+
 import numbers
 import sys
 from contextlib import contextmanager

--- a/kombu/utils/debug.py
+++ b/kombu/utils/debug.py
@@ -1,5 +1,7 @@
 """Debugging support."""
 
+from __future__ import annotations
+
 import logging
 
 from vine.utils import wraps

--- a/kombu/utils/div.py
+++ b/kombu/utils/div.py
@@ -1,5 +1,7 @@
 """Div. Utilities."""
 
+from __future__ import annotations
+
 import sys
 
 from .encoding import default_encode

--- a/kombu/utils/encoding.py
+++ b/kombu/utils/encoding.py
@@ -5,6 +5,8 @@ applications without crashing from the infamous
 :exc:`UnicodeDecodeError` exception.
 """
 
+from __future__ import annotations
+
 import sys
 import traceback
 

--- a/kombu/utils/eventio.py
+++ b/kombu/utils/eventio.py
@@ -1,5 +1,7 @@
 """Selector Utilities."""
 
+from __future__ import annotations
+
 import errno
 import math
 import select as __select__

--- a/kombu/utils/functional.py
+++ b/kombu/utils/functional.py
@@ -1,5 +1,7 @@
 """Functional Utilities."""
 
+from __future__ import annotations
+
 import inspect
 import random
 import threading

--- a/kombu/utils/imports.py
+++ b/kombu/utils/imports.py
@@ -1,5 +1,7 @@
 """Import related utilities."""
 
+from __future__ import annotations
+
 import importlib
 import sys
 

--- a/kombu/utils/json.py
+++ b/kombu/utils/json.py
@@ -1,5 +1,7 @@
 """JSON Serialization Utilities."""
 
+from __future__ import annotations
+
 import base64
 import datetime
 import decimal

--- a/kombu/utils/limits.py
+++ b/kombu/utils/limits.py
@@ -1,5 +1,7 @@
 """Token bucket implementation for rate limiting."""
 
+from __future__ import annotations
+
 from collections import deque
 from time import monotonic
 

--- a/kombu/utils/objects.py
+++ b/kombu/utils/objects.py
@@ -1,5 +1,7 @@
 """Object Utilities."""
 
+from __future__ import annotations
+
 __all__ = ('cached_property',)
 
 try:

--- a/kombu/utils/scheduling.py
+++ b/kombu/utils/scheduling.py
@@ -1,5 +1,7 @@
 """Scheduling Utilities."""
 
+from __future__ import annotations
+
 from itertools import count
 
 from .imports import symbol_by_name

--- a/kombu/utils/text.py
+++ b/kombu/utils/text.py
@@ -2,6 +2,8 @@
 # flake8: noqa
 
 
+from __future__ import annotations
+
 from difflib import SequenceMatcher
 from typing import Iterable, Iterator, Optional, Tuple, Union
 
@@ -17,7 +19,7 @@ def escape_regex(p, white=''):
                    for c in p)
 
 
-def fmatch_iter(needle: str, haystack: Iterable[str], min_ratio: float = 0.6) -> Iterator[Tuple[float, str]]:
+def fmatch_iter(needle: str, haystack: Iterable[str], min_ratio: float = 0.6) -> Iterator[tuple[float, str]]:
     """Fuzzy match: iteratively.
 
     Yields:
@@ -29,7 +31,7 @@ def fmatch_iter(needle: str, haystack: Iterable[str], min_ratio: float = 0.6) ->
             yield ratio, key
 
 
-def fmatch_best(needle: str, haystack: Iterable[str], min_ratio: float = 0.6) -> Optional[str]:
+def fmatch_best(needle: str, haystack: Iterable[str], min_ratio: float = 0.6) -> str | None:
     """Fuzzy match - Find best match (scalar)."""
     try:
         return sorted(
@@ -53,15 +55,15 @@ def version_string_as_tuple(s: str) -> version_info_t:
 
 def _unpack_version(
     major: str,
-    minor: Union[str, int] = 0,
-    micro: Union[str, int] = 0,
+    minor: str | int = 0,
+    micro: str | int = 0,
     releaselevel: str = '',
     serial: str = ''
 ) -> version_info_t:
     return version_info_t(int(major), int(minor), micro, releaselevel, serial)
 
 
-def _splitmicro(micro: str, releaselevel: str = '', serial: str = '') -> Tuple[int, str, str]:
+def _splitmicro(micro: str, releaselevel: str = '', serial: str = '') -> tuple[int, str, str]:
     for index, char in enumerate(micro):
         if not char.isdigit():
             break

--- a/kombu/utils/time.py
+++ b/kombu/utils/time.py
@@ -1,9 +1,9 @@
 """Time Utilities."""
-from typing import Optional, Union
+from __future__ import annotations
 
 __all__ = ('maybe_s_to_ms',)
 
 
-def maybe_s_to_ms(v: Optional[Union[int, float]]) -> Optional[int]:
+def maybe_s_to_ms(v: int | float | None) -> int | None:
     """Convert seconds to milliseconds, but return None for None."""
     return int(float(v) * 1000.0) if v is not None else v

--- a/kombu/utils/url.py
+++ b/kombu/utils/url.py
@@ -2,6 +2,8 @@
 # flake8: noqa
 
 
+from __future__ import annotations
+
 from collections.abc import Mapping
 from functools import partial
 from typing import NamedTuple

--- a/kombu/utils/uuid.py
+++ b/kombu/utils/uuid.py
@@ -1,4 +1,6 @@
 """UUID utilities."""
+from __future__ import annotations
+
 from typing import Callable
 from uuid import UUID, uuid4
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,10 @@ all_files = 1
 # whenever it makes the code more readable.
 extend-ignore = W504, N806, N802, N801, N803
 
+[isort]
+add_imports =
+    from __future__ import annotations
+
 [mypy]
 warn_unused_configs = True
 strict = False

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import os
 import re
 import sys

--- a/t/integration/__init__.py
+++ b/t/integration/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import sys
 

--- a/t/integration/common.py
+++ b/t/integration/common.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import socket
 from contextlib import closing
 from time import sleep

--- a/t/integration/test_py_amqp.py
+++ b/t/integration/test_py_amqp.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 import pytest

--- a/t/integration/test_redis.py
+++ b/t/integration/test_redis.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from time import sleep
 

--- a/t/mocks.py
+++ b/t/mocks.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from itertools import count
-from typing import TYPE_CHECKING, Optional, Type
+from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
 from kombu.transport import base
@@ -19,9 +21,9 @@ class _ContextMock(Mock):
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
-        exc_val: Optional[BaseException],
-        exc_tb: Optional['TracebackType']
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None
     ) -> None:
         pass
 

--- a/t/skip.py
+++ b/t/skip.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 import pytest

--- a/t/unit/asynchronous/aws/case.py
+++ b/t/unit/asynchronous/aws/case.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 import t.skip

--- a/t/unit/asynchronous/aws/sqs/test_connection.py
+++ b/t/unit/asynchronous/aws/sqs/test_connection.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest.mock import MagicMock, Mock
 
 from kombu.asynchronous.aws.ext import boto3

--- a/t/unit/asynchronous/aws/sqs/test_queue.py
+++ b/t/unit/asynchronous/aws/sqs/test_queue.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest.mock import Mock
 
 import pytest

--- a/t/unit/asynchronous/aws/test_aws.py
+++ b/t/unit/asynchronous/aws/test_aws.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest.mock import Mock
 
 from kombu.asynchronous.aws import connect_sqs

--- a/t/unit/asynchronous/aws/test_connection.py
+++ b/t/unit/asynchronous/aws/test_connection.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from contextlib import contextmanager
 from io import StringIO
 from unittest.mock import Mock

--- a/t/unit/asynchronous/http/test_curl.py
+++ b/t/unit/asynchronous/http/test_curl.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from io import BytesIO
 from unittest.mock import ANY, Mock, call, patch
 

--- a/t/unit/asynchronous/http/test_http.py
+++ b/t/unit/asynchronous/http/test_http.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from io import BytesIO
 from unittest.mock import Mock
 

--- a/t/unit/asynchronous/test_hub.py
+++ b/t/unit/asynchronous/test_hub.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import errno
 from unittest.mock import Mock, call, patch
 

--- a/t/unit/asynchronous/test_semaphore.py
+++ b/t/unit/asynchronous/test_semaphore.py
@@ -1,4 +1,4 @@
-from typing import List
+from __future__ import annotations
 
 from kombu.asynchronous.semaphore import LaxBoundedSemaphore
 
@@ -7,7 +7,7 @@ class test_LaxBoundedSemaphore:
 
     def test_over_release(self) -> None:
         x = LaxBoundedSemaphore(2)
-        calls: List[int] = []
+        calls: list[int] = []
         for i in range(1, 21):
             x.acquire(calls.append, i)
         x.release()

--- a/t/unit/asynchronous/test_timer.py
+++ b/t/unit/asynchronous/test_timer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime
 from unittest.mock import Mock, patch
 

--- a/t/unit/conftest.py
+++ b/t/unit/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import atexit
 import builtins
 import io

--- a/t/unit/test_clocks.py
+++ b/t/unit/test_clocks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pickle
 from heapq import heappush
 from time import time

--- a/t/unit/test_common.py
+++ b/t/unit/test_common.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import socket
-from typing import TYPE_CHECKING, Optional, Type
+from typing import TYPE_CHECKING
 from unittest.mock import Mock, patch
 
 import pytest
@@ -344,9 +346,9 @@ class MockConsumer:
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
-        exc_val: Optional[BaseException],
-        exc_tb: Optional['TracebackType']
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None
     ) -> None:
         self.consumers.discard(self)
 

--- a/t/unit/test_compat.py
+++ b/t/unit/test_compat.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest.mock import Mock, patch
 
 import pytest

--- a/t/unit/test_compression.py
+++ b/t/unit/test_compression.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 import pytest

--- a/t/unit/test_connection.py
+++ b/t/unit/test_connection.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pickle
 import socket
 from copy import copy, deepcopy

--- a/t/unit/test_entity.py
+++ b/t/unit/test_entity.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pickle
 from unittest.mock import Mock, call
 

--- a/t/unit/test_exceptions.py
+++ b/t/unit/test_exceptions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest.mock import Mock
 
 from kombu.exceptions import HttpError

--- a/t/unit/test_log.py
+++ b/t/unit/test_log.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import sys
 from unittest.mock import ANY, Mock, patch

--- a/t/unit/test_matcher.py
+++ b/t/unit/test_matcher.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from kombu.matcher import (MatcherNotInstalled, fnmatch, match, register,

--- a/t/unit/test_message.py
+++ b/t/unit/test_message.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from unittest.mock import Mock, patch
 

--- a/t/unit/test_messaging.py
+++ b/t/unit/test_messaging.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pickle
 import sys
 from collections import defaultdict

--- a/t/unit/test_mixins.py
+++ b/t/unit/test_mixins.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import socket
 from unittest.mock import Mock, patch
 

--- a/t/unit/test_pidbox.py
+++ b/t/unit/test_pidbox.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import socket
 import warnings
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor

--- a/t/unit/test_pools.py
+++ b/t/unit/test_pools.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest.mock import Mock
 
 import pytest

--- a/t/unit/test_serialization.py
+++ b/t/unit/test_serialization.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 
+from __future__ import annotations
+
 from base64 import b64decode
 from unittest.mock import call, patch
 

--- a/t/unit/test_simple.py
+++ b/t/unit/test_simple.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest.mock import Mock
 
 import pytest

--- a/t/unit/transport/test_SQS.py
+++ b/t/unit/transport/test_SQS.py
@@ -4,6 +4,8 @@ NOTE: The SQSQueueMock and SQSConnectionMock classes originally come from
 http://github.com/pcsforeducation/sqs-mock-python. They have been patched
 slightly.
 """
+from __future__ import annotations
+
 import base64
 import os
 import random

--- a/t/unit/transport/test_azureservicebus.py
+++ b/t/unit/transport/test_azureservicebus.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import base64
 import json
 import random

--- a/t/unit/transport/test_base.py
+++ b/t/unit/transport/test_base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest.mock import Mock
 
 import pytest

--- a/t/unit/transport/test_consul.py
+++ b/t/unit/transport/test_consul.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from array import array
 from queue import Empty
 from unittest.mock import Mock

--- a/t/unit/transport/test_etcd.py
+++ b/t/unit/transport/test_etcd.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from queue import Empty
 from unittest.mock import Mock, patch
 

--- a/t/unit/transport/test_filesystem.py
+++ b/t/unit/transport/test_filesystem.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import tempfile
 from queue import Empty
 

--- a/t/unit/transport/test_librabbitmq.py
+++ b/t/unit/transport/test_librabbitmq.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest.mock import Mock, patch
 
 import pytest

--- a/t/unit/transport/test_memory.py
+++ b/t/unit/transport/test_memory.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import socket
 
 import pytest

--- a/t/unit/transport/test_mongodb.py
+++ b/t/unit/transport/test_mongodb.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 from queue import Empty
 from unittest.mock import MagicMock, call, patch

--- a/t/unit/transport/test_pyamqp.py
+++ b/t/unit/transport/test_pyamqp.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from itertools import count
 from unittest.mock import MagicMock, Mock, patch

--- a/t/unit/transport/test_pyro.py
+++ b/t/unit/transport/test_pyro.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import socket
 
 import pytest

--- a/t/unit/transport/test_qpid.py
+++ b/t/unit/transport/test_qpid.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import select
 import socket
 import ssl

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import base64
 import copy
 import socket
@@ -6,7 +8,7 @@ from collections import defaultdict
 from itertools import count
 from queue import Empty
 from queue import Queue as _Queue
-from typing import TYPE_CHECKING, Optional, Type
+from typing import TYPE_CHECKING
 from unittest.mock import ANY, Mock, call, patch
 
 import pytest
@@ -237,9 +239,9 @@ class Pipeline:
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
-        exc_val: Optional[BaseException],
-        exc_tb: Optional['TracebackType']
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None
     ) -> None:
         pass
 

--- a/t/unit/transport/test_sqlalchemy.py
+++ b/t/unit/transport/test_sqlalchemy.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest.mock import patch
 
 import pytest

--- a/t/unit/transport/test_transport.py
+++ b/t/unit/transport/test_transport.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest.mock import Mock, patch
 
 from kombu import transport

--- a/t/unit/transport/test_zookeeper.py
+++ b/t/unit/transport/test_zookeeper.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from kombu import Connection

--- a/t/unit/transport/virtual/test_base.py
+++ b/t/unit/transport/virtual/test_base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import io
 import socket
 import warnings

--- a/t/unit/transport/virtual/test_exchange.py
+++ b/t/unit/transport/virtual/test_exchange.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest.mock import Mock
 
 import pytest

--- a/t/unit/utils/test_amq_manager.py
+++ b/t/unit/utils/test_amq_manager.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest.mock import patch
 
 import pytest

--- a/t/unit/utils/test_compat.py
+++ b/t/unit/utils/test_compat.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import socket
 import sys
 import types

--- a/t/unit/utils/test_debug.py
+++ b/t/unit/utils/test_debug.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from unittest.mock import Mock, patch
 

--- a/t/unit/utils/test_div.py
+++ b/t/unit/utils/test_div.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pickle
 from io import BytesIO, StringIO
 

--- a/t/unit/utils/test_encoding.py
+++ b/t/unit/utils/test_encoding.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from contextlib import contextmanager
 from unittest.mock import patch

--- a/t/unit/utils/test_functional.py
+++ b/t/unit/utils/test_functional.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pickle
 from itertools import count
 from unittest.mock import Mock

--- a/t/unit/utils/test_imports.py
+++ b/t/unit/utils/test_imports.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest.mock import Mock
 
 import pytest

--- a/t/unit/utils/test_json.py
+++ b/t/unit/utils/test_json.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import namedtuple
 from datetime import datetime
 from decimal import Decimal

--- a/t/unit/utils/test_objects.py
+++ b/t/unit/utils/test_objects.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from kombu.utils.objects import cached_property
 
 

--- a/t/unit/utils/test_scheduling.py
+++ b/t/unit/utils/test_scheduling.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest.mock import Mock
 
 import pytest

--- a/t/unit/utils/test_time.py
+++ b/t/unit/utils/test_time.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from kombu.utils.time import maybe_s_to_ms

--- a/t/unit/utils/test_url.py
+++ b/t/unit/utils/test_url.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 try:
     from urllib.parse import urlencode
 except ImportError:

--- a/t/unit/utils/test_utils.py
+++ b/t/unit/utils/test_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from kombu import version_info_t

--- a/t/unit/utils/test_uuid.py
+++ b/t/unit/utils/test_uuid.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from kombu.utils.uuid import uuid
 
 


### PR DESCRIPTION
This PR adds:
- `--py37-plus` for `pyupgrade`.
- `add_imports` on `isort` to add `from __future__ import annotations` on all files.

More info on:
- Memory impact section: https://lukasz.langa.pl/61df599c-d9d8-4938-868b-36b67fdb4448/