### PR TITLE
json.py cleaning from outdated libs

### DIFF
--- a/docs/reference/kombu.serialization.rst
+++ b/docs/reference/kombu.serialization.rst
@@ -44,8 +44,6 @@
 
     .. autodata:: registry
 
-.. _`cjson`: https://pypi.org/project/python-cjson/
-.. _`simplejson`: https://github.com/simplejson/simplejson
 .. _`Python 2.7+`: https://docs.python.org/library/json.html
 .. _`PyYAML`: https://pyyaml.org/
 .. _`msgpack`: https://msgpack.org/

--- a/docs/userguide/serialization.rst
+++ b/docs/userguide/serialization.rst
@@ -32,10 +32,9 @@ The accept argument can also include MIME-types.
 
 Each option has its advantages and disadvantages.
 
-`json` -- JSON is supported in many programming languages, is now
-    a standard part of Python (since 2.6), and is fairly fast to
-    decode using the modern Python libraries such as `cjson` or
-    `simplejson`.
+`json` -- JSON is supported in many programming languages, is
+    a standard part of Python, and is fairly fast to
+    decode.
 
     The primary disadvantage to `JSON` is that it limits you to
     the following data types: strings, Unicode, floats, boolean,

--- a/kombu/utils/json.py
+++ b/kombu/utils/json.py
@@ -13,9 +13,6 @@ except ImportError:  # pragma: no cover
         """Dummy object."""
 
 
-_json_extra_kwargs = {}
-
-
 class _DecodeError(Exception):
     pass
 
@@ -65,8 +62,7 @@ _default_encoder = JSONEncoder
 
 def dumps(s, _dumps=json.dumps, cls=None, default_kwargs=None, **kwargs):
     """Serialize object to json string."""
-    if not default_kwargs:
-        default_kwargs = _json_extra_kwargs
+    default_kwargs = default_kwargs or {}
     return _dumps(s, cls=cls or _default_encoder,
                   **dict(default_kwargs, **kwargs))
 

--- a/kombu/utils/json.py
+++ b/kombu/utils/json.py
@@ -3,8 +3,8 @@
 import base64
 import datetime
 import decimal
-import json as stdjson
 import uuid
+import json
 
 try:
     from django.utils.functional import Promise as DjangoPromise
@@ -12,19 +12,12 @@ except ImportError:  # pragma: no cover
     class DjangoPromise:
         """Dummy object."""
 
-try:
-    import json
-    _json_extra_kwargs = {}
 
-    class _DecodeError(Exception):
-        pass
-except ImportError:                 # pragma: no cover
-    import simplejson as json
-    from simplejson.decoder import JSONDecodeError as _DecodeError
-    _json_extra_kwargs = {
-        'use_decimal': False,
-        'namedtuple_as_object': False,
-    }
+_json_extra_kwargs = {}
+
+
+class _DecodeError(Exception):
+    pass
 
 
 _encoder_cls = type(json._default_encoder)
@@ -106,4 +99,4 @@ def loads(s, _loads=json.loads, decode_bytes=True, object_hook=object_hook):
         return _loads(s, object_hook=object_hook)
     except _DecodeError:
         # catch "Unpaired high surrogate" error
-        return stdjson.loads(s)
+        return json.loads(s)

--- a/kombu/utils/json.py
+++ b/kombu/utils/json.py
@@ -3,8 +3,8 @@
 import base64
 import datetime
 import decimal
-import uuid
 import json
+import uuid
 
 try:
     from django.utils.functional import Promise as DjangoPromise


### PR DESCRIPTION
We import `import json as stdjson`, but then we try again to `import json` and otherwise do `import simplejson`. This is the legacy of Python 2.7 and there is no need to support that.
Issue: #1528 