### PR TITLE
Added HLEN to the list of prefixed redis commands

### DIFF
--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -191,6 +191,7 @@ class GlobalKeyPrefixMixin:
     PREFIXED_SIMPLE_COMMANDS = [
         "HDEL",
         "HGET",
+        "HLEN",
         "HSET",
         "LLEN",
         "LPUSH",


### PR DESCRIPTION
Although HLEN is not used anywhere inside kombu or celery, it is the method that is used to get the count of unacked messages.
This can be used similar to monitoring celery queue length.

The unacked_key that is used to store info about the unacknowledged tasks is a hash.
If I wish to identify whether all celery tasks have been processed, I need to ensure that the unacked_key is empty along with queues length also.
When using a prefix, HLEN should also use the same key prefix.