### PR TITLE
Fix mongodb connection parameters not passed correctly

### DIFF
--- a/kombu/transport/mongodb.py
+++ b/kombu/transport/mongodb.py
@@ -313,6 +313,7 @@ class Channel(virtual.Channel):
                                  if self.connect_timeout else None),
         }
         options.update(parsed['options'])
+        options.update(client.transport_options)
         options = self._prepare_client_options(options)
 
         return hostname, dbname, options


### PR DESCRIPTION
In Kombu 3.x versions, the MongoDB transport allows accepting the Celery `transport_options` parameters(BROKER_TRANSPORT_OPTIONS) as connection parameters.

In https://github.com/celery/kombu/pull/537 , removed support for parameter passing, maybe we should add it back.