### PR TITLE
Add support to SQS DelaySeconds

### DIFF
--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -413,6 +413,9 @@ class Channel(virtual.Channel):
                     message['properties']['MessageDeduplicationId']
             else:
                 kwargs['MessageDeduplicationId'] = str(uuid.uuid4())
+        else:
+            if "DelaySeconds" in message['properties']:
+                kwargs['DelaySeconds'] = message['properties']['DelaySeconds']
 
         c = self.sqs(queue=self.canonical_queue_name(queue))
         if message.get('redelivered'):

--- a/t/unit/transport/test_SQS.py
+++ b/t/unit/transport/test_SQS.py
@@ -770,6 +770,29 @@ class test_Channel:
         assert 'MessageDeduplicationId' in \
             sqs_queue_mock.send_message.call_args[1]
 
+    def test_predefined_queues_put_to_queue(self):
+        connection = Connection(transport=SQS.Transport, transport_options={
+            'predefined_queues': example_predefined_queues,
+        })
+        channel = connection.channel()
+
+        queue_name = 'queue-2'
+
+        exchange = Exchange('test_SQS', type='direct')
+        p = messaging.Producer(channel, exchange, routing_key=queue_name)
+
+        queue = Queue(queue_name, exchange, queue_name)
+        queue(channel).declare()
+
+        channel.sqs = Mock()
+        sqs_queue_mock = Mock()
+        channel.sqs.return_value = sqs_queue_mock
+        p.publish('message')
+
+        sqs_queue_mock.send_message.assert_called_once()
+
+        assert 'DelaySeconds' in sqs_queue_mock.send_message.call_args[1]
+
     @pytest.mark.parametrize('predefined_queues', (
         {
             'invalid-fifo-queue-name': {


### PR DESCRIPTION
SQS has a built-in "DelaySeconds" feature currently not supported by kombu. If `DelaySeconds` is present in the properties, then add it to the kwargs passed to the method `send_message`. Also added a test for DelaySeconds.

Related to celery/kombu#1074
