### PR TITLE
Add Redis WATCH to prefixed complex commands

### DIFF
--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -211,6 +211,7 @@ class GlobalKeyPrefixMixin:
         "DEL": {"args_start": 0, "args_end": None},
         "BRPOP": {"args_start": 0, "args_end": -1},
         "EVALSHA": {"args_start": 2, "args_end": 3},
+        "WATCH": {"args_start": 0, "args_end": None},
     }
 
     def _prefix_args(self, args):


### PR DESCRIPTION
The [Redis WATCH command](https://redis.io/commands/watch/) accepts multiple keys as arguments -- all of those keys should be prefixed using the `global_keyprefix` setting.

Kombu does not execute this command directly, but the command is used when running Redis transactions (restore tag and restore message).

Fixes #1569 