### PR TITLE
Avoid losing type of UUID when serializing/deserializing

### DIFF
--- a/docs/userguide/serialization.rst
+++ b/docs/userguide/serialization.rst
@@ -38,11 +38,17 @@ Each option has its advantages and disadvantages.
 
     The primary disadvantage to `JSON` is that it limits you to
     the following data types: strings, Unicode, floats, boolean,
-    dictionaries, and lists. Decimals and dates are notably missing.
+    dictionaries, lists, decimals, DjangoPromise, datetimes, dates,
+    time, bytes and UUIDs.
+
+    For dates, datetimes, UUIDs and bytes the serializer will generate
+    a dict that will later instruct the deserializer how to produce
+    the right type.
 
     Also, binary data will be transferred using Base64 encoding, which
     will cause the transferred data to be around 34% larger than an
-    encoding which supports native binary types.
+    encoding which supports native binary types. This will only happen
+    if the bytes object can't be decoded into utf8.
 
     However, if your data fits inside the above constraints and
     you need cross-language support, the default setting of `JSON`

--- a/kombu/utils/json.py
+++ b/kombu/utils/json.py
@@ -29,7 +29,7 @@ class JSONEncoder(_encoder_cls):
     def default(self, o,
                 dates=(datetime.datetime, datetime.date),
                 times=(datetime.time,),
-                textual=(decimal.Decimal, uuid.UUID, DjangoPromise),
+                textual=(decimal.Decimal, DjangoPromise),
                 isinstance=isinstance,
                 datetime=datetime.datetime,
                 text_t=str):
@@ -44,6 +44,8 @@ class JSONEncoder(_encoder_cls):
                 return {"datetime": r, "__datetime__": True}
             elif isinstance(o, times):
                 return o.isoformat()
+            elif isinstance(o, uuid.UUID):
+                return {"uuid": str(o), "__uuid__": True, "version": o.version}
             elif isinstance(o, textual):
                 return text_t(o)
             elif isinstance(o, bytes):
@@ -75,6 +77,8 @@ def object_hook(dct):
         return dct["bytes"].encode("utf-8")
     if "__base64__" in dct:
         return base64.b64decode(dct["bytes"].encode("utf-8"))
+    if "__uuid__" in dct:
+        return uuid.UUID(dct["uuid"], version=dct["version"])
     return dct
 
 

--- a/t/unit/utils/test_json.py
+++ b/t/unit/utils/test_json.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+import uuid
 from collections import namedtuple
 from datetime import datetime
 from decimal import Decimal
 from unittest.mock import MagicMock, Mock
-import uuid
 
 import pytest
 import pytz

--- a/t/unit/utils/test_json.py
+++ b/t/unit/utils/test_json.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 from datetime import datetime
 from decimal import Decimal
 from unittest.mock import MagicMock, Mock
-from uuid import uuid4
+import uuid
 
 import pytest
 import pytz
@@ -61,8 +61,17 @@ class test_JSONEncoder:
         assert loads(dumps(Foo(123))) == [123]
 
     def test_UUID(self):
-        id = uuid4()
-        assert loads(dumps({'u': id})), {'u': str(id)}
+        constructors = [
+            uuid.uuid1,
+            lambda: uuid.uuid3(uuid.NAMESPACE_URL, "https://example.org"),
+            uuid.uuid4,
+            lambda: uuid.uuid5(uuid.NAMESPACE_URL, "https://example.org"),
+        ]
+        for constructor in constructors:
+            id = constructor()
+            loaded_value = loads(dumps({'u': id}))
+            assert loaded_value, {'u': id}
+            assert loaded_value["u"].version == id.version
 
     def test_default(self):
         with pytest.raises(TypeError):


### PR DESCRIPTION
Serializing UUIDs as strs and deserializing them as strs can lead to
somewhat obscure bugs such as the one that led to the creation of this
PR in django-cacheback
https://github.com/codeinthehole/django-cacheback/pull/100 which some
would call unexpected behaviour.

After all, an UUID is altogether a different type from strs and if
bytes got their own serializer/deserializer for UUID the same logic
should apply.

I added a case for every uuidX constructor found in CPython.

Lemme know what you think of it and if there's anything I'm misreading :D.

P.D: I understand that UUIDs are now serialized as a convenience for users
but perhaps it's a bit non-intuitive that after versions of not supporting them
now they're converted to a different type when deserializing?