### PR TITLE
Fix typo in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -127,7 +127,7 @@ Quick overview
     video_queue = Queue('video', exchange=media_exchange, routing_key='video')
 
     def process_media(body, message):
-        print body
+        print(body)
         message.ack()
 
     # connections


### PR DESCRIPTION
Change print style into python 3.

docs already reflected it.

https://github.com/celery/kombu/blob/master/docs/includes/introduction.txt#L127