### PR TITLE
Not actually calling the intended function

### DIFF
--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -363,7 +363,7 @@ class Channel(virtual.Channel):
                     "defined in 'predefined_queues'."
                 ).format(queue))
 
-            attributes = {'VisibilityTimeout': str(self.visibility_timeout)}
+            attributes = {'VisibilityTimeout': str(self.visibility_timeout())}
             if queue.endswith('.fifo'):
                 attributes['FifoQueue'] = 'true'
 

--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -363,7 +363,7 @@ class Channel(virtual.Channel):
                     "defined in 'predefined_queues'."
                 ).format(queue))
 
-            attributes = {'VisibilityTimeout': str(self.visibility_timeout())}
+            attributes = {'VisibilityTimeout': self.visibility_timeout()}
             if queue.endswith('.fifo'):
                 attributes['FifoQueue'] = 'true'
 


### PR DESCRIPTION
Causes an error where broker transport options won't actually change the visibility timeout.