### PR TITLE
Fix azurestoragequeues transport

### DIFF
--- a/kombu/transport/azurestoragequeues.py
+++ b/kombu/transport/azurestoragequeues.py
@@ -103,7 +103,7 @@ class Channel(virtual.Channel):
             except ResourceExistsError:
                 q = self._queue_service.get_queue_client(queue=queue)
 
-            self._queue_name_cache[queue] = q
+            self._queue_name_cache[queue] = q.get_queue_properties()
         return q
 
     def _delete(self, queue, *args, **kwargs):


### PR DESCRIPTION
Saves `QueueProperties` objects (rather than `QueueClient` objects) into the `_queue_name_cache` dictionary. 

Fixes a bug where calling `QueueServiceClient.get_queue_client` with a `QueueClient` object resulted in type errors further down the line.

Fixes #1585 

Related to #1539, #1468 and possibly #1168 