### PR TITLE
hub: tick delay fix

### DIFF
--- a/kombu/asynchronous/hub.py
+++ b/kombu/asynchronous/hub.py
@@ -300,14 +300,15 @@ class Hub:
         while 1:
             todo = self._pop_ready()
 
-            for tick_callback in on_tick:
-                tick_callback()
-
             for item in todo:
                 if item:
                     item()
 
             poll_timeout = fire_timers(propagate=propagate) if scheduled else 1
+
+            for tick_callback in on_tick:
+                tick_callback()
+
             #  print('[[[HUB]]]: %s' % (self.repr_active(),))
             if readers or writers:
                 to_consolidate = []


### PR DESCRIPTION
todo and timer callbacks can perform actions that
require a tick callback to be executed right away
without polling.

the current order can cause issues
when using single worker with no prefetch (acks late).

related issue in celery:
https://github.com/celery/celery/issues/7718