### PR TITLE
Make JSONEncoder keep the same type for date/datetime.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -89,6 +89,7 @@ Lorenzo Mancini <lmancini@develer.com>
 Luyun Xie <2304310@qq.com>
 Mads Jensen <https://github.com/atombrella>
 Mahendra M <Mahendra_M@infosys.com>
+Manuel Vazquez Acosta <https://github.com/mvaled>
 Marcin Lulek (ergo) <info@webreactor.eu>
 Marcin Puhacz <marcin.puhacz@gmail.com>
 Mark Lavin <mlavin@caktusgroup.com>

--- a/kombu/utils/json.py
+++ b/kombu/utils/json.py
@@ -38,10 +38,13 @@ class JSONEncoder(_encoder_cls):
             return reducer()
         else:
             if isinstance(o, dates):
+                marker = "__date__"
                 if not isinstance(o, datetime):
                     o = datetime(o.year, o.month, o.day, 0, 0, 0, 0)
+                else:
+                    marker = "__datetime__"
                 r = o.isoformat()
-                return {"datetime": r, "__datetime__": True}
+                return {"datetime": r, marker: True}
             elif isinstance(o, times):
                 return o.isoformat()
             elif isinstance(o, uuid.UUID):
@@ -71,6 +74,8 @@ def dumps(s, _dumps=json.dumps, cls=None, default_kwargs=None, **kwargs):
 
 def object_hook(dct):
     """Hook function to perform custom deserialization."""
+    if "__date__" in dct:
+        return datetime.datetime.fromisoformat(dct["datetime"]).date()
     if "__datetime__" in dct:
         return datetime.datetime.fromisoformat(dct["datetime"])
     if "__bytes__" in dct:

--- a/t/unit/utils/test_json.py
+++ b/t/unit/utils/test_json.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import uuid
 from collections import namedtuple
-from datetime import datetime
+from datetime import date, datetime
 from decimal import Decimal
 from unittest.mock import MagicMock, Mock
 
@@ -39,7 +39,7 @@ class test_JSONEncoder:
             'datetime': now,
             'tz': now_utc,
             'time': now.time().isoformat(),
-            'date':  datetime(now.year, now.month, now.day, 0, 0, 0, 0),
+            'date':  date(now.year, now.month, now.day),
         }
 
     @given(message=st.binary())


### PR DESCRIPTION
Otherwise Celery jobs start to get `datetime` in place of `date` and that could lead to errors.

See https://github.com/celery/celery/issues/7754, related PR #1515.