### PR TITLE
importlib_metadata remove deprecated entry point interfaces

### DIFF
--- a/kombu/utils/compat.py
+++ b/kombu/utils/compat.py
@@ -82,7 +82,12 @@ def entrypoints(namespace):
     if sys.version_info >= (3,10):
         entry_points = importlib_metadata.entry_points(group=namespace)
     else:
-        entry_points = importlib_metadata.entry_points().get(namespace, [])
+        entry_points = importlib_metadata.entry_points()
+        try:
+            entry_points = entry_points.get(namespace, [])
+        except AttributeError:
+            entry_points = entry_points.select(group=namespace)
+
     return (
         (ep, ep.load())
         for ep in entry_points

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,4 +1,4 @@
-importlib-metadata>=0.18; python_version<"3.8"
+importlib-metadata>=3.6; python_version<"3.8"
 cached_property; python_version<"3.8"
 typing_extensions; python_version<"3.10"
 amqp>=5.1.1,<6.0.0


### PR DESCRIPTION
Closes https://github.com/celery/kombu/issues/1600

See https://github.com/python/importlib_metadata/pull/405