### PR TITLE
Fix errors from flake8 lint

### DIFF
--- a/kombu/__init__.py
+++ b/kombu/__init__.py
@@ -26,8 +26,8 @@ _temp = cast(re.Match, re.match(
     r'(\d+)\.(\d+).(\d+)(.+)?', __version__)).groups()
 VERSION = version_info = version_info_t(
     int(_temp[0]), int(_temp[1]), int(_temp[2]), _temp[3] or '', '')
-del(_temp)
-del(re)
+del _temp
+del re
 
 STATICA_HACK = True
 globals()['kcah_acitats'[::-1].upper()] = False

--- a/t/unit/test_pools.py
+++ b/t/unit/test_pools.py
@@ -141,7 +141,7 @@ class test_PoolGroup:
     def test_delitem(self):
         g = self.MyGroup()
         g['foo']
-        del(g['foo'])
+        del g['foo']
         assert 'foo' not in g
 
     def test_Connections(self):

--- a/t/unit/transport/test_memory.py
+++ b/t/unit/transport/test_memory.py
@@ -133,8 +133,8 @@ class test_MemoryTransport:
         with pytest.raises(socket.timeout):
             self.c.drain_events(timeout=0.1)
 
-        del(c1)  # so pyflakes doesn't complain.
-        del(c2)
+        del c1  # so pyflakes doesn't complain.
+        del c2
 
     def test_drain_events_unregistered_queue(self):
         c1 = self.c.channel()

--- a/t/unit/transport/test_pyro.py
+++ b/t/unit/transport/test_pyro.py
@@ -61,8 +61,8 @@ class test_PyroTransport:
         with pytest.raises(socket.timeout):
             self.c.drain_events(timeout=0.1)
 
-        del(c1)  # so pyflakes doesn't complain.
-        del(c2)
+        del c1  # so pyflakes doesn't complain.
+        del c2
 
     @pytest.mark.skip("requires running Pyro nameserver and Kombu Broker")
     def test_drain_events_unregistered_queue(self):

--- a/t/unit/transport/virtual/test_base.py
+++ b/t/unit/transport/virtual/test_base.py
@@ -582,8 +582,8 @@ class test_Transport:
         assert len(self.transport.channels) == 2
         self.transport.close_connection(self.transport)
         assert not self.transport.channels
-        del(c1)  # so pyflakes doesn't complain
-        del(c2)
+        del c1  # so pyflakes doesn't complain
+        del c2
 
     def test_create_channel(self):
         """Ensure create_channel can create channels successfully."""


### PR DESCRIPTION
Python's `del` is a statement, not a function, and doesn't need parenthesis.

The flake8 lint has been failing in kombu for a while now, this fixes the failures.
