### PR TITLE
Allow azurestoragequeues transport to be used with Azurite emulator in docker-compose

### DIFF
--- a/kombu/transport/azurestoragequeues.py
+++ b/kombu/transport/azurestoragequeues.py
@@ -179,7 +179,7 @@ class Transport(virtual.Transport):
     can_parse_url = True
 
     @staticmethod
-    def parse_uri(uri: str) -> tuple[Union[str, dict], str]:
+    def parse_uri(uri: str) -> tuple[str | dict, str]:
         # URL like:
         #  azurestoragequeues://STORAGE_ACCOUNT_ACCESS_KEY@STORAGE_ACCOUNT_URL
         #  azurestoragequeues://SAS_TOKEN@STORAGE_ACCOUNT_URL

--- a/kombu/transport/azurestoragequeues.py
+++ b/kombu/transport/azurestoragequeues.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import string
 from queue import Empty
+from typing import Union
 
 from azure.core.exceptions import ResourceExistsError
 
@@ -178,7 +179,7 @@ class Transport(virtual.Transport):
     can_parse_url = True
 
     @staticmethod
-    def parse_uri(uri: str) -> tuple[str, str]:
+    def parse_uri(uri: str) -> tuple[Union[str, dict], str]:
         # URL like:
         #  azurestoragequeues://STORAGE_ACCOUNT_ACCESS_KEY@STORAGE_ACCOUNT_URL
         #  azurestoragequeues://SAS_TOKEN@STORAGE_ACCOUNT_URL
@@ -191,6 +192,11 @@ class Transport(virtual.Transport):
             uri = uri.replace('azurestoragequeues://', '')
             # > 'some/key',  'url'
             credential, url = uri.rsplit('@', 1)
+            if "devstoreaccount1" in url and not ".core.windows.net" in url:  # azurite
+                credential = {
+                    "account_name": "devstoreaccount1",
+                    "account_key": credential,
+                }
 
             # Validate parameters
             assert all([credential, url])

--- a/kombu/transport/azurestoragequeues.py
+++ b/kombu/transport/azurestoragequeues.py
@@ -35,7 +35,6 @@ from __future__ import annotations
 
 import string
 from queue import Empty
-from typing import Union
 
 from azure.core.exceptions import ResourceExistsError
 
@@ -192,7 +191,9 @@ class Transport(virtual.Transport):
             uri = uri.replace('azurestoragequeues://', '')
             # > 'some/key',  'url'
             credential, url = uri.rsplit('@', 1)
-            if "devstoreaccount1" in url and not ".core.windows.net" in url:  # azurite
+
+            # parse credential as a dict if Azurite is being used
+            if "devstoreaccount1" in url and ".core.windows.net" not in url:
                 credential = {
                     "account_name": "devstoreaccount1",
                     "account_key": credential,

--- a/t/unit/transport/test_azurestoragequeues.py
+++ b/t/unit/transport/test_azurestoragequeues.py
@@ -45,4 +45,4 @@ def test_queue_service_works_for_azurite(creds, hostname):
             'account_name': 'devstoreaccount1',
             'account_key': 'Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=='
         }
-        assert channel._url == 'http://{}:10001/devstoreaccount1'.format(hostname) # noqa
+        assert channel._url == f'http://{hostname}:10001/devstoreaccount1' # noqa

--- a/t/unit/transport/test_azurestoragequeues.py
+++ b/t/unit/transport/test_azurestoragequeues.py
@@ -11,6 +11,8 @@ from kombu.transport import azurestoragequeues  # noqa
 
 URL_NOCREDS = 'azurestoragequeues://'
 URL_CREDS = 'azurestoragequeues://sas/key%@https://STORAGE_ACCOUNT_NAME.queue.core.windows.net/' # noqa
+AZURITE_CREDS = 'azurestoragequeues://Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==@http://localhost:10001/devstoreaccount1'
+AZURITE_CREDS_DOCKER_COMPOSE = 'azurestoragequeues://Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==@http://azurite:10001/devstoreaccount1'
 
 
 def test_queue_service_nocredentials():
@@ -31,3 +33,16 @@ def test_queue_service():
         # Check the SAS token "sas/key%" has been parsed from the url correctly
         assert channel._credential == 'sas/key%'
         assert channel._url == 'https://STORAGE_ACCOUNT_NAME.queue.core.windows.net/' # noqa
+
+
+@pytest.mark.parametrize("creds, hostname", [(AZURITE_CREDS, 'localhost'), (AZURITE_CREDS_DOCKER_COMPOSE, 'azurite')])
+def test_queue_service_works_for_azurite(creds, hostname):
+    conn = Connection(creds, transport=azurestoragequeues.Transport)
+    with patch('kombu.transport.azurestoragequeues.QueueServiceClient'):
+        channel = conn.channel()
+
+        assert channel._credential == {
+            'account_name': 'devstoreaccount1',
+            'account_key': 'Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=='
+        }
+        assert channel._url == 'http://{}:10001/devstoreaccount1'.format(hostname) # noqa

--- a/t/unit/transport/test_azurestoragequeues.py
+++ b/t/unit/transport/test_azurestoragequeues.py
@@ -11,8 +11,8 @@ from kombu.transport import azurestoragequeues  # noqa
 
 URL_NOCREDS = 'azurestoragequeues://'
 URL_CREDS = 'azurestoragequeues://sas/key%@https://STORAGE_ACCOUNT_NAME.queue.core.windows.net/' # noqa
-AZURITE_CREDS = 'azurestoragequeues://Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==@http://localhost:10001/devstoreaccount1'
-AZURITE_CREDS_DOCKER_COMPOSE = 'azurestoragequeues://Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==@http://azurite:10001/devstoreaccount1'
+AZURITE_CREDS = 'azurestoragequeues://Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==@http://localhost:10001/devstoreaccount1'  # noqa
+AZURITE_CREDS_DOCKER_COMPOSE = 'azurestoragequeues://Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==@http://azurite:10001/devstoreaccount1'  # noqa
 
 
 def test_queue_service_nocredentials():
@@ -35,7 +35,13 @@ def test_queue_service():
         assert channel._url == 'https://STORAGE_ACCOUNT_NAME.queue.core.windows.net/' # noqa
 
 
-@pytest.mark.parametrize("creds, hostname", [(AZURITE_CREDS, 'localhost'), (AZURITE_CREDS_DOCKER_COMPOSE, 'azurite')])
+@pytest.mark.parametrize(
+    "creds, hostname",
+    [
+        (AZURITE_CREDS, 'localhost'),
+        (AZURITE_CREDS_DOCKER_COMPOSE, 'azurite'),
+    ]
+)
 def test_queue_service_works_for_azurite(creds, hostname):
     conn = Connection(creds, transport=azurestoragequeues.Transport)
     with patch('kombu.transport.azurestoragequeues.QueueServiceClient'):
@@ -43,6 +49,6 @@ def test_queue_service_works_for_azurite(creds, hostname):
 
         assert channel._credential == {
             'account_name': 'devstoreaccount1',
-            'account_key': 'Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=='
+            'account_key': 'Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=='  # noqa
         }
         assert channel._url == f'http://{hostname}:10001/devstoreaccount1' # noqa


### PR DESCRIPTION
When integration testing the `azurestoragequeues` transport locally using [Azurite](https://github.com/Azure/Azurite) within a docker-compose stack, the queue url becomes `http://<service>:10001/devstoreaccount1` rather than `http://localhost:10001/devstoreaccount1` where `<service>` is the name of the azurite service in docker-compose. As described in [this issue on the Azure python SDK](https://github.com/Azure/azure-sdk-for-python/issues/19202), this results in a failure to connect to the queue service. This PR applies the suggested workaround in [this comment](https://github.com/Azure/azure-sdk-for-python/issues/19202#issuecomment-1158057765) to enable the kombu transport to work with Azurite in local docker-compose stacks for integration testing.

This PR should close #1168 