### PR TITLE
Allowing `Connection.ensure()` to retry on specific exceptions given by policy

### DIFF
--- a/t/unit/test_connection.py
+++ b/t/unit/test_connection.py
@@ -497,6 +497,20 @@ class test_Connection:
         with pytest.raises(OperationalError):
             ensured()
 
+    def test_ensure_retry_errors_is_not_looping_infinitely(self):
+        class _MessageNacked(Exception):
+            pass
+
+        def publish():
+            raise _MessageNacked('NACK')
+
+        with pytest.raises(ValueError):
+            self.conn.ensure(
+                self.conn,
+                publish,
+                retry_errors=(_MessageNacked,)
+            )
+
     def test_autoretry(self):
         myfun = Mock()
 


### PR DESCRIPTION
To be used with [task_publish_retry_policy](https://github.com/celery/celery/blob/7b585138af8318d62b8fe7086df7e85d110ac786/celery/app/defaults.py#L270)