### PR TITLE
add autoflake to .pre-commit-config.yaml to automatically remove unused imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,12 @@ repos:
       - id: pyupgrade
         args: ["--py37-plus"]
 
+  - repo: https://github.com/PyCQA/autoflake
+    rev: v2.0.0
+    hooks:
+      - id: autoflake
+        args: ["--in-place", "--ignore-pass-after-docstring", "--imports"]
+
   - repo: https://github.com/PyCQA/flake8
     rev: 6.0.0
     hooks:

--- a/kombu/utils/text.py
+++ b/kombu/utils/text.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from difflib import SequenceMatcher
-from typing import Iterable, Iterator, Optional, Tuple, Union
+from typing import Iterable, Iterator
 
 from kombu import version_info_t
 


### PR DESCRIPTION
I observed a lot of ci failures related to unused typing imports being reported by flake8. This change makes it so that these will automatically get cleaned up by the pre-commit.ci bot.