### PR TITLE
add --keep-runtime-typing argument to pyupgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v3.3.1
     hooks:
       - id: pyupgrade
-        args: ["--py37-plus"]
+        args: ["--py37-plus", "--keep-runtime-typing"]
 
   - repo: https://github.com/PyCQA/autoflake
     rev: v2.0.0


### PR DESCRIPTION
Per https://github.com/celery/kombu/pull/1632 @thedrow asked to add this argument so `Optional` is still used.