### PR TITLE
Mark methods accepting Connection instances as such

### DIFF
--- a/kombu/abstract.py
+++ b/kombu/abstract.py
@@ -10,6 +10,7 @@ from .exceptions import NotBoundError
 from .utils.functional import ChannelPromise
 
 if TYPE_CHECKING:
+    from kombu.connection import Connection
     from kombu.transport.virtual import Channel
 
 
@@ -80,19 +81,19 @@ class MaybeChannelBound(Object):
     can_cache_declaration = False
 
     def __call__(
-        self: _MaybeChannelBoundType, channel: Channel
+        self: _MaybeChannelBoundType, channel: (Channel | Connection)
     ) -> _MaybeChannelBoundType:
         """`self(channel) -> self.bind(channel)`."""
         return self.bind(channel)
 
     def bind(
-        self: _MaybeChannelBoundType, channel: Channel
+        self: _MaybeChannelBoundType, channel: (Channel | Connection)
     ) -> _MaybeChannelBoundType:
         """Create copy of the instance that is bound to a channel."""
         return copy(self).maybe_bind(channel)
 
     def maybe_bind(
-        self: _MaybeChannelBoundType, channel: Channel
+        self: _MaybeChannelBoundType, channel: (Channel | Connection)
     ) -> _MaybeChannelBoundType:
         """Bind instance to channel if not already bound."""
         if not self.is_bound and channel:


### PR DESCRIPTION
In MaybeChannelBound, the `__call__()`, `bind()` and `maybe_bind()` methods takes a channel argument. The type annotation say this argument must be a Channel, but it goes through `maybe_channel()`, so it can also be a Connection. Update the annotation to accept both Channel and Connection.