### PR TITLE
Remove unused `_setupfuns` from serialization.py

### DIFF
--- a/kombu/serialization.py
+++ b/kombu/serialization.py
@@ -384,18 +384,6 @@ register_msgpack()
 # Default serializer is 'json'
 registry._set_default_serializer('json')
 
-
-_setupfuns = {
-    'json': register_json,
-    'pickle': register_pickle,
-    'yaml': register_yaml,
-    'msgpack': register_msgpack,
-    'application/json': register_json,
-    'application/x-yaml': register_yaml,
-    'application/x-python-serialize': register_pickle,
-    'application/x-msgpack': register_msgpack,
-}
-
 NOTSET = object()
 
 


### PR DESCRIPTION
Looks like `_setupfuns` is unused and should be removed.

If they're used somehow, please explain how, so i can add comment here to avoid future confusion.