### PR TITLE
fix: don't crash on `properties`.`body_encoding`: `utf-8`

### DIFF
--- a/kombu/transport/virtual/base.py
+++ b/kombu/transport/virtual/base.py
@@ -802,12 +802,12 @@ class Channel(AbstractChannel, base.StdChannel):
         self.exchange_types = None
 
     def encode_body(self, body, encoding=None):
-        if encoding:
+        if encoding and encoding.lower() != 'utf-8':
             return self.codecs.get(encoding).encode(body), encoding
         return body, encoding
 
     def decode_body(self, body, encoding=None):
-        if encoding:
+        if encoding and encoding.lower() != 'utf-8':
             return self.codecs.get(encoding).decode(body)
         return body
 


### PR DESCRIPTION
when a message has an `properties`.`body_encoding` of `utf-8` (e.g. the default on https://github.com/node-celery-ts/node-celery-ts), celery workers crash with an error `AttributeError: 'NoneType' object has no attribute 'decode'`. `utf-8` is functionally equivalent to not providing an encoding, so this should be good.