### PR TITLE
Update to Latest Service Bus Library

### DIFF
--- a/requirements/extras/azureservicebus.txt
+++ b/requirements/extras/azureservicebus.txt
@@ -1,1 +1,1 @@
-azure-servicebus>=7.9.0; platform_python_implementation=="CPython"
+azure-servicebus>=7.10.0


### PR DESCRIPTION
Update to the newest service bus library that is built on pure python AMQP stack.   `uamqp` is no longer a requirement and will help yall with the pypy CI