### PR TITLE
chore(ci): improve CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         id: python
-        uses: actions/setup-python@main
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         id: python
-        uses: actions/setup-python@main
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -71,7 +71,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         id: python
-        uses: actions/setup-python@main
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
         python-version: [3.8,3.9,"3.10"]
         experimental: [false]
         include:
-          - python-version: pypy-3.9
+          - python-version: pypy3.9
             experimental: true
     steps:
       - name: Install system packages
@@ -47,17 +47,15 @@ jobs:
       - name: Install dependencies
         run: pip install --upgrade pip wheel tox tox-docker
       # Tox fails if a Python versions contains a hyphen, this changes "pypy-3.9" to "pypy3.9".
-      - name: Determine Python version
-        run: echo PYTHON_VERSION=$(echo ${{ matrix.python-version }} | sed s/-//) >> $GITHUB_ENV
       - name: Run AMQP integration tests
-        run: tox -v -e ${{ env.PYTHON_VERSION }}-linux-integration-py-amqp -- -v
+        run: tox -v -e ${{ matrix.python-version }}-linux-integration-py-amqp -- -v
       - name: Run redis integration tests
-        run: tox -v -e ${{ env.PYTHON_VERSION }}-linux-integration-py-redis -- -v
+        run: tox -v -e ${{ matrix.python-version }}-linux-integration-py-redis -- -v
       - name: Run MongoDB integration tests
-        run: tox -v -e ${{ env.PYTHON_VERSION }}-linux-integration-py-mongodb -- -v
+        run: tox -v -e ${{ matrix.python-version }}-linux-integration-py-mongodb -- -v
       - name: Run kafka integration tests
-        if: ${{ env.PYTHON_VERSION != 'pypy3.9'}}
-        run: tox -v -e ${{ env.PYTHON_VERSION }}-linux-integration-py-kafka -- -v
+        if: ${{ matrix.python-version != 'pypy3.9'}}
+        run: tox -v -e ${{ matrix.python-version }}-linux-integration-py-kafka -- -v
 
   #################### Linters and checkers ####################
   lint:


### PR DESCRIPTION
Improvements found while I was working on https://github.com/celery/kombu/pull/1705.

- Use exact tag for `setup-python` GH action.
- Get rid of dash stripping step for PyPy 3.9 version as [setup-python GH action supports using `pypy3.9` reference](https://github.com/actions/setup-python#basic-usage).

## How this has been tested ?

`ci.yaml` GitHub Actions workflow has been run locally using [`act`](https://github.com/nektos/act), with the following command:
```
act -W .github/workflows/ci.yaml
```