### PR TITLE
chore(python): remove Python 3.7 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7,3.8,3.9,"3.10"]
+        python-version: [3.8,3.9,"3.10"]
     steps:
       - name: Install system packages
         run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev libssl-dev

--- a/kombu/utils/compat.py
+++ b/kombu/utils/compat.py
@@ -6,13 +6,7 @@ import numbers
 import sys
 from contextlib import contextmanager
 from functools import wraps
-
-try:
-    from importlib import metadata as importlib_metadata
-except ImportError:
-    # TODO: Remove this when we drop support for Python 3.7
-    import importlib_metadata
-
+from importlib import metadata as importlib_metadata
 from io import UnsupportedOperation
 
 from kombu.exceptions import reraise

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,5 +1,3 @@
-importlib-metadata>=3.6; python_version<"3.8"
-cached_property; python_version<"3.8"
 typing_extensions; python_version<"3.10"
 amqp>=5.1.1,<6.0.0
 vine

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
     },
     platforms=['any'],
     license='BSD-3-Clause',
-    python_requires=">=3.7",
+    python_requires=">=3.8.1",
     install_requires=reqs('default.txt'),
     tests_require=reqs('test.txt'),
     extras_require={
@@ -125,7 +125,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
     },
     platforms=['any'],
     license='BSD-3-Clause',
-    python_requires=">=3.8.1",
+    python_requires=">=3.8",
     install_requires=reqs('default.txt'),
     tests_require=reqs('test.txt'),
     extras_require={

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 envlist =
-    {pypy3.9,3.7,3.8,3.9,3.10,3.11}-unit
-    {pypy3.9,3.7,3.8,3.9,3.10,3.11}-linux-integration-py-amqp
-    {pypy3.9,3.7,3.8,3.9,3.10,3.11}-linux-integration-redis
-    {pypy3.9,3.7,3.8,3.9,3.10,3.11}-linux-integration-mongodb
-    {3.7,3.8,3.9,3.10,3.11}-linux-integration-kafka
+    {pypy3.9,3.8,3.9,3.10,3.11}-unit
+    {pypy3.9,3.8,3.9,3.10,3.11}-linux-integration-py-amqp
+    {pypy3.9,3.8,3.9,3.10,3.11}-linux-integration-redis
+    {pypy3.9,3.8,3.9,3.10,3.11}-linux-integration-mongodb
+    {3.8,3.9,3.10,3.11}-linux-integration-kafka
     flake8
     apicheck
     pydocstyle
@@ -13,7 +13,6 @@ requires = tox-docker>=3.0
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310, mypy
@@ -26,10 +25,10 @@ passenv =
   DISTUTILS_USE_SDK
 deps=
     -r{toxinidir}/requirements/dev.txt
-    apicheck,pypy3.9,3.7,3.8,3.9,3.10,3.11: -r{toxinidir}/requirements/default.txt
-    apicheck,pypy3.9,3.7,3.8,3.9,3.10,3.11: -r{toxinidir}/requirements/test.txt
-    apicheck,pypy3.9,3.7-linux,3.8-linux,3.9-linux,3.10-linux,3.11-linux: -r{toxinidir}/requirements/test-ci.txt
-    apicheck,3.7-linux,3.8-linux,3.9-linux,3.10-linux,3.11-linux: -r{toxinidir}/requirements/extras/confluentkafka.txt
+    apicheck,pypy3.9,3.8,3.9,3.10,3.11: -r{toxinidir}/requirements/default.txt
+    apicheck,pypy3.9,3.8,3.9,3.10,3.11: -r{toxinidir}/requirements/test.txt
+    apicheck,pypy3.9,linux,3.8-linux,3.9-linux,3.10-linux,3.11-linux: -r{toxinidir}/requirements/test-ci.txt
+    apicheck,3.8-linux,3.9-linux,3.10-linux,3.11-linux: -r{toxinidir}/requirements/extras/confluentkafka.txt
     3.8-windows,3.9-windows,3.10-windows,3.11-windows: -r{toxinidir}/requirements/test-ci-windows.txt
     apicheck,linkcheck: -r{toxinidir}/requirements/docs.txt
     flake8,pydocstyle,mypy: -r{toxinidir}/requirements/pkgutils.txt
@@ -44,7 +43,6 @@ commands =
 basepython =
     pypy3.9: pypy3.9
     pypy3.8: pypy3.8
-    3.7: python3.7
     3.8,mypy: python3.8
     3.9,apicheck,pydocstyle,flake8,linkcheck,cov: python3.9
     3.10: python3.10


### PR DESCRIPTION
Improvement found while I was working on https://github.com/celery/kombu/pull/1705.

## Description

As Python 3.7 will reach end-of-life in June 2023, we can get rid of Python 3.7 support. 
Python 3.8.1 instead of 3.8.0 is required as a requirement for `flake8>=6.0.0`, cf. https://github.com/celery/kombu/pull/1709.