### PR TITLE
chore(pkgutils): upgrade flake8 to 6.0.0

### DIFF
--- a/requirements/pkgutils.txt
+++ b/requirements/pkgutils.txt
@@ -1,6 +1,6 @@
 setuptools>=47.0.0
 wheel>=0.29.0
-flake8==5.0.4
+flake8==6.0.0
 tox>=4.4.8
 sphinx2rst>=1.0
 bumpversion


### PR DESCRIPTION
Improvements found while I was working on https://github.com/celery/kombu/pull/1705.

This PR upgrades `flake8` to 6.0.0 in `pkgutils.txt` as we are already using 6.0.0 in pre-commit.