### PR TITLE
chore(build): clean `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,6 @@ setup(
         'Source': 'https://github.com/celery/kombu'
     },
     platforms=['any'],
-    zip_safe=False,
     license='BSD-3-Clause',
     cmdclass={'test': pytest},
     python_requires=">=3.7",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ import re
 import sys
 
 import setuptools
-import setuptools.command.test
 
 try:
     from setuptools import setup
@@ -80,18 +79,6 @@ def extras(*p):
     return reqs('extras', *p)
 
 
-class pytest(setuptools.command.test.test):
-    user_options = [('pytest-args=', 'a', 'Arguments to pass to py.test')]
-
-    def initialize_options(self):
-        super().initialize_options()
-        self.pytest_args = []
-
-    def run_tests(self):
-        import pytest
-        sys.exit(pytest.main(self.pytest_args))
-
-
 def readme():
     with open('README.rst') as f:
         return f.read()
@@ -111,7 +98,6 @@ setup(
     },
     platforms=['any'],
     license='BSD-3-Clause',
-    cmdclass={'test': pytest},
     python_requires=">=3.7",
     install_requires=reqs('default.txt'),
     tests_require=reqs('test.txt'),


### PR DESCRIPTION
Cleaning before https://github.com/celery/kombu/pull/1705.

This PR:
- removes `zip_safe` parameter as this is considered deprecated and used for egg distribution format, cf. https://setuptools.pypa.io/en/latest/deprecated/zip_safe.html.
- removes `cmdclass` as it seems unused, cf. https://setuptools.pypa.io/en/latest/userguide/extension.html for more context.