### PR TITLE
chore(manifest): remove unneeded directives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .DS_Store
 *.pyc
+*.pyo
+ **/__pycache__/
 *$py.class
 *~
 *.sqlite
@@ -8,6 +10,7 @@ settings_local.py
 build/
 .build/
 _build/
+docs/_build
 .*.sw*
 dist/
 *.egg-info

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,21 +3,11 @@ include Changelog
 include FAQ
 include INSTALL
 include LICENSE
-include MANIFEST.in
-include README.rst
-include README
 include THANKS
 include TODO
-include setup.cfg
 recursive-include extra *
 recursive-include docs *
-recursive-include kombu *.py
 recursive-include t *.py
 recursive-include requirements *.txt
 recursive-include funtests *.py setup.cfg
 recursive-include examples *.py
-
-recursive-exclude docs/_build *
-recursive-exclude * __pycache__
-recursive-exclude * *.py[co]
-recursive-exclude * .*.sw*


### PR DESCRIPTION
Cleaning before https://github.com/celery/kombu/pull/1705.

## Description

This PR removes unneeded directives in `MANIFEST.in` file, cf. https://packaging.python.org/en/latest/guides/using-manifest-in/.

Exclude directives have also been removed and instead added to `.gitignore` as they are compiled Python files or docs build artifacts.

## How this has been tested ?
Used the following script to check sdist content diff between both versions:
```
git checkout main
python setup.py sdist
tar -tvf dist/kombu-5.3.0b3.tar.gz > old_archive_content.txt
git checkout chore/clean-manifest-file
python setup.py sdist
tar -tvf dist/kombu-5.3.0b3.tar.gz > new_archive_content.txt
diff new_archive_content.txt old_archive_content.txt > diff.txt
```
The last command returns nothing.