### PR TITLE
chore(mypy): upgrade mypy to 1.3.0

### DIFF
--- a/requirements/pkgutils.txt
+++ b/requirements/pkgutils.txt
@@ -5,4 +5,4 @@ tox>=4.4.8
 sphinx2rst>=1.0
 bumpversion
 pydocstyle==1.1.1
-mypy==1.2.0
+mypy==1.3.0


### PR DESCRIPTION
This upgrades `mypy` to 1.3.0.

Changelog: https://mypy-lang.blogspot.com/2023/05/mypy-13-released.html, no impact for us.