### PR TITLE
fix: Prevent redis task loss when closing connection while in poll

### DIFF
--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -1079,6 +1079,11 @@ class Channel(virtual.Channel):
 
     def close(self):
         self._closing = True
+        if self._in_poll:
+            try:
+                self._brpop_read()
+            except Empty:
+                pass
         if not self.closed:
             # remove from channel poller.
             self.connection.cycle.discard(self)

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -1290,6 +1290,15 @@ class test_Redis:
         assert conn1.disconnected
         assert conn2.disconnected
 
+    def test_close_in_poll(self):
+        c = Connection(transport=Transport).channel()
+        conn1 = c.client.connection
+        conn1._sock.data = [('BRPOP', ('test_Redis',))]
+        c._in_poll = True
+        c.close()
+        assert conn1.disconnected
+        assert conn1._sock.data == []
+
     def test_get__Empty(self):
         channel = self.connection.channel()
         with pytest.raises(Empty):


### PR DESCRIPTION
## Summary of issue

The redis poller uses the [BRPOP](https://redis.io/commands/brpop/) command to pull items from the queue:

> BRPOP is a blocking list pop primitive. It is the blocking version of [RPOP](https://redis.io/commands/rpop) because it blocks the connection when there are no elements to pop from any of the given lists. An element is popped from the tail of the first list that is non-empty, with the given keys being checked in the order that they are given.

If the channel is closed before the `BRPOP` [response is read](https://github.com/celery/kombu/blob/e5299379b002b0b663562d073735bf9f05c62333/kombu/transport/redis.py#L956), there is a risk that a task will be popped from the queue, but never picked up or restored:

```mermaid
sequenceDiagram
    Worker->>Redis: Worker issues BRPOP command to redis, with N second timeout
    Worker->>Redis: Worker receives warm shutdown request, and closes connection
    Client->>Redis: Client adds task to the task queue
    Redis->>Redis: BRPOP removes task from queue, but fails to respond to worker (connection is closed)
    Worker->>Worker: Worker terminates, but client's task is lost
```

## Summary of change

If the channel is in the [_in_poll](https://github.com/celery/kombu/blob/e5299379b002b0b663562d073735bf9f05c62333/kombu/transport/redis.py#L948) state when it is closed (i.e. or waiting for the `BRPOP` command to return), attempt to read the `BRPOP` response before closing the channel. This _should_ allow the task to be restored before the channel is closed. 

## Potentially related issues

* https://github.com/celery/celery/issues/4354
* https://github.com/celery/celery/issues/7950