### PR TITLE
zoneinfo: the actual timezone data is an optional dependency

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,4 +1,4 @@
 typing_extensions; python_version<"3.10"
 amqp>=5.1.1,<6.0.0
 vine
-backports.zoneinfo>=0.2.1; python_version < '3.9'
+backports.zoneinfo[tzdata]>=0.2.1; python_version < '3.9'


### PR DESCRIPTION
https://github.com/celery/kombu/issues/1731#issuecomment-1571887264

`ZoneInfo("UTC")` works on linux without the extra `tzdata` dependency. It doesn't work on Windows without `tzdata`. It doesn't work for any other time zones like `CET` on any OS.

So I propose to always install `tzdata`.