### PR TITLE
fix: allow deserializing any version of UUID

### DIFF
--- a/kombu/utils/json.py
+++ b/kombu/utils/json.py
@@ -123,6 +123,6 @@ register_type(Decimal, "decimal", str, Decimal)
 register_type(
     uuid.UUID,
     "uuid",
-    lambda o: {"hex": o.hex, "version": o.version},
+    lambda o: {"hex": o.hex},
     lambda o: uuid.UUID(**o),
 )

--- a/t/unit/utils/test_json.py
+++ b/t/unit/utils/test_json.py
@@ -20,7 +20,6 @@ else:
 
 
 class Custom:
-
     def __init__(self, data):
         self.data = data
 
@@ -71,6 +70,11 @@ class test_JSONEncoder:
             lambda: uuid.uuid3(uuid.NAMESPACE_URL, "https://example.org"),
             uuid.uuid4,
             lambda: uuid.uuid5(uuid.NAMESPACE_URL, "https://example.org"),
+            # The uuids below correspond to v6, v7 and v8 respectively and were
+            # generated using the package uuid6.
+            lambda: uuid.UUID("1ee0b1e6-dd55-63d2-867f-88cb9205458f"),
+            lambda: uuid.UUID("0188bcbb-8475-7605-a094-fe41c58df798"),
+            lambda: uuid.UUID("0188bcbb-8cb2-8bf7-b3b5-fd1faa0431bd"),
         ]
         for constructor in constructors:
             id = constructor()


### PR DESCRIPTION
In PR #1575 a new serializer for UUIDs was introduced, however it fails when deserializing UUIDs which version is not within 1 and 5. Given that there's a new standard (https://datatracker.ietf.org/doc/html/draft-peabody-dispatch-new-uuid-format-04) gaining traction that introduces UUIDs v6, v7 and v8, we change the code to allow such versions.

In the test, we generate one UUID for each version using the package `uuid6` (https://github.com/oittaa/uuid6-python)

Fixes #1750 1750