### PR TITLE
Reverted unwanted constraint introduced in #1629 with max_retries

### DIFF
--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -543,12 +543,6 @@ class Connection:
         """
         if retry_errors is None:
             retry_errors = tuple()
-        elif max_retries is None:
-            # If the retry_errors is specified, but max_retries is not,
-            # this could lead into an infinite loop potentially.
-            raise ValueError(
-                "max_retries must be specified if retry_errors is specified"
-            )
 
         def _ensured(*args, **kwargs):
             got_connection = 0

--- a/t/unit/test_connection.py
+++ b/t/unit/test_connection.py
@@ -497,20 +497,6 @@ class test_Connection:
         with pytest.raises(OperationalError):
             ensured()
 
-    def test_ensure_retry_errors_is_not_looping_infinitely(self):
-        class _MessageNacked(Exception):
-            pass
-
-        def publish():
-            raise _MessageNacked('NACK')
-
-        with pytest.raises(ValueError):
-            self.conn.ensure(
-                self.conn,
-                publish,
-                retry_errors=(_MessageNacked,)
-            )
-
     def test_ensure_retry_errors_is_limited_by_max_retries(self):
         class _MessageNacked(Exception):
             pass


### PR DESCRIPTION
#1629 introduced a constraint forcing setting `max_retries` when it was originally designed to be able to be `None` for infinite retries.

This PR relaxes back the constraint as it was before while keeping the change from #1629