### PR TITLE
Python3.12: fix imports in kombu/utils/objects.py

### DIFF
--- a/kombu/utils/objects.py
+++ b/kombu/utils/objects.py
@@ -5,13 +5,12 @@ from __future__ import annotations
 __all__ = ('cached_property',)
 
 try:
-    from functools import _NOT_FOUND
     from functools import cached_property as _cached_property
 except ImportError:
     # TODO: Remove this fallback once we drop support for Python < 3.8
     from cached_property import threaded_cached_property as _cached_property
 
-    _NOT_FOUND = object()
+_NOT_FOUND = object()
 
 
 class cached_property(_cached_property):


### PR DESCRIPTION
Consider the following piece of code, very similar to what can be found
in kombu/utils/objects.py:
---8<------------------------------------------------------------------
$ cat  /tmp/x.py
try:
    from functools import _NOT_FOUND
    from functools import cached_property as _cached_property
except ImportError:
    from cached_property import threaded_cached_property as _cached_property
    _NOT_FOUND = object()

print("OK!")
---8<------------------------------------------------------------------

This works well in Python3.11:
---8<------------------------------------------------------------------
$ podman run -it --rm -v /tmp:/tmp python:3.11.4  python /tmp/x.py
OK!
---8<------------------------------------------------------------------

But fails in Python3.12:
---8<------------------------------------------------------------------
$ podman run -it --rm -v /tmp:/tmp python:3.12.0b2  python /tmp/x.py
Traceback (most recent call last):
  File "/tmp/x.py", line 2, in <module>
    from functools import _NOT_FOUND
ImportError: cannot import name '_NOT_FOUND' from 'functools' (/usr/local/lib/python3.12/functools.py)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/tmp/x.py", line 6, in <module>
    from cached_property import threaded_cached_property as _cached_property
ModuleNotFoundError: No module named 'cached_property'
---8<------------------------------------------------------------------

This is because Python3.12 removed functools._NOT_FOUND (see commit
056dfc71dce15f81887f0bd6da09d6099d71f979), which prevents
cached_property from being imported from functools in our code. If the
cached_property library is not installed, then the imports fail.

We should be using two different try/except blocks, but since
functools._NOT_FOUND was defined as "object()" in the standard library
anyway, let's just not bother importing it.
