### PR TITLE
docs: Remove SimpleQueue import

### DIFF
--- a/docs/userguide/simple.rst
+++ b/docs/userguide/simple.rst
@@ -32,7 +32,7 @@ This is equivalent to:
 
 .. code-block:: pycon
 
-    >>> from kombu.simple import SimpleQueue, SimpleBuffer
+    >>> from kombu.simple import SimpleBuffer
 
     >>> channel = connection.channel()
     >>> queue = SimpleBuffer(channel, 'mybuffer')


### PR DESCRIPTION
It seems SimpleQueue is not used in the example below.
