### PR TITLE
Kombu & celery with SQS #222

### DIFF
--- a/docs/userguide/connections.rst
+++ b/docs/userguide/connections.rst
@@ -67,7 +67,7 @@ resources:
 .. _connection-urls:
 
 Celery with SQS
-=============
+=================
 SQS broker url doesn't include queue_name_prefix by default.
 So we can use the following code snippet to make it work in celery.
 .. code-block:: python

--- a/docs/userguide/connections.rst
+++ b/docs/userguide/connections.rst
@@ -67,7 +67,7 @@ resources:
 .. _connection-urls:
 
 Celery with SQS
-=================
+===============
 SQS broker url doesn't include queue_name_prefix by default.
 So we can use the following code snippet to make it work in celery.
 .. code-block:: python

--- a/docs/userguide/connections.rst
+++ b/docs/userguide/connections.rst
@@ -67,7 +67,7 @@ resources:
 .. _connection-urls:
 
 Celery with SQS
-====
+=============
 
 .. code-block:: python
 

--- a/docs/userguide/connections.rst
+++ b/docs/userguide/connections.rst
@@ -68,7 +68,7 @@ resources:
 
 Celery with SQS
 =============
-
+SQS broker url doesn't include queue_name_prefix by default. So we can use the following code snippet to make it work.
 .. code-block:: python
 
     from celery import Celery

--- a/docs/userguide/connections.rst
+++ b/docs/userguide/connections.rst
@@ -66,6 +66,33 @@ resources:
 
 .. _connection-urls:
 
+Celery with SQS
+====
+
+.. code-block:: python
+
+    from celery import Celery
+    def make_celery(app):
+        celery = Celery(
+            app.import_name,
+            broker="sqs://",
+            broker_transport_options={
+                "queue_name_prefix": "{SERVICE_ENV}-{SERVICE_NAME}-"
+            },
+        )
+        task_base = celery.Task
+
+        class ContextTask(task_base):
+            abstract = True
+
+            def __call__(self, *args, **kwargs):
+                with app.app_context():
+                    return task_base.__call__(self, *args, **kwargs)
+
+        celery.Task = ContextTask
+
+        return celery
+
 URLs
 ====
 
@@ -88,7 +115,7 @@ All of these are valid URLs:
 
     # Using Redis over a Unix socket
     redis+socket:///tmp/redis.sock
-    
+
     # Using Redis sentinel
     sentinel://sentinel1:26379;sentinel://sentinel2:26379
 

--- a/docs/userguide/connections.rst
+++ b/docs/userguide/connections.rst
@@ -68,7 +68,8 @@ resources:
 
 Celery with SQS
 =============
-SQS broker url doesn't include queue_name_prefix by default. So we can use the following code snippet to make it work.
+SQS broker url doesn't include queue_name_prefix by default.
+So we can use the following code snippet to make it work in celery.
 .. code-block:: python
 
     from celery import Celery


### PR DESCRIPTION
+ celery with sqs #222

SQS broker url doesn't include queue_name_prefix #222
ANSWER:-
I have used the below code for queue_name_prefix...
It is in Flask App running on production..

    from celery import Celery
    def make_celery(app):
        celery = Celery(
            app.import_name,
            broker="sqs://",
            broker_transport_options={
                "queue_name_prefix": "{SERVICE_ENV}-{SERVICE_NAME}-"
            },
        )
        task_base = celery.Task
    
        class ContextTask(task_base):
            abstract = True
    
            def __call__(self, *args, **kwargs):
                with app.app_context():
                    return task_base.__call__(self, *args, **kwargs)
    
        celery.Task = ContextTask
    
        return celery