### PR TITLE
Fixes #1795 - Added as_uri method to MongoDB transport

### DIFF
--- a/kombu/transport/mongodb.py
+++ b/kombu/transport/mongodb.py
@@ -47,6 +47,7 @@ from kombu.utils.compat import _detect_environment
 from kombu.utils.encoding import bytes_to_str
 from kombu.utils.json import dumps, loads
 from kombu.utils.objects import cached_property
+from kombu.utils.url import maybe_sanitize_url
 
 from . import virtual
 from .base import to_rabbitmq_queue_arguments
@@ -510,3 +511,15 @@ class Transport(virtual.Transport):
 
     def driver_version(self):
         return pymongo.version
+
+    def as_uri(self, uri: str, include_password=False, mask='**') -> str:
+        if not uri:
+            return 'mongodb://'
+        if include_password:
+            return uri
+
+        if ',' not in uri:
+            return maybe_sanitize_url(uri)
+
+        uri1, remainder = uri.split(',', 1)
+        return ','.join([maybe_sanitize_url(uri1), remainder])

--- a/t/unit/transport/test_mongodb.py
+++ b/t/unit/transport/test_mongodb.py
@@ -79,6 +79,30 @@ class test_mongodb_uri_parsing:
 
         assert dbname == 'kombu_default'
 
+    def test_custom_port(self):
+        url = 'mongodb://localhost:27018'
+        channel = _create_mock_connection(url).default_channel
+        hostname, dbname, options = channel._parse_uri()
+
+        assert hostname == 'mongodb://localhost:27018'
+
+    def test_replicaset_hosts(self):
+        url = 'mongodb://mongodb1.example.com:27317,mongodb2.example.com:27017/?replicaSet=test_rs'
+        channel = _create_mock_connection(url).default_channel
+        hostname, dbname, options = channel._parse_uri()
+
+        assert hostname == 'mongodb://mongodb1.example.com:27317,mongodb2.example.com:27017/?replicaSet=test_rs'
+        assert options['replicaset'] == 'test_rs'
+
+    def test_replicaset_hosts_custom_database(self):
+        url = 'mongodb://mongodb1.example.com:27317,mongodb2.example.com:27017/dbname?replicaSet=test_rs'
+        channel = _create_mock_connection(url).default_channel
+        hostname, dbname, options = channel._parse_uri()
+
+        assert hostname == 'mongodb://mongodb1.example.com:27317,mongodb2.example.com:27017/?replicaSet=test_rs'
+        assert dbname == 'dbname'
+        assert options['replicaset'] == 'test_rs'
+
     def test_custom_database(self):
         url = 'mongodb://localhost/dbname'
         channel = _create_mock_connection(url).default_channel


### PR DESCRIPTION
Added as_uri method to MongoDB transport, now the Replica Set URIs parse correctly.