### PR TITLE
fix: redis requeue concurrency bug  #1800

### DIFF
--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -382,7 +382,9 @@ class QoS(virtual.QoS):
     def reject(self, delivery_tag, requeue=False):
         if requeue:
             self.restore_by_tag(delivery_tag, leftmost=True)
-        self.ack(delivery_tag)
+        else:
+            self._remove_from_indices(delivery_tag).execute()
+        super().ack(delivery_tag)
 
     @contextmanager
     def pipe_or_acquire(self, pipe=None, client=None):

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -1521,9 +1521,15 @@ class test_MultiChannelPoller:
     def test_qos_reject(self):
         p, channel = self.create_get()
         qos = redis.QoS(channel)
-        qos.ack = Mock(name='Qos.ack')
+        qos._remove_from_indices = Mock(name='_remove_from_indices')
         qos.reject(1234)
-        qos.ack.assert_called_with(1234)
+
+    def test_qos_requeue(self):
+        p, channel = self.create_get()
+        qos = redis.QoS(channel)
+        qos.restore_by_tag = Mock(name='restore_by_tag')
+        qos.reject(1234, True)
+        qos.restore_by_tag.assert_called_with(1234, leftmost=True)
 
     def test_get_brpop_qos_allow(self):
         p, channel = self.create_get(queues=['a_queue'])

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -1523,6 +1523,7 @@ class test_MultiChannelPoller:
         qos = redis.QoS(channel)
         qos._remove_from_indices = Mock(name='_remove_from_indices')
         qos.reject(1234)
+        qos._remove_from_indices.assert_called_with(1234)
 
     def test_qos_requeue(self):
         p, channel = self.create_get()


### PR DESCRIPTION
this bug is ack concurrency caused by del unack key.

for debug i print full stack :

delete a58b8b31-c8c8-4c1e-88d9-f857bbf375a2 unacked_index
  File "/home/jiangxf/py3/lib/python3.10/site-packages/kombu/transport/virtual/base.py", line 639, in _callback
    return callback(message)
  File "/home/jiangxf/py3/lib/python3.10/site-packages/kombu/messaging.py", line 656, in _receive_callback
    return on_m(message) if on_m else self.receive(decoded, message)
  File "/home/jiangxf/py3/lib/python3.10/site-packages/kombu/messaging.py", line 622, in receive
    [callback(body, message) for callback in callbacks]
  File "/home/jiangxf/py3/lib/python3.10/site-packages/kombu/messaging.py", line 622, in <listcomp>
    [callback(body, message) for callback in callbacks]
  File "/home/jiangxf/test_kombu.py", line 22, in message_process_requeue
    message.requeue()
  File "/home/jiangxf/py3/lib/python3.10/site-packages/kombu/message.py", line 187, in requeue
    self.channel.basic_reject(self.delivery_tag, requeue=True)
  File "/home/jiangxf/py3/lib/python3.10/site-packages/kombu/transport/virtual/base.py", line 680, in basic_reject
    self.qos.reject(delivery_tag, requeue=requeue)
  File "/home/jiangxf/py3/lib/python3.10/site-packages/kombu/transport/redis.py", line 385, in reject
    self.ack(delivery_tag)
  File "/home/jiangxf/py3/lib/python3.10/site-packages/kombu/transport/redis.py", line 379, in ack
    self._remove_from_indices(delivery_tag).execute()
  File "/home/jiangxf/py3/lib/python3.10/site-packages/kombu/transport/redis.py", line 397, in _remove_from_indices
    traceback.print_stack(limit=10)
