### PR TITLE
Bump kafka deps versions & fix integration test failures

### DIFF
--- a/kombu/transport/confluentkafka.py
+++ b/kombu/transport/confluentkafka.py
@@ -69,7 +69,7 @@ from kombu.utils.json import dumps, loads
 
 try:
     import confluent_kafka
-    from confluent_kafka import Consumer, Producer, TopicPartition
+    from confluent_kafka import Consumer, Producer, TopicPartition, KafkaException
     from confluent_kafka.admin import AdminClient, NewTopic
 
     KAFKA_CONNECTION_ERRORS = ()
@@ -86,7 +86,7 @@ logger = get_logger(__name__)
 DEFAULT_PORT = 9092
 
 
-class NoBrokersAvailable(confluent_kafka.KafkaException):
+class NoBrokersAvailable(KafkaException):
     """Kafka broker is not available exception."""
 
     retriable = True

--- a/requirements/extras/confluentkafka.txt
+++ b/requirements/extras/confluentkafka.txt
@@ -1,1 +1,1 @@
-confluent-kafka==2.1.1
+confluent-kafka>=2.2.0

--- a/tox.ini
+++ b/tox.ini
@@ -99,7 +99,7 @@ healthcheck_start_period = 5
 environment = ALLOW_ANONYMOUS_LOGIN=yes
 
 [docker:kafka]
-image = bitnami/kafka:3.4.0-debian-11-r21
+image = bitnami/kafka:latest
 ports =
     9092:9092/tcp
 healthcheck_cmd = /bin/bash -c 'kafka-topics.sh --list --bootstrap-server 127.0.0.1:9092'

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     {pypy3.9,3.8,3.9,3.10,3.11,3.12}-linux-integration-py-amqp
     {pypy3.9,3.8,3.9,3.10,3.11}-linux-integration-redis
     {pypy3.9,3.8,3.9,3.10,3.11}-linux-integration-mongodb
-    {3.8,3.9,3.10,3.11}-linux-integration-kafka
+    {3.8,3.9,3.10,3.11,3.12}-linux-integration-kafka
     flake8
     apicheck
     pydocstyle
@@ -29,7 +29,7 @@ deps=
     apicheck,pypy3.9,3.8,3.9,3.10,3.11,3.12: -r{toxinidir}/requirements/default.txt
     apicheck,pypy3.9,3.8,3.9,3.10,3.11,3.12: -r{toxinidir}/requirements/test.txt
     apicheck,pypy3.9,3.8,3.9,3.10,3.11,3.12: -r{toxinidir}/requirements/test-ci.txt
-    apicheck,3.8-linux,3.9-linux,3.10-linux,3.11-linux: -r{toxinidir}/requirements/extras/confluentkafka.txt
+    apicheck,3.8-linux,3.9-linux,3.10-linux,3.11-linux,3.12-linux: -r{toxinidir}/requirements/extras/confluentkafka.txt
     apicheck,linkcheck: -r{toxinidir}/requirements/docs.txt
     flake8,pydocstyle,mypy: -r{toxinidir}/requirements/pkgutils.txt
 


### PR DESCRIPTION
 class NoBrokersAvailable(confluent_kafka.KafkaException):
E   AttributeError: 'NoneType' object has no attribute 'KafkaException'

kombu/transport/confluentkafka.py:89: AttributeError
=============================== warnings summary ===============================
t/integration/test_kafka.py:46