### PR TITLE
azure service bus: fix TypeError when using Managed Identities

### DIFF
--- a/kombu/transport/azureservicebus.py
+++ b/kombu/transport/azureservicebus.py
@@ -481,7 +481,7 @@ class Transport(virtual.Transport):
     @classmethod
     def as_uri(cls, uri: str, include_password=False, mask='**') -> str:
         namespace, credential = cls.parse_uri(uri)
-        if ":" in credential:
+        if isinstance(credential, str) and ":" in credential:
             policy, sas_key = credential.split(':', 1)
             return 'azureservicebus://{}:{}@{}'.format(
                 policy,
@@ -490,6 +490,6 @@ class Transport(virtual.Transport):
             )
 
         return 'azureservicebus://{}@{}'.format(
-            credential,
+            credential.__class__.__name__,
             namespace
         )

--- a/t/unit/transport/test_azureservicebus.py
+++ b/t/unit/transport/test_azureservicebus.py
@@ -450,7 +450,6 @@ def test_basic_ack_reject_message_when_raises_exception(
 
 def test_returning_sas():
     conn = Connection(URL_CREDS_SAS, transport=azureservicebus.Transport)
-    print(conn.as_uri(True))
     assert conn.as_uri(True) == URL_CREDS_SAS
 
 

--- a/t/unit/transport/test_azureservicebus.py
+++ b/t/unit/transport/test_azureservicebus.py
@@ -455,7 +455,6 @@ def test_returning_sas():
 
 def test_returning_da():
     conn = Connection(URL_CREDS_DA, transport=azureservicebus.Transport)
-    print(conn.as_uri(True))
     assert conn.as_uri(True) == URL_CREDS_DA
 
 

--- a/t/unit/transport/test_azureservicebus.py
+++ b/t/unit/transport/test_azureservicebus.py
@@ -446,3 +446,21 @@ def test_basic_ack_reject_message_when_raises_exception(
         assert mock_queue.channel._get_asb_receiver.call_count == 1
         assert queue_object_mock.receiver.complete_message.call_count == 1
         assert super_basic_reject.call_count == 1
+
+
+def test_returning_sas():
+    conn = Connection(URL_CREDS_SAS, transport=azureservicebus.Transport)
+    print(conn.as_uri(True))
+    assert conn.as_uri(True) == URL_CREDS_SAS
+
+
+def test_returning_da():
+    conn = Connection(URL_CREDS_DA, transport=azureservicebus.Transport)
+    print(conn.as_uri(True))
+    assert conn.as_uri(True) == URL_CREDS_DA
+
+
+def test_returning_mi():
+    conn = Connection(URL_CREDS_MI, transport=azureservicebus.Transport)
+    print(conn.as_uri(True))
+    assert conn.as_uri(True) == URL_CREDS_MI

--- a/t/unit/transport/test_azureservicebus.py
+++ b/t/unit/transport/test_azureservicebus.py
@@ -460,5 +460,4 @@ def test_returning_da():
 
 def test_returning_mi():
     conn = Connection(URL_CREDS_MI, transport=azureservicebus.Transport)
-    print(conn.as_uri(True))
     assert conn.as_uri(True) == URL_CREDS_MI


### PR DESCRIPTION
When trying the new version of Kombu I get the following error:
```
TypeError("argument of type 'DefaultAzureCredential' is not iterable")
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/celery/worker/worker.py", line 202, in start
    self.blueprint.start(self)
  File "/usr/local/lib/python3.8/dist-packages/celery/bootsteps.py", line 112, in start
    self.on_start()
  File "/usr/local/lib/python3.8/dist-packages/celery/apps/worker.py", line 135, in on_start
    self.emit_banner()
  File "/usr/local/lib/python3.8/dist-packages/celery/apps/worker.py", line 169, in emit_banner
    ' \n', self.startup_info(artlines=not use_image))),
  File "/usr/local/lib/python3.8/dist-packages/celery/apps/worker.py", line 230, in startup_info
    conninfo=self.app.connection().as_uri(),
  File "/usr/local/lib/python3.8/dist-packages/kombu/connection.py", line 715, in as_uri
    return self.transport.as_uri(
  File "/usr/local/lib/python3.8/dist-packages/kombu/transport/azureservicebus.py", line 484, in as_uri
    if ":" in credential:
TypeError: argument of type 'DefaultAzureCredential' is not iterable
```
Since I don't understand the meaning of the as_url function I just fixed the error locally. Feedback is welcome :)