### PR TITLE
fix(docs): add Redis to the list of transports where SSL is supported

### DIFF
--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -82,7 +82,7 @@ class Connection:
 
     Note:
     ----
-        SSL currently only works with the py-amqp, and qpid
+        SSL currently only works with the py-amqp, qpid and redis
         transports.  For other transports you can use stunnel.
 
     Arguments:


### PR DESCRIPTION
Hey,

* Ran into this when trying to setup `celery` configuration to correctly support SSL using a Redis backend. It *is* supported but this bit of documentation had me second guessing things
* As-per [my comment](https://github.com/celery/kombu/issues/1493#issuecomment-1829589295) on #1493 with a working configuration, this is working as expected in the current release

