### PR TITLE
Fixed Improper Method Call: Replaced `mktemp`

### DIFF
--- a/kombu/utils/div.py
+++ b/kombu/utils/div.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+import os
 
 from .encoding import default_encode
 
@@ -10,13 +11,14 @@ from .encoding import default_encode
 def emergency_dump_state(state, open_file=open, dump=None, stderr=None):
     """Dump message state to stdout or file."""
     from pprint import pformat
-    from tempfile import mktemp
+    from tempfile import mkstemp
     stderr = sys.stderr if stderr is None else stderr
 
     if dump is None:
         import pickle
         dump = pickle.dump
-    persist = mktemp()
+    fd, persist = mkstemp()
+    os.close(fd)
     print(f'EMERGENCY DUMP STATE TO FILE -> {persist} <-',
           file=stderr)
     fh = open_file(persist, 'w')

--- a/kombu/utils/div.py
+++ b/kombu/utils/div.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import sys
 import os
+import sys
 
 from .encoding import default_encode
 


### PR DESCRIPTION
## Details
While triaging your project, our bug fixing tool generated the following message(s)-

> In file: [div.py](https://github.com/celery/kombu/blob/main/kombu/utils/div.py#L19), there is a method that creates a temporary file using an unsafe API `mktemp`. The use of this method is discouraged in the [Python documentation](https://docs.python.org/3/library/tempfile.html#tempfile.mktemp). iCR suggested that a temporary file should be created using `mkstemp` which is a [safe API](https://docs.python.org/3/library/tempfile.html#tempfile.mkstemp). iCR replaced the usage of mktemp with `mkstemp`.


#### Resources Related to `mktemp`
- [POC - Improper Method Call - python - mktemp.mp4](https://drive.google.com/file/d/16YKuKgv7iItWcac2biRyi2Cm8upJ3HP_/view?usp=share_link)
- [MISC - Python - Taking a peek under the tempfile library.mp4](https://drive.google.com/file/d/1ns2_x_ZDvzFwj0eNNxyay-HUMclLasNT/view?usp=share_link)


## Changes
- Replaced `mktemp()` method with `mkstemp()`


## Previously Found & Fixed
- https://www.github.com/spcl/dace/pull/1428
- https://www.github.com/invesalius/invesalius3/pull/679
- https://www.github.com/Azure/azure-linux-extensions/pull/1816
- https://www.github.com/celery/billiard/pull/394


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
\- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
