### PR TITLE
fix: freeze set during ticks iter in async hub

### DIFF
--- a/kombu/asynchronous/hub.py
+++ b/kombu/asynchronous/hub.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import errno
 import threading
 from contextlib import contextmanager
+from copy import copy
 from queue import Empty
 from time import sleep
 from types import GeneratorType as generator
@@ -295,7 +296,6 @@ class Hub:
         scheduled = self.timer._queue
         consolidate = self.consolidate
         consolidate_callback = self.consolidate_callback
-        on_tick = self.on_tick
         propagate = self.propagate_errors
 
         while 1:
@@ -307,7 +307,7 @@ class Hub:
 
             poll_timeout = fire_timers(propagate=propagate) if scheduled else 1
 
-            for tick_callback in on_tick:
+            for tick_callback in copy(self.on_tick):
                 tick_callback()
 
             #  print('[[[HUB]]]: %s' % (self.repr_active(),))

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -134,6 +134,7 @@ def get_redis_error_classes():
             IOError,
             OSError,
             exceptions.ConnectionError,
+            exceptions.BusyLoadingError,
             exceptions.AuthenticationError,
             exceptions.TimeoutError)),
         (virtual.Transport.channel_errors + (
@@ -1229,7 +1230,7 @@ class Channel(virtual.Channel):
                 global_keyprefix=self.global_keyprefix,
             )
 
-        return redis.StrictRedis
+        return redis.Redis
 
     @contextmanager
     def conn_or_acquire(self, client=None):

--- a/t/unit/asynchronous/test_hub.py
+++ b/t/unit/asynchronous/test_hub.py
@@ -541,7 +541,6 @@ class test_Hub:
 
         ticks_list[0].assert_has_calls([call()])
         ticks_list[1].assert_has_calls([call(), call()])
-        #self.hub.poller.unregister.assert_called_with()
 
     def test_loop__todo(self):
         deferred = Mock(name='cb_deferred')

--- a/t/unit/asynchronous/test_hub.py
+++ b/t/unit/asynchronous/test_hub.py
@@ -525,6 +525,24 @@ class test_Hub:
         ticks[0].assert_called_once_with()
         ticks[1].assert_called_once_with()
 
+    def test_loop__tick_callbacks_on_ticks_change(self):
+        def callback_1():
+            ticks.remove(ticks_list[0])
+            return Mock(name='cb1')
+
+        ticks_list = [Mock(wraps=callback_1), Mock(name='cb2')]
+        ticks = set(ticks_list)
+
+        self.hub.on_tick = ticks
+        self.hub.poller.unregister = Mock()
+
+        next(self.hub.loop)
+        next(self.hub.loop)
+
+        ticks_list[0].assert_has_calls([call()])
+        ticks_list[1].assert_has_calls([call(), call()])
+        #self.hub.poller.unregister.assert_called_with()
+
     def test_loop__todo(self):
         deferred = Mock(name='cb_deferred')
 


### PR DESCRIPTION
Relates to https://github.com/celery/kombu/issues/1774

With redis broker, when the redis server reaches timeout and celery worker is running a long cpu-intensive task, the transport tick automatically disconnects, and that's expected.

The connection error is thrown by the `redis-py` lib, but before that happens, the redis transport layer is auto-disconnected.
Instead of propagating the `ConnectionError`, the async hub gets its ticks set changed in the middle of the for loop that executes its callbacks, resulting in an error such as `RuntimeError: Set changed size during iteration`.
This happens because one of these callbacks belongs to the transport layer itself.

This solution basically freezes those ticks sets so they keep their consistency until the `ConnectionError` is thrown, which allows the celery worker to automatically recover itself, rather than just teardown due to an unrecoverable error like that one above.
