### PR TITLE
Fix crash when using global_keyprefix with a sentinel connection

### DIFF
--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -1429,7 +1429,7 @@ class SentinelChannel(Channel):
 
         return sentinel_inst.master_for(
             master_name,
-            self.Client,
+            redis.StrictRedis,
         ).connection_pool
 
     def _get_pool(self, asynchronous=False):

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -1429,7 +1429,7 @@ class SentinelChannel(Channel):
 
         return sentinel_inst.master_for(
             master_name,
-            redis.StrictRedis,
+            redis.Redis,
         ).connection_pool
 
     def _get_pool(self, asynchronous=False):

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -1770,6 +1770,7 @@ class test_RedisSentinel:
                 connection.channel().client.global_keyprefix
                 == 'some_prefix'
             )
+            connection.close()
 
 
 class test_GlobalKeyPrefixMixin:

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -1737,15 +1737,18 @@ class test_RedisSentinel:
     def test_can_create_connection_with_global_keyprefix(self):
         from redis.exceptions import ConnectionError
 
-        connection = Connection(
-            'sentinel://localhost:65534/',
-            transport_options={
-                'global_keyprefix': 'some_prefix',
-                'master_name': 'not_important',
-            },
-        )
-        with pytest.raises(ConnectionError):
-            connection.channel()
+        try:
+            connection = Connection(
+                'sentinel://localhost:65534/',
+                transport_options={
+                    'global_keyprefix': 'some_prefix',
+                    'master_name': 'not_important',
+                },
+            )
+            with pytest.raises(ConnectionError):
+                connection.channel()
+        finally:
+            connection.close()
 
     def test_can_create_correct_mixin_with_global_keyprefix(self):
         from kombu.transport.redis import GlobalKeyPrefixMixin

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -1734,6 +1734,40 @@ class test_RedisSentinel:
                 assert (params['connection_class'] is
                         SentinelManagedSSLConnection)
 
+    def test_can_create_connection_with_global_keyprefix(self):
+        from redis.exceptions import ConnectionError
+
+        connection = Connection(
+            'sentinel://localhost:65534/',
+            transport_options={
+                'global_keyprefix': 'some_prefix',
+                'master_name': 'not_important',
+            },
+        )
+        with pytest.raises(ConnectionError):
+            connection.channel()
+
+    def test_can_create_correct_mixin_with_global_keyprefix(self):
+        from kombu.transport.redis import GlobalKeyPrefixMixin
+
+        with patch('redis.sentinel.Sentinel'):
+            connection = Connection(
+                'sentinel://localhost:65534/',
+                transport_options={
+                    'global_keyprefix': 'some_prefix',
+                    'master_name': 'not_important',
+                },
+            )
+
+            assert isinstance(
+                connection.channel().client,
+                GlobalKeyPrefixMixin
+            )
+            assert (
+                connection.channel().client.global_keyprefix
+                == 'some_prefix'
+            )
+
 
 class test_GlobalKeyPrefixMixin:
 


### PR DESCRIPTION
Fix for https://github.com/celery/kombu/issues/1809.

When global_keyprefix is set, self.Client is no longer a class, it is a closure to create the class with the prefix argument.  This breaks in a place that expects this to be a class and not just any callable.  Fortunately, in this particular case, the place that is breaking doesn't actually need or care about the prefix and so it is safe to use the main redis client class.  It only cares about the pool that comes back.  This fix does not prevent the key prefix from being used later by kombu's own client extension.