### PR TITLE
Fix unacknowledge typo in restore_visible()

### DIFF
--- a/kombu/transport/virtual/base.py
+++ b/kombu/transport/virtual/base.py
@@ -304,7 +304,7 @@ class QoS:
             state.restored = True
 
     def restore_visible(self, *args, **kwargs):
-        """Restore any pending unackwnowledged messages.
+        """Restore any pending unacknowledged messages.
 
         To be filled in for visibility_timeout style implementations.
 


### PR DESCRIPTION
There is typo in the spelling of `unacknowledged` in the `restore_visible` function. It is fixed in this PR.