### PR TITLE
Always convert azureservicebus namespace to fully qualified

### DIFF
--- a/kombu/transport/azureservicebus.py
+++ b/kombu/transport/azureservicebus.py
@@ -148,13 +148,8 @@ class Channel(virtual.Channel):
         if ":" in self._credential:
             self._policy, self._sas_key = self._credential.split(':', 1)
 
-        # Convert
-        endpoint = 'sb://' + self._namespace
-        if not endpoint.endswith('.net'):
-            endpoint += '.servicebus.windows.net'
-
         conn_dict = {
-            'Endpoint': endpoint,
+            'Endpoint': 'sb://' + self._namespace,
             'SharedAccessKeyName': self._policy,
             'SharedAccessKey': self._sas_key,
         }
@@ -450,6 +445,9 @@ class Transport(virtual.Transport):
         uri = uri.replace('azureservicebus://', '')
         # > 'rootpolicy:some/key',  'somenamespace'
         credential, namespace = uri.rsplit('@', 1)
+
+        if not namespace.endswith('.net'):
+            namespace += '.servicebus.windows.net'
 
         if "DefaultAzureCredential".lower() == credential.lower():
             if DefaultAzureCredential is None:

--- a/t/unit/transport/test_azureservicebus.py
+++ b/t/unit/transport/test_azureservicebus.py
@@ -133,6 +133,7 @@ def test_queue_service_sas():
         # Ensure that queue_service is cached
         assert channel.queue_service == 'test'
         assert m.from_connection_string.call_count == 1
+        assert channel._namespace == 'hostname.servicebus.windows.net'
 
 
 def test_queue_service_da():
@@ -142,6 +143,7 @@ def test_queue_service_da():
     # Check the DefaultAzureCredential has been parsed from the url correctly
     # and the credential is a ManagedIdentityCredential
     assert isinstance(channel._credential, DefaultAzureCredential)
+    assert channel._namespace == 'hostname.servicebus.windows.net'
 
 
 def test_queue_service_mi():
@@ -151,6 +153,7 @@ def test_queue_service_mi():
     # Check the ManagedIdentityCredential has been parsed from the url
     # correctly and the credential is a ManagedIdentityCredential
     assert isinstance(channel._credential, ManagedIdentityCredential)
+    assert channel._namespace == 'hostname.servicebus.windows.net'
 
 
 def test_conninfo():


### PR DESCRIPTION
Bug from the implementation discussed in issue #1345 