### PR TITLE
Expose cancel callback from py-amqp channel.basic_consume

### DIFF
--- a/kombu/entity.py
+++ b/kombu/entity.py
@@ -722,7 +722,7 @@ class Queue(MaybeChannelBound):
                                         nowait=nowait) or 0
 
     def consume(self, consumer_tag='', callback=None,
-                no_ack=None, nowait=False):
+                no_ack=None, nowait=False, on_cancel=None):
         """Start a queue consumer.
 
         Consumers last as long as the channel they were created on, or
@@ -741,6 +741,9 @@ class Queue(MaybeChannelBound):
             nowait (bool): Do not wait for a reply.
 
             callback (Callable): callback called for each delivered message.
+
+            on_cancel (Callable): callback called on cancel notify received
+                from broker.
         """
         if no_ack is None:
             no_ack = self.no_ack
@@ -750,7 +753,9 @@ class Queue(MaybeChannelBound):
             consumer_tag=consumer_tag or '',
             callback=callback,
             nowait=nowait,
-            arguments=self.consumer_arguments)
+            arguments=self.consumer_arguments,
+            on_cancel=on_cancel,
+        )
 
     def cancel(self, consumer_tag):
         """Cancel a consumer by consumer tag."""

--- a/t/unit/test_entity.py
+++ b/t/unit/test_entity.py
@@ -387,6 +387,22 @@ class test_Queue:
         b.consume('fifafo', None)
         assert 'basic_consume' in b.channel
 
+    def test_consume_with_callbacks(self) -> None:
+        chan = Mock()
+        b = Queue('foo', self.exchange, 'foo', channel=chan)
+        callback = Mock()
+        on_cancel = Mock()
+        b.consume('fifafo', callback=callback, on_cancel=on_cancel)
+        chan.basic_consume.assert_called_with(
+            queue='foo',
+            no_ack=False,
+            consumer_tag='fifafo',
+            callback=callback,
+            nowait=False,
+            arguments=None,
+            on_cancel=on_cancel
+        )
+
     def test_cancel(self) -> None:
         b = Queue('foo', self.exchange, 'foo', channel=get_conn().channel())
         b.cancel('fifafo')

--- a/t/unit/transport/test_pyamqp.py
+++ b/t/unit/transport/test_pyamqp.py
@@ -78,6 +78,12 @@ class test_Channel:
         self.channel.basic_cancel('my-consumer-tag')
         assert 'my-consumer-tag' not in self.channel.no_ack_consumers
 
+    def test_consume_registers_cancel_callback(self):
+        on_cancel = Mock()
+        self.channel.wait_returns = ['my-consumer-tag']
+        self.channel.basic_consume('foo', on_cancel=on_cancel)
+        assert self.channel.cancel_callbacks['my-consumer-tag'] == on_cancel
+
 
 class test_Transport:
 


### PR DESCRIPTION
When broker send Basic.cancel notification, py-amqp default behavior is to raise a ConsumerCancelled exception. It is then treated as an error even if connection and channel are still operationnal and connection is closed.

Basic.cancel may be sent by broker when a queue is deleted or when replicated queue leader change. py-amqp channel.basic_consume allow to define a callback function on this event. It may be useful to register this callback from kombu when consuming from a queue.