### PR TITLE
enhance: allow users to disable broker heartbeats 

### DIFF
--- a/kombu/mixins.py
+++ b/kombu/mixins.py
@@ -195,10 +195,11 @@ class ConsumerMixin:
                 try:
                     conn.drain_events(timeout=safety_interval)
                 except socket.timeout:
-                    conn.heartbeat_check()
-                    elapsed += safety_interval
-                    if timeout and elapsed >= timeout:
-                        raise
+                    if timeout:
+                        conn.heartbeat_check()
+                        elapsed += safety_interval
+                        if elapsed >= timeout:
+                            raise
                 except OSError:
                     if not self.should_stop:
                         raise


### PR DESCRIPTION
broker heartbeats clutter the logs console which prevents users from seeing important logs. this allows users to disable broker heartbeats if timeout isn't provided.

[reference issue](https://github.com/celery/kombu/issues/1997)
