### PR TITLE
enable/fix test_etcd.py (resolves #2001)

### DIFF
--- a/requirements/test-ci.txt
+++ b/requirements/test-ci.txt
@@ -15,3 +15,4 @@ urllib3>=1.26.16; sys_platform != 'win32'
 -r extras/brotli.txt
 -r extras/zstd.txt
 -r extras/sqlalchemy.txt
+-r extras/etcd.txt


### PR DESCRIPTION
Enabled and fixed test_etcd.py. See [Issue 2001](https://github.com/celery/kombu/issues/2001).

Added etcd requirements and fixed the test in line with test_consul.py