### PR TITLE
Fix Redis connections after reconnect - consumer starts consuming the tasks after crash.

### DIFF
--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -56,8 +56,8 @@ failover_strategies = {
     'shuffle': shufflecycle,
 }
 
-_log_connection = os.environ.get('KOMBU_LOG_CONNECTION', False)
-_log_channel = os.environ.get('KOMBU_LOG_CHANNEL', False)
+_log_connection = os.environ.get('KOMBU_LOG_CONNECTION', True)
+_log_channel = os.environ.get('KOMBU_LOG_CHANNEL', True)
 
 
 class Connection:

--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -56,8 +56,8 @@ failover_strategies = {
     'shuffle': shufflecycle,
 }
 
-_log_connection = os.environ.get('KOMBU_LOG_CONNECTION', True)
-_log_channel = os.environ.get('KOMBU_LOG_CHANNEL', True)
+_log_connection = os.environ.get('KOMBU_LOG_CONNECTION', False)
+_log_channel = os.environ.get('KOMBU_LOG_CHANNEL', False)
 
 
 class Connection:

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -1204,7 +1204,7 @@ class Channel(virtual.Channel):
             class Connection(connection_cls):
                 def disconnect(self, *args):
                     super().disconnect(*args)
-                    # We only remove the connection from the poller
+                    # We remove the connection from the poller
                     # only if it has been added properly.
                     if channel._registered:
                         channel._on_connection_disconnect(self)

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -722,7 +722,7 @@ class Channel(virtual.Channel):
 
         if not self.ack_emulation:  # disable visibility timeout
             self.QoS = virtual.QoS
-
+        self._registered = False
         self._queue_cycle = cycle_by_name(self.queue_order_strategy)()
         self.Client = self._get_client()
         self.ResponseError = self._get_response_error()
@@ -747,6 +747,9 @@ class Channel(virtual.Channel):
             raise
 
         self.connection.cycle.add(self)  # add to channel poller.
+        # and set to true after sucessfuly added channel to the poll.
+        self._registered = True
+
         # copy errors, in case channel closed but threads still
         # are still waiting for data.
         self.connection_errors = self.connection.connection_errors
@@ -1201,7 +1204,9 @@ class Channel(virtual.Channel):
             class Connection(connection_cls):
                 def disconnect(self, *args):
                     super().disconnect(*args)
-                    channel._on_connection_disconnect(self)
+                    # We only remove the connection from the poller if it has been added properly
+                    if channel._registered:
+                        channel._on_connection_disconnect(self)
             connection_cls = Connection
 
         connparams['connection_class'] = connection_cls

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -1204,7 +1204,8 @@ class Channel(virtual.Channel):
             class Connection(connection_cls):
                 def disconnect(self, *args):
                     super().disconnect(*args)
-                    # We only remove the connection from the poller if it has been added properly
+                    # We only remove the connection from the poller
+                    # only if it has been added properly.
                     if channel._registered:
                         channel._on_connection_disconnect(self)
             connection_cls = Connection


### PR DESCRIPTION
**TL;DR**
After updating to version 5.2.3, Celery workers stop processing tasks indefinitely after losing connection to the Redis broker.
    This issue does not occur in version 5.2.2. Analysis revealed that the problem is related to the removal of new Redis connections from the `on_tick` method and the behaviour of the `__del__` method, which removes these connections before they are properly registered.
    The solution is to modify the logic for removing connections from on_tick so that only connections that were properly added to the poller are removed, thereby resolving the reconnection issue.

This cannot be made without @ziollek because he figure out the GC problem and proposed a simple solution.
Big thanks to him :)

**Full Description**
_Problem_
After losing connection to the Redis broker, the Celery worker stops consuming tasks indefinitely. This issue didn't occur previously, but it started happening again after version 5.2.3. The discussion is extensive but reveals a few key problems:

- After a few restarts, the Celery worker stops consuming tasks: https://github.com/celery/celery/issues/8030#issuecomment-2067570550
- The problem doesn’t occur in version 5.2.2: https://github.com/celery/celery/issues/8030#issuecomment-1684160184

So, after a deep dive into the topic, we (with Ziolek) have three main questions to answer:

1. What was the change in version 5.2.3?
2. Why does a couple of restarts reveal the problem?
3. Why doesn’t the problem occur on the first reconnection?

_Analysis_
First, we used our VaaS environment to simulate Redis instance restarts. After a few restarts, the Celery worker wouldn’t consume tasks from Redis, so we easily reproduced the error. The problem seems to be a race condition because of non-deterministic behaviour. Sometimes the reconnection cannot be handled after one or two restarts, but sometimes (if you restart it quickly) the reconnection problem occurs even after 10 restarts.
Secondly, we compared the differences between versions 5.2.2 and 5.2.3 and tried to find the main change causing the problem:
https://github.com/celery/kombu/compare/v5.2.2...v5.2.3#diff-203e309d100714904255d0af4500dd295e40e4ffedfdc9295ab3b386718ca87eR1241-R1247.
One of the features added in this version was logic responsible for removing the connection to Redis from the on_tick method if the file descriptors (fds) are added to the set. This was added to fix a memory leak (because earlier on_tick was only adding items and never removing them), but it started causing the reconnection problem.

You may ask why it broken? The simple answer is: because it removes fresh connections to Redis from the connection pool.

How it Works:
After adding more logs and restarting Redis, we see that Celery tries to reconnect. To do that, it creates a new connection (channel) and checks if it can ping the server. If yes, it is added to the poller and on_tick. If the channel isn’t connected, it raises an exception that the connection cannot be established. On the next attempt, the process looks the same.

Here we start asking a question: what happened to those orphan connections? The answer is: the garbage collector (GC) takes place.

The reason why this was non-deterministic is that the GC runs when it can, so it looks like a race condition.

From this, we can figure out how it really works from the beginning:

1. The channel is created but cannot establish a connection to Redis, so it becomes an orphan.
2. The Redis server starts responding.
3. Celery starts the second attempt, creates a new channel, and checks if it can ping Redis. Now it works, so the channel is added to on_tick and the poll, and the rest of the consumers try to start.
4. Meanwhile, the GC gets processor time and starts to remove unused objects by calling the __del__ method if defined.
5. The __del__ method runs reset().
6. The reset function launches disconnect().
7. The disconnect function launches _on_disconnect.
8. The _on_disconnect method removes the newly created, synchronised pub/sub connection to Redis from on_tick.
9. The server is missing mingle and stops consuming the task.
10. It hangs because the Celery cycle works properly but without synchronised functions attached to the set.

_Solution_
We can remove the channel from on_tick only when it was properly added to the poller. To do this, we can start marking the connection that was added to the poll, and in the disconnect function, we only try to remove the connection object that was added to the poller. After adding this logic, the reconnection problem stops occurring.

