### PR TITLE
Limit requests<2.32.0 due to docker-py issue 3256

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -2,3 +2,6 @@ typing_extensions; python_version<"3.10"
 amqp>=5.1.1,<6.0.0
 vine
 backports.zoneinfo[tzdata]>=0.2.1; python_version < '3.9'
+# due to this bug https://github.com/docker/docker-py/issues/3256
+# we need to hard-code the version of requests
+requests<2.32.0

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,9 @@ envlist =
     apicheck
     pydocstyle
 
-requires = tox-docker>=3.0
+requires =
+    tox-docker<=4.1
+    requests<2.32.0
 
 [gh-actions]
 python =

--- a/tox.ini
+++ b/tox.ini
@@ -63,7 +63,7 @@ dockerenv =
     RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=-rabbit tcp_listeners [5672]
 
 [docker:rabbitmq]
-image = rabbitmq:3.12
+image = rabbitmq
 ports = 5672:5672/tcp
 healthcheck_cmd = /bin/bash -c 'rabbitmq-diagnostics ping -q'
 healthcheck_interval = 10

--- a/tox.ini
+++ b/tox.ini
@@ -63,7 +63,7 @@ dockerenv =
     RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=-rabbit tcp_listeners [5672]
 
 [docker:rabbitmq]
-image = rabbitmq
+image = rabbitmq:3.12
 ports = 5672:5672/tcp
 healthcheck_cmd = /bin/bash -c 'rabbitmq-diagnostics ping -q'
 healthcheck_interval = 10


### PR DESCRIPTION
Extracted from https://github.com/celery/kombu/pull/2007 by @awmackowiak

Due to: https://github.com/docker/docker-py/issues/3256