### PR TITLE
enhance: allow uses to disable broker heartbeats by not providing a timeout (#1997,#1998)

### DIFF
--- a/kombu/mixins.py
+++ b/kombu/mixins.py
@@ -195,10 +195,11 @@ class ConsumerMixin:
                 try:
                     conn.drain_events(timeout=safety_interval)
                 except socket.timeout:
-                    conn.heartbeat_check()
-                    elapsed += safety_interval
-                    if timeout and elapsed >= timeout:
-                        raise
+                    if timeout:
+                        conn.heartbeat_check()
+                        elapsed += safety_interval
+                        if elapsed >= timeout:
+                            raise
                 except OSError:
                     if not self.should_stop:
                         raise

--- a/t/unit/test_mixins.py
+++ b/t/unit/test_mixins.py
@@ -110,7 +110,6 @@ class test_ConsumerMixin:
             next(it)
         c.connection.heartbeat_check.assert_not_called()
 
-
     def test_Consumer_context(self):
         c, Acons, Bcons = self._context()
 


### PR DESCRIPTION
Hi,

I took the liberty to add a test case for #1998. I was not able to add to that request so created (upon advise) a new PR with the change in it as well. The original change was done by @smart-programmer and resolves #1997. Hopefully this is enough to close the issues (this, #1997 and #1998).

I basically verified if the heartbeat_check is called/not called based upon the timeout value.