### PR TITLE
ConnectionPool can't be used after .resize(..., reset=True) (resolves #2018)

### DIFF
--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -1065,7 +1065,8 @@ class ConnectionPool(Resource):
     def setup(self):
         if self.limit:
             q = self._resource.queue
-            while len(q) < self.limit:
+            # Keep in mind dirty/used resources
+            while len(q) < self.limit - len(self._dirty):
                 self._resource.put_nowait(lazy(self.new))
 
     def prepare(self, resource):
@@ -1091,7 +1092,8 @@ class ChannelPool(Resource):
         channel = self.new()
         if self.limit:
             q = self._resource.queue
-            while len(q) < self.limit:
+            # Keep in mind dirty/used resources
+            while len(q) < self.limit - len(self._dirty):
                 self._resource.put_nowait(lazy(channel))
 
     def prepare(self, channel):

--- a/kombu/resource.py
+++ b/kombu/resource.py
@@ -144,15 +144,20 @@ class Resource:
     def collect_resource(self, resource):
         pass
 
-    def force_close_all(self):
+    def force_close_all(self, close_pool=True):
         """Close and remove all resources in the pool (also those in use).
 
         Used to close resources from parent processes after fork
         (e.g. sockets/connections).
+
+        Arguments:
+        ---------
+            close_pool (bool): If True (default) then the pool is marked
+                as closed. In case of False the pool can be reused.
         """
         if self._closed:
             return
-        self._closed = True
+        self._closed = close_pool
         dirty = self._dirty
         resource = self._resource
         while 1:  # - acquired
@@ -188,7 +193,7 @@ class Resource:
         self._limit = limit
         if reset:
             try:
-                self.force_close_all()
+                self.force_close_all(close_pool=False)
             except Exception:
                 pass
         self.setup()
@@ -211,7 +216,9 @@ class Resource:
         resource = self._resource
         # Items to the left are last recently used, so we remove those first.
         with getattr(resource, 'mutex', Noop()):
-            while len(resource.queue) > self.limit:
+            # keep in mind teh dirty resources are not shrinked
+            while len(resource.queue) and \
+                    (len(resource.queue) + len(self._dirty)) > self.limit:
                 R = resource.queue.popleft()
                 if collect:
                     self.collect_resource(R)

--- a/kombu/resource.py
+++ b/kombu/resource.py
@@ -216,7 +216,7 @@ class Resource:
         resource = self._resource
         # Items to the left are last recently used, so we remove those first.
         with getattr(resource, 'mutex', Noop()):
-            # keep in mind teh dirty resources are not shrinked
+            # keep in mind the dirty resources are not shrinking
             while len(resource.queue) and \
                     (len(resource.queue) + len(self._dirty)) > self.limit:
                 R = resource.queue.popleft()

--- a/t/unit/test_connection.py
+++ b/t/unit/test_connection.py
@@ -811,6 +811,93 @@ class ResourceCase:
         P = self.create_resource(None)
         P.acquire().release()
 
+    def test_acquire_resize_in_use(self):
+        P = self.create_resource(5)
+        self.assert_state(P, 5, 0)
+        chans = [P.acquire() for _ in range(5)]
+        self.assert_state(P, 0, 5)
+        with pytest.raises(RuntimeError):
+            P.resize(4)
+        [chan.release() for chan in chans]
+        self.assert_state(P, 5, 0)
+
+    def test_acquire_resize_ignore_err_no_shrink(self):
+        P = self.create_resource(5)
+        self.assert_state(P, 5, 0)
+        chans = [P.acquire() for _ in range(5)]
+        self.assert_state(P, 0, 5)
+        P.resize(4, ignore_errors=True)
+        self.assert_state(P, 0, 5)
+        [chan.release() for chan in chans]
+        self.assert_state(P, 5, 0)
+
+    def test_acquire_resize_ignore_err_shrink(self):
+        P = self.create_resource(5)
+        self.assert_state(P, 5, 0)
+        chans = [P.acquire() for _ in range(4)]
+        self.assert_state(P, 1, 4)
+        P.resize(4, ignore_errors=True)
+        self.assert_state(P, 0, 4)
+        [chan.release() for chan in chans]
+        self.assert_state(P, 4, 0)
+
+    def test_acquire_resize_larger(self):
+        P = self.create_resource(1)
+        self.assert_state(P, 1, 0)
+        c1 = P.acquire()
+        self.assert_state(P, 0, 1)
+        with pytest.raises(P.LimitExceeded):
+            P.acquire()
+        P.resize(2)
+        self.assert_state(P, 1, 1)
+        c2 = P.acquire()
+        self.assert_state(P, 0, 2)
+        c1.release()
+        c2.release()
+        self.assert_state(P, 2, 0)
+
+    def test_acquire_resize_force_smaller(self):
+        P = self.create_resource(2)
+        self.assert_state(P, 2, 0)
+        c1 = P.acquire()
+        c2 = P.acquire()
+        self.assert_state(P, 0, 2)
+        with pytest.raises(P.LimitExceeded):
+            P.acquire()
+        P.resize(1, force=True)     # acts like reset
+        del c1
+        del c2
+        self.assert_state(P, 1, 0)
+        c1 = P.acquire()
+        self.assert_state(P, 0, 1)
+        with pytest.raises(P.LimitExceeded):
+            P.acquire()
+        c1.release()
+        self.assert_state(P, 1, 0)
+
+    def test_acquire_resize_reset(self):
+        P = self.create_resource(2)
+        self.assert_state(P, 2, 0)
+        c1 = P.acquire()
+        c2 = P.acquire()
+        self.assert_state(P, 0, 2)
+        with pytest.raises(P.LimitExceeded):
+            P.acquire()
+        P.resize(3, reset=True)
+        del c1
+        del c2
+        self.assert_state(P, 3, 0)
+        c1 = P.acquire()
+        c2 = P.acquire()
+        c3 = P.acquire()
+        self.assert_state(P, 0, 3)
+        with pytest.raises(P.LimitExceeded):
+            P.acquire()
+        c1.release()
+        c2.release()
+        c3.release()
+        self.assert_state(P, 3, 0)
+
     def test_replace_when_limit(self):
         P = self.create_resource(10)
         r = P.acquire()


### PR DESCRIPTION
Hi, can you please have a look at this pull request. It addresses the issue #2018.

What did I do to tackle the issue. First I added several test case for the resize method (in test_connection.py), as they were not available. Basically the test test_acquire_resize_reset() triggered the given issue.

In short the use of force_close_all() (used also in other cases) caused the pool to be set on _closed = True. In the acquire method this resulted in the RuntimeError('Acquire on closed pool'). 

I've added a parameter **close_pool** in force_close_all with default of True (old behaviour as used by other callers), which allows the pool to be kept open if set to False. In the resize method, reset branch I've added force_close_all(close_pool=False).

PLEASE NOTE:
While testing the resize I've found 2 issues related to resizing which I think are a problem. They are addressed as well.
- Issue 1. The resize calls the setup from within connectionPool and channelPool. This method allocated resource based on the current setting of limit. This works fine for fresh pools however if it is called within the resize then with acquired/dirty resources then it would create to many resources. I fixed this by subtracting the amount of dirty resource from the limit. See connection.py:1069/1095
- Issue 2. The _shrink_down (only called by resize) did not keep in mind the dirty resources and would not correctly shrink if there were dirty resouces. Now it shrink resources and leaves the dirty one as it was before. See resource.py:220

Please have a look at the changes,
Regards,

Frank

