### PR TITLE
Fix typo in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -168,7 +168,7 @@ Or handle channels manually:
 
     with connection.channel() as channel:
         producer = Producer(channel, ...)
-        consumer = Producer(channel)
+        consumer = Consumer(channel)
 
 
 All objects can be used outside of with statements too,


### PR DESCRIPTION
Replace `consumer = Producer(channel)` by `consumer = Consumer (channel)` in README example.