### PR TITLE
Exclude Unit 3.9 from CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,9 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        exclude:
+          - python-version: "3.9"
+            reason: "3.9 is currently flaky on GitHub Actions"
     steps:
       - name: Install system packages
         run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev libssl-dev


### PR DESCRIPTION
For some reason, unit tests for python 3.9 are hanging when running via GitHub Actions.
Locally, it passes successfully:
```
  3.8-unit: OK (63.03=setup[21.26]+cmd[41.77] seconds)
  3.9-unit: OK (61.05=setup[20.77]+cmd[40.28] seconds)
  3.10-unit: OK (61.68=setup[20.60]+cmd[41.08] seconds)
  3.11-unit: OK (62.84=setup[20.64]+cmd[42.20] seconds)
  3.12-unit: OK (62.81=setup[22.25]+cmd[40.56] seconds)
```

There wasn’t any PR that made changes that should break `3.9-unit` tests but at this moment this is blocking from the rest of the CI to run and from validating further changes.

This is not ideal and should be reverted as soon as possible, but for now I want to skip 3.9 to allow the rest of the CI to run.

It is less probable that something that passes `3.8-unit` will not also pass `3.9-unit` in case it will be introduced during this time window, so it is not as risky as it looks but will bring out the benefit of being able to continue working on Kombu.

Apart from that, Python 3.9 tests will run as part of the integration tests so this will also reduce the risk of accepting this temporary CI change for now.