### PR TITLE
Fixed CI error from excluding Python 3.9 unit tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,6 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         exclude:
           - python-version: "3.9"
-            reason: "3.9 is currently flaky on GitHub Actions"
     steps:
       - name: Install system packages
         run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev libssl-dev


### PR DESCRIPTION
This should be have been caught during the work on #2046 

In another PR it is worth upgrading the CI yaml, *sigh*...