### PR TITLE
Use logging.Logger.warning

### DIFF
--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -89,7 +89,7 @@ except ImportError:  # pragma: no cover
 
 
 logger = get_logger('kombu.transport.redis')
-crit, warn = logger.critical, logger.warn
+crit, warning = logger.critical, logger.warning
 
 DEFAULT_PORT = 6379
 DEFAULT_DB = 0
@@ -939,8 +939,8 @@ class Channel(virtual.Channel):
                     try:
                         message = loads(bytes_to_str(payload['data']))
                     except (TypeError, ValueError):
-                        warn('Cannot process event on channel %r: %s',
-                             channel, repr(payload)[:4096], exc_info=1)
+                        warning('Cannot process event on channel %r: %s',
+                                channel, repr(payload)[:4096], exc_info=1)
                         raise Empty()
                     exchange = channel.split('/', 1)[0]
                     self.connection._deliver(


### PR DESCRIPTION
Usage of `logging.Logger.warn` was deprecated since Python 3.3 and it will be removed in Python 3.13: https://docs.python.org/3.13/whatsnew/3.13.html#logging

There is a pull request (https://github.com/celery/kombu/pull/2052) with similar changes, however merging that PR will likely take time. At the same time, Fedora 41 comes with Python 3.13 and packages kombu. A similar patch can be found in https://src.fedoraproject.org/rpms/python-kombu/pull-request/10. To avoid the need for distro-specific patches (see https://pkgs.org/search/?q=python3.13 for distros that come with Python 3.13), I propose to make this change in this upstream repository.

Unfortunately, I could not find an easy way to prevent issues like this with linters: the current stable version of `mypy` does not find this issue (`mypy` installed from master can find this issue though). `ruff`, proposed in https://github.com/celery/kombu/issues/2055, does not find this issue: https://github.com/astral-sh/ruff/issues/12295.
