### PR TITLE
SQS: add support for passing MessageAttributes

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -11,7 +11,7 @@
 :release-date: 11 July, 2024
 :release-by: Tomer Nosrati
 
-The ``requests`` is no longer limited to <2.32.0 per #2041.
+The ``requests`` package is no longer limited to <2.32.0 per #2041.
 Contribution #2007 by @awmackowiak was confirmed to have solved the Redis reconnection bug.
 
 - Bump mypy from 1.10.0 to 1.10.1 (#2039)

--- a/docs/reference/kombu.transport.SQS.rst
+++ b/docs/reference/kombu.transport.SQS.rst
@@ -63,3 +63,11 @@ The above policy:
 +-----------------------------------------+--------------------------------------------+
 | ``6th attempt``                         | 640 seconds                                |
 +-----------------------------------------+--------------------------------------------+
+
+
+Message Attributes
+------------------------
+
+SQS supports sending message attributes along with the message body.
+To use this feature, you can pass a 'message_attributes' as keyword argument
+to `basic_publish` method.

--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -34,6 +34,14 @@ up to 'prefetch_count' messages from queueA and work on them all before
 moving on to queueB.  If queueB is empty, it will wait up until
 'polling_interval' expires before moving back and checking on queueA.
 
+Message Attributes
+-----------------
+https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-metadata.html
+
+SQS supports sending message attributes along with the message body.
+To use this feature, you can pass a 'message_attributes' as keyword argument
+to `basic_publish` method.
+
 Other Features supported by this transport
 ==========================================
 Predefined Queues

--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -412,13 +412,12 @@ class Channel(virtual.Channel):
     def _put(self, queue, message, **kwargs):
         """Put message onto queue."""
         q_url = self._new_queue(queue)
-        if self.sqs_base64_encoding:
-            body = AsyncMessage().encode(dumps(message))
-        else:
-            body = dumps(message)
-        kwargs = {'QueueUrl': q_url, 'MessageBody': body}
-
+        kwargs = {'QueueUrl': q_url}
         if 'properties' in message:
+            if 'message_attributes' in message['properties']:
+                # we don't want to want to have the attribute in the body
+                kwargs['MessageAttributes'] = \
+                    message['properties'].pop('message_attributes')
             if queue.endswith('.fifo'):
                 if 'MessageGroupId' in message['properties']:
                     kwargs['MessageGroupId'] = \
@@ -434,6 +433,13 @@ class Channel(virtual.Channel):
                 if "DelaySeconds" in message['properties']:
                     kwargs['DelaySeconds'] = \
                         message['properties']['DelaySeconds']
+
+        if self.sqs_base64_encoding:
+            body = AsyncMessage().encode(dumps(message))
+        else:
+            body = dumps(message)
+        kwargs['MessageBody'] = body
+
         c = self.sqs(queue=self.canonical_queue_name(queue))
         if message.get('redelivered'):
             c.change_message_visibility(

--- a/t/unit/transport/test_SQS.py
+++ b/t/unit/transport/test_SQS.py
@@ -107,13 +107,14 @@ class SQSClientMock:
     def get_queue_url(self, QueueName=None):
         return self._queues[QueueName]
 
-    def send_message(self, QueueUrl=None, MessageBody=None):
+    def send_message(self, QueueUrl=None, MessageBody=None, MessageAttributes=None):
         for q in self._queues.values():
             if q.url == QueueUrl:
                 handle = ''.join(random.choice(string.ascii_lowercase) for
                                  x in range(10))
                 q.messages.append({'Body': MessageBody,
-                                   'ReceiptHandle': handle})
+                                   'ReceiptHandle': handle,
+                                   'MessageAttributes': MessageAttributes})
                 break
 
     def receive_message(self, QueueUrl=None, MaxNumberOfMessages=1,

--- a/t/unit/transport/test_SQS.py
+++ b/t/unit/transport/test_SQS.py
@@ -472,7 +472,7 @@ class test_Channel:
             'WaitTimeSeconds': self.channel.wait_time_seconds,
         }
         assert get_list_args[3] == \
-               self.channel.sqs().get_queue_url(self.queue_name).url
+            self.channel.sqs().get_queue_url(self.queue_name).url
         assert get_list_kwargs['parent'] == self.queue_name
 
     def test_drain_events_with_empty_list(self):
@@ -977,3 +977,15 @@ class test_Channel:
 
         # Assert
         mock_generate_sts_session_token.assert_not_called()
+
+    def test_message_attribute(self):
+        message = 'my test message'
+        self.producer.publish(message, message_attributes={
+            'Attribute1': {'DataType': 'String',
+                           'StringValue': 'STRING_VALUE'}
+        }
+        )
+        output_message = self.queue(self.channel).get()
+        assert message == output_message.payload
+        # It's not propogated to the properties
+        assert 'message_attributes' not in output_message.properties

--- a/t/unit/transport/test_SQS.py
+++ b/t/unit/transport/test_SQS.py
@@ -107,7 +107,8 @@ class SQSClientMock:
     def get_queue_url(self, QueueName=None):
         return self._queues[QueueName]
 
-    def send_message(self, QueueUrl=None, MessageBody=None, MessageAttributes=None):
+    def send_message(self, QueueUrl=None, MessageBody=None,
+                     MessageAttributes=None):
         for q in self._queues.values():
             if q.url == QueueUrl:
                 handle = ''.join(random.choice(string.ascii_lowercase) for


### PR DESCRIPTION
Hi!
I looked for a contributing guide and couldn't find one, so apologies if I missed any requirement/need.

SQS supports MessageAttributes, and with this PR, users using celery can easily add message attributes like this:
```python
from celery import Celery, signature

# Initialize the Celery app with SQS as the broker
app = Celery('sqs_producer', broker='sqs://')

# AWS configuration
app.conf.update(
    broker_transport_options={
        'region': 'eu-north-1',
        'polling_interval': 1,
    },
    task_default_queue='ManualTesting1'
)


# Custom signature function
def custom_signature(message_body):
    return signature('sqs_producer.send_message_to_sqs', args=(message_body,))

if __name__ == '__main__':
    message_body = {
        'key1': 'value1',
        'key2': 'value2'
    }
    # Using the custom signature to create a task
    task = custom_signature(message_body)
    # Apply the task asynchronously
    result = task.apply_async(message_attributes = {
    'Attribute1': {'DataType': 'String',
            'StringValue': 'STRING_VALUE'}
    })

```

Notes:
- I don't put the message attributes into the message properties - I feel that's a bit weird to include it there, but would understand if that might be problematic (if someone used this attribute before and now it won't appear)

This is probably useful for many reasons, but in our case it's blocking use of feature we provide over it - https://github.com/metalbear-co/mirrord/issues/2066