### PR TITLE
Resolving TypeError, during version unpacking 

### DIFF
--- a/kombu/utils/text.py
+++ b/kombu/utils/text.py
@@ -1,4 +1,5 @@
 """Text Utilities."""
+
 # flake8: noqa
 
 
@@ -11,16 +12,19 @@ from typing import Iterable, Iterator
 from kombu import version_info_t
 
 
-def escape_regex(p, white=''):
+def escape_regex(p, white=""):
     # type: (str, str) -> str
     """Escape string for use within a regular expression."""
     # what's up with re.escape? that code must be neglected or something
-    return ''.join(c if c.isalnum() or c in white
-                   else ('\\000' if c == '\000' else '\\' + c)
-                   for c in p)
+    return "".join(
+        c if c.isalnum() or c in white else ("\\000" if c == "\000" else "\\" + c)
+        for c in p
+    )
 
 
-def fmatch_iter(needle: str, haystack: Iterable[str], min_ratio: float = 0.6) -> Iterator[tuple[float, str]]:
+def fmatch_iter(
+    needle: str, haystack: Iterable[str], min_ratio: float = 0.6
+) -> Iterator[tuple[float, str]]:
     """Fuzzy match: iteratively.
 
     Yields
@@ -33,23 +37,41 @@ def fmatch_iter(needle: str, haystack: Iterable[str], min_ratio: float = 0.6) ->
             yield ratio, key
 
 
-def fmatch_best(needle: str, haystack: Iterable[str], min_ratio: float = 0.6) -> str | None:
+def fmatch_best(
+    needle: str, haystack: Iterable[str], min_ratio: float = 0.6
+) -> str | None:
     """Fuzzy match - Find best match (scalar)."""
     try:
         return sorted(
-            fmatch_iter(needle, haystack, min_ratio), reverse=True,
-        )[0][1]
+            fmatch_iter(needle, haystack, min_ratio),
+            reverse=True,
+        )[
+            0
+        ][1]
     except IndexError:
         return None
 
 
 def version_string_as_tuple(version: str) -> version_info_t:
-    """
-    This is a function for parsing the version into
-    meaningful comment.
-    """
+    """Parse a version string into its components and return a version_info_t tuple.
 
-    # regex pattern to match the different parts of the version string
+    The version string is expected to follow the pattern:
+    'major.minor.micro[releaselevel][serial]'. Each component of the version
+    is extracted and returned as a tuple in the format (major, minor, micro,
+    releaselevel, serial).
+
+    Args
+    ----
+        version (str): The version string to parse.
+
+    Returns
+    -------
+        version_info_t: A tuple containing the parsed version components.
+
+    Raises
+    ------
+        ValueError: If the version string is invalid and does not match the expected pattern.
+    """
     pattern = r"^(\d+)"  # catching the major version (mandatory)
     pattern += r"(?:\.(\d+))?"  # optionally catching the minor version
     pattern += r"(?:\.(\d+))?"  # optionally catching the micro version
@@ -76,13 +98,15 @@ def _unpack_version(
     major: str,
     minor: str | int = 0,
     micro: str | int = 0,
-    releaselevel: str = '',
-    serial: str = '',
+    releaselevel: str = "",
+    serial: str = "",
 ) -> version_info_t:
     return version_info_t(int(major), int(minor), micro, releaselevel, serial)
 
 
-def _splitmicro(micro: str, releaselevel: str = '', serial: str = '') -> tuple[int, str, str]:
+def _splitmicro(
+    micro: str, releaselevel: str = "", serial: str = ""
+) -> tuple[int, str, str]:
     for index, char in enumerate(micro):
         if not char.isdigit():
             break

--- a/kombu/utils/text.py
+++ b/kombu/utils/text.py
@@ -12,12 +12,12 @@ from typing import Iterable, Iterator
 from kombu import version_info_t
 
 
-def escape_regex(p, white=""):
+def escape_regex(p, white=''):
     # type: (str, str) -> str
     """Escape string for use within a regular expression."""
     # what's up with re.escape? that code must be neglected or something
-    return "".join(
-        c if c.isalnum() or c in white else ("\\000" if c == "\000" else "\\" + c)
+    return ''.join(
+        c if c.isalnum() or c in white else ('\\000' if c == '\000' else '\\' + c)
         for c in p
     )
 
@@ -72,11 +72,11 @@ def version_string_as_tuple(version: str) -> version_info_t:
     ------
         ValueError: If the version string is invalid and does not match the expected pattern.
     """
-    pattern = r"^(\d+)"  # catching the major version (mandatory)
-    pattern += r"(?:\.(\d+))?"  # optionally catching the minor version
-    pattern += r"(?:\.(\d+))?"  # optionally catching the micro version
-    pattern += r"(?:\.*([a-zA-Z+-][\da-zA-Z+-]*))?"  # optionally catching the release level (starting with a letter, + or -) after a dot
-    pattern += r"(?:\.(.*))?"  # optionally catching the serial number after a dot
+    pattern = r'^(\d+)'  # catching the major version (mandatory)
+    pattern += r'(?:\.(\d+))?'  # optionally catching the minor version
+    pattern += r'(?:\.(\d+))?'  # optionally catching the micro version
+    pattern += r'(?:\.*([a-zA-Z+-][\da-zA-Z+-]*))?'  # optionally catching the release level (starting with a letter, + or -) after a dot
+    pattern += r'(?:\.(.*))?'  # optionally catching the serial number after a dot
 
     # applying the regex pattern to the input version string
     match = re.match(pattern, version)
@@ -88,24 +88,24 @@ def version_string_as_tuple(version: str) -> version_info_t:
     major = int(match.group(1))
     minor = int(match.group(2)) if match.group(2) else 0
     micro = int(match.group(3)) if match.group(3) else 0
-    releaselevel = match.group(4) if match.group(4) else ""
-    serial = match.group(5) if match.group(5) else ""
+    releaselevel = match.group(4) if match.group(4) else ''
+    serial = match.group(5) if match.group(5) else ''
 
     return _unpack_version(major, minor, micro, releaselevel, serial)
 
 
 def _unpack_version(
-    major: str,
+    major: str | int = 0,
     minor: str | int = 0,
     micro: str | int = 0,
-    releaselevel: str = "",
-    serial: str = "",
+    releaselevel: str = '',
+    serial: str = '',
 ) -> version_info_t:
-    return version_info_t(int(major), int(minor), micro, releaselevel, serial)
+    return version_info_t(int(major), int(minor), int(micro), releaselevel, serial)
 
 
 def _splitmicro(
-    micro: str, releaselevel: str = "", serial: str = ""
+    micro: str, releaselevel: str = '', serial: str = ''
 ) -> tuple[int, str, str]:
     for index, char in enumerate(micro):
         if not char.isdigit():

--- a/kombu/utils/text.py
+++ b/kombu/utils/text.py
@@ -6,11 +6,7 @@ from __future__ import annotations
 
 import re
 from difflib import SequenceMatcher
-<<<<<<< HEAD
 from typing import Iterable, Iterator
-=======
-from typing import Iterable, Iterator, Tuple
->>>>>>> b8cf3ab6c566bc61da06943a5e2c0d56b51cdaa1
 
 from kombu import version_info_t
 

--- a/kombu/utils/text.py
+++ b/kombu/utils/text.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from difflib import SequenceMatcher
 from typing import Iterable, Iterator
-
+from typing import Tuple
 from kombu import version_info_t
 
 
@@ -59,7 +59,8 @@ def _unpack_version(
     minor: str | int = 0,
     micro: str | int = 0,
     releaselevel: str = '',
-    serial: str = ''
+    serial: str = '',
+    *args: Tuple[str]
 ) -> version_info_t:
     return version_info_t(int(major), int(minor), micro, releaselevel, serial)
 

--- a/t/unit/utils/test_utils.py
+++ b/t/unit/utils/test_utils.py
@@ -8,15 +8,23 @@ from kombu.utils.text import version_string_as_tuple
 
 def test_dir():
     import kombu
+
     assert dir(kombu)
 
 
-@pytest.mark.parametrize('version,expected', [
-    ('3', version_info_t(3, 0, 0, '', '')),
-    ('3.3', version_info_t(3, 3, 0, '', '')),
-    ('3.3.1', version_info_t(3, 3, 1, '', '')),
-    ('3.3.1a3', version_info_t(3, 3, 1, 'a3', '')),
-    ('3.3.1.a3.40c32', version_info_t(3, 3, 1, 'a3', '40c32')),
-])
+@pytest.mark.parametrize(
+    "version,expected",
+    [
+        ("3", version_info_t(3, 0, 0, "", "")),
+        ("3.3", version_info_t(3, 3, 0, "", "")),
+        ("3.3.1", version_info_t(3, 3, 1, "", "")),
+        ("3.3.1a3", version_info_t(3, 3, 1, "a3", "")),
+        ("3.3.1.a3.40c32", version_info_t(3, 3, 1, "a3", "40c32")),
+        ("4.0.0+beta.3.47.g4f1a05b", version_info_t(4, 0, 0, "+beta", "3.47.g4f1a05b")),
+        ("4.0.0-beta3.47.g4f1a05b", version_info_t(4, 0, 0, "-beta3", "47.g4f1a05b")),
+        ("4.0.1-alpha.3+40c32", version_info_t(4, 0, 1, "-alpha", "3+40c32")),
+        ("0+beta3.14159265", version_info_t(0, 0, 0, "+beta3", "14159265")),
+    ],
+)
 def test_version_string_as_tuple(version, expected):
     assert version_string_as_tuple(version) == expected

--- a/t/unit/utils/test_utils.py
+++ b/t/unit/utils/test_utils.py
@@ -20,8 +20,10 @@ def test_dir():
         ("3.3.1", version_info_t(3, 3, 1, "", "")),
         ("3.3.1a3", version_info_t(3, 3, 1, "a3", "")),
         ("3.3.1.a3.40c32", version_info_t(3, 3, 1, "a3", "40c32")),
-        ("4.0.0+beta.3.47.g4f1a05b", version_info_t(4, 0, 0, "+beta", "3.47.g4f1a05b")),
-        ("4.0.0-beta3.47.g4f1a05b", version_info_t(4, 0, 0, "-beta3", "47.g4f1a05b")),
+        ("4.0.0+beta.3.47.g4f1a05b", version_info_t(
+            4, 0, 0, "+beta", "3.47.g4f1a05b")),
+        ("4.0.0-beta3.47.g4f1a05b", version_info_t(
+            4, 0, 0, "-beta3", "47.g4f1a05b")),
         ("4.0.1-alpha.3+40c32", version_info_t(4, 0, 1, "-alpha", "3+40c32")),
         ("0+beta3.14159265", version_info_t(0, 0, 0, "+beta3", "14159265")),
     ],

--- a/t/unit/utils/test_utils.py
+++ b/t/unit/utils/test_utils.py
@@ -13,19 +13,19 @@ def test_dir():
 
 
 @pytest.mark.parametrize(
-    "version,expected",
+    'version,expected',
     [
-        ("3", version_info_t(3, 0, 0, "", "")),
-        ("3.3", version_info_t(3, 3, 0, "", "")),
-        ("3.3.1", version_info_t(3, 3, 1, "", "")),
-        ("3.3.1a3", version_info_t(3, 3, 1, "a3", "")),
-        ("3.3.1.a3.40c32", version_info_t(3, 3, 1, "a3", "40c32")),
-        ("4.0.0+beta.3.47.g4f1a05b", version_info_t(
-            4, 0, 0, "+beta", "3.47.g4f1a05b")),
-        ("4.0.0-beta3.47.g4f1a05b", version_info_t(
-            4, 0, 0, "-beta3", "47.g4f1a05b")),
-        ("4.0.1-alpha.3+40c32", version_info_t(4, 0, 1, "-alpha", "3+40c32")),
-        ("0+beta3.14159265", version_info_t(0, 0, 0, "+beta3", "14159265")),
+        ('3', version_info_t(3, 0, 0, '', '')),
+        ('3.3', version_info_t(3, 3, 0, '', '')),
+        ('3.3.1', version_info_t(3, 3, 1, '', '')),
+        ('3.3.1a3', version_info_t(3, 3, 1, 'a3', '')),
+        ('3.3.1.a3.40c32', version_info_t(3, 3, 1, 'a3', '40c32')),
+        ('4.0.0+beta.3.47.g4f1a05b', version_info_t(
+            4, 0, 0, '+beta', '3.47.g4f1a05b')),
+        ('4.0.0-beta3.47.g4f1a05b', version_info_t(
+            4, 0, 0, '-beta3', '47.g4f1a05b')),
+        ('4.0.1-alpha.3+40c32', version_info_t(4, 0, 1, '-alpha', '3+40c32')),
+        ('0+beta3.14159265', version_info_t(0, 0, 0, '+beta3', '14159265')),
     ],
 )
 def test_version_string_as_tuple(version, expected):


### PR DESCRIPTION
This will make sure that the version unpacking doesn't stop connection to some versions of message brokers. For message brokers with normal-style version, say 3.13.6, 
```Pyhon
def version_string_as_tuple(s: str) -> version_info_t:
    """Convert version string to version info tuple."""
    v = _unpack_version(*s.split('.'))
    ...
```
will result in `['3', '13', '6']` list. But for newer releases of rabbitmq, say when you pull docker image using a specified version, in my case `4.0-rc` as discussed in this  [issue](https://github.com/celery/celery/issues/9161#issuecomment-2288083848) related to #2088 it becomes this:
```Python
['4', '0', '0+beta', '2', '6', 'g65c3daf']
```
which causes that `TypeError`.