### PR TITLE
SQS: Fixes #2091 queue_delete() method doesn't actually delete the queue

### DIFF
--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -384,7 +384,7 @@ class Channel(virtual.Channel):
                 ).format(sqs_qname))
 
             raise DoesNotExistQueueException(
-                "Queue with name '{}' doesn't exist in SQS".format(sqs_qname)
+                f"Queue with name '{sqs_qname}' doesn't exist in SQS"
             )
 
     def _new_queue(self, queue, **kwargs):

--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -428,7 +428,11 @@ class Channel(virtual.Channel):
         """Delete queue by name."""
         if self.predefined_queues:
             return
-        super()._delete(queue)
+
+        q_url = self._resolve_queue_url(queue)
+        self.sqs().delete_queue(
+            QueueUrl=q_url,
+        )
         self._queue_cache.pop(queue, None)
 
     def _put(self, queue, message, **kwargs):

--- a/t/unit/transport/test_SQS.py
+++ b/t/unit/transport/test_SQS.py
@@ -262,6 +262,11 @@ class test_Channel:
             'foo-bar-baz_qux_quux'
         assert self.channel.entity_name('abcdef.fifo') == 'abcdef.fifo'
 
+    def test_resolve_queue_url(self):
+        queue_name = 'unittest_queue'
+        assert self.sqs_conn_mock._queues[queue_name].url == \
+            self.channel._resolve_queue_url(queue_name)
+
     def test_new_queue(self):
         queue_name = 'new_unittest_queue'
         self.channel._new_queue(queue_name)

--- a/t/unit/transport/test_SQS.py
+++ b/t/unit/transport/test_SQS.py
@@ -137,6 +137,16 @@ class SQSClientMock:
             if q.url == QueueUrl:
                 q.messages = []
 
+    def delete_queue(self, QueueUrl=None):
+        queue_name = None
+        for key, val in self._queues.items():
+            if val.url == QueueUrl:
+                queue_name = key
+                break
+        if queue_name is None:
+            raise Exception(f"Queue url {QueueUrl} not found")
+        del self._queues[queue_name]
+
 
 class test_Channel:
 
@@ -321,6 +331,7 @@ class test_Channel:
         self.channel._new_queue(queue_name)
         self.channel._delete(queue_name)
         assert queue_name not in self.channel._queue_cache
+        assert queue_name not in self.sqs_conn_mock._queues
 
     def test_get_from_sqs(self):
         # Test getting a single message


### PR DESCRIPTION
Fix for issue [#2091](https://github.com/celery/kombu/issues/2091)

`.queue_delete()` method of SQS channel is not actually deleting the queue. See implementation [here](https://github.com/celery/kombu/blob/1dddf9949fd763da03128bfa0c96fa92446c0146/kombu/transport/SQS.py#L413).

```
    def _delete(self, queue, *args, **kwargs):
        """Delete queue by name."""
        if self.predefined_queues:
            return
        super()._delete(queue)
        self._queue_cache.pop(queue, None)
```

* I managed to call `delete_queue` using sqs client (`boto3`).
* I wrapped logic to resolve queue URL into a reusable method `_resolve_queue_url` method for reusability.
* I added unit tests coverage for new changes.

I took the liberty of creating a new method (`_resolve_queue_url`). I found it convenient to delegate the responsibility of resolving the queue URL to a separate method.

Thank you :)