### PR TITLE
Revert: allow users to disable broker heartbeats by not providing a timeout (#2097, #2016)

### DIFF
--- a/kombu/mixins.py
+++ b/kombu/mixins.py
@@ -195,11 +195,10 @@ class ConsumerMixin:
                 try:
                     conn.drain_events(timeout=safety_interval)
                 except socket.timeout:
-                    if timeout:
-                        conn.heartbeat_check()
-                        elapsed += safety_interval
-                        if elapsed >= timeout:
-                            raise
+                    conn.heartbeat_check()
+                    elapsed += safety_interval
+                    if timeout and elapsed >= timeout:
+                        raise
                 except OSError:
                     if not self.should_stop:
                         raise

--- a/t/unit/test_mixins.py
+++ b/t/unit/test_mixins.py
@@ -91,7 +91,7 @@ class test_ConsumerMixin:
             next(it)
         c.connection.heartbeat_check.assert_called()
 
-    def test_consume_drain_no_heartbeat_check(self):
+    def test_consume_drain_heartbeat_check_no_timeout(self):
         c, Acons, Bcons = self._context()
         c.should_stop = False
         it = c.consume(no_ack=True, timeout=None)
@@ -102,13 +102,13 @@ class test_ConsumerMixin:
         c.connection.drain_events.side_effect = se
         with pytest.raises(StopIteration):
             next(it)
-        c.connection.heartbeat_check.assert_not_called()
+        c.connection.heartbeat_check.assert_called()
 
         it = c.consume(no_ack=True, timeout=0)
         c.connection.drain_events.side_effect = se
         with pytest.raises(StopIteration):
             next(it)
-        c.connection.heartbeat_check.assert_not_called()
+        c.connection.heartbeat_check.assert_called()
 
     def test_Consumer_context(self):
         c, Acons, Bcons = self._context()


### PR DESCRIPTION
Hello,

In issue #2097 it is mentioned that #1997, #1998, #2016 caused heartbeats not to be sent any more if timeout is None or 0. I'm not sure if we want to revert the change from @smart-programmer but this pull request will do so. Perhaps @auvipy can give his opinion. I reverted the change and changed the test case to expect the opposite old behavior which is to send heartbeats even if timeout is None or 0.

Please review and decide if revert is wanted or not.

With kind regards,

Frank 