### PR TITLE
Integrate large payload support for SQS

### DIFF
--- a/kombu/asynchronous/aws/ext.py
+++ b/kombu/asynchronous/aws/ext.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 try:
     import boto3
+    import sqs_extended_client
     from botocore import exceptions
     from botocore.awsrequest import AWSRequest
     from botocore.httpsession import get_cert_path
     from botocore.response import get_response
 except ImportError:
     boto3 = None
+    sqs_extended_client = None
 
     class _void:
         pass

--- a/kombu/asynchronous/aws/ext.py
+++ b/kombu/asynchronous/aws/ext.py
@@ -4,14 +4,12 @@ from __future__ import annotations
 
 try:
     import boto3
-    import sqs_extended_client
     from botocore import exceptions
     from botocore.awsrequest import AWSRequest
     from botocore.httpsession import get_cert_path
     from botocore.response import get_response
 except ImportError:
     boto3 = None
-    sqs_extended_client = None
 
     class _void:
         pass
@@ -23,6 +21,11 @@ except ImportError:
     AWSRequest = _void()
     get_response = _void()
     get_cert_path = _void()
+
+try:
+    import sqs_extended_client
+except ImportError:
+    sqs_extended_client = None
 
 
 __all__ = (

--- a/kombu/asynchronous/aws/sqs/ext.py
+++ b/kombu/asynchronous/aws/sqs/ext.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 
 try:
     import boto3
-    import sqs_extended_client
 except ImportError:
     boto3 = None
+
+try:
+    import sqs_extended_client
+except ImportError:
     sqs_extended_client = None

--- a/kombu/asynchronous/aws/sqs/ext.py
+++ b/kombu/asynchronous/aws/sqs/ext.py
@@ -5,5 +5,7 @@ from __future__ import annotations
 
 try:
     import boto3
+    import sqs_extended_client
 except ImportError:
     boto3 = None
+    sqs_extended_client = None

--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -514,9 +514,8 @@ class Channel(virtual.Channel):
 
                 # The message body is under a wrapper class called StreamingBody
                 streaming_body = response["Body"]
-                payload = json.loads(
-                    self._optional_b64_decode(streaming_body.read())
-                )
+                body = self._optional_b64_decode(streaming_body.read())
+                payload = json.loads(body)
 
             try:
                 properties = payload['properties']

--- a/requirements/extras/sqs.txt
+++ b/requirements/extras/sqs.txt
@@ -1,2 +1,3 @@
 boto3>=1.26.143
 urllib3>=1.26.16
+amazon-sqs-extended-client>=1.0.1

--- a/t/unit/transport/test_SQS.py
+++ b/t/unit/transport/test_SQS.py
@@ -17,11 +17,11 @@ from queue import Empty
 from unittest.mock import Mock, patch
 
 import pytest
-import sqs_extended_client
 
 from kombu import Connection, Exchange, Queue, messaging
 
 boto3 = pytest.importorskip('boto3')
+sqs_extended_client = pytest.importorskip('sqs_extended_client')
 
 from botocore.exceptions import ClientError  # noqa
 


### PR DESCRIPTION
This adds support for handling large payloads in SQS. The 'sqs_extended_client' is imported and utilized for fetching file from S3 as payload when necessary.

As Kombu asynchronously fetches new messages from the queue, not using the standard boto3 APIs, we have to manually fetch the s3 file, rather than rely on the sqs_extended_client to perform that action

Relates to: celery/kombu#279