### PR TITLE
Apply errback and callback when retry occurs

### DIFF
--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -903,6 +903,10 @@ class Connection:
             if 'connect_retries_timeout' in transport_opts:
                 conn_opts['timeout'] = \
                     transport_opts['connect_retries_timeout']
+            if 'errback' in transport_opts:
+                conn_opts['errback'] = transport_opts['errback']
+            if 'callback' in transport_opts:
+                conn_opts['callback'] = transport_opts['callback']
         return conn_opts
 
     @property

--- a/t/unit/test_connection.py
+++ b/t/unit/test_connection.py
@@ -752,6 +752,42 @@ class test_Connection:
                 conn.default_channel
             assert conn._establish_connection.call_count == 2
 
+    def test_connection_timeout_with_errback(self):
+        errback = Mock()
+        with Connection(
+            ['server1', 'server2'],
+            transport=TimeoutingTransport,
+            connect_timeout=1,
+            transport_options={
+                'connect_retries_timeout': 2,
+                'interval_start': 0,
+                'interval_step': 0,
+                'errback': errback
+            },
+        ) as conn:
+            with pytest.raises(OperationalError):
+                conn.default_channel
+
+        errback.assert_called()
+
+    def test_connection_timeout_with_callback(self):
+        callback = Mock()
+        with Connection(
+            ['server1', 'server2'],
+            transport=TimeoutingTransport,
+            connect_timeout=1,
+            transport_options={
+                'connect_retries_timeout': 2,
+                'interval_start': 0,
+                'interval_step': 0,
+                'callback': callback
+            },
+        ) as conn:
+            with pytest.raises(OperationalError):
+                conn.default_channel
+
+        callback.assert_called()
+
 
 class test_Connection_with_transport_options:
 


### PR DESCRIPTION
Before this change, retry over time did not call the errback or callback if specified in `broker_transport_options`.
This PR fixes this bug by including them in connection options.