### PR TITLE
Update the transport options according to the retry policy

### DIFF
--- a/kombu/messaging.py
+++ b/kombu/messaging.py
@@ -182,6 +182,7 @@ class Producer:
                 declare.append(self.exchange)
 
         if retry:
+            self.connection.transport_options.update(retry_policy)
             _publish = self.connection.ensure(self, _publish, **retry_policy)
         return _publish(
             body, priority, content_type, content_encoding,

--- a/t/unit/test_messaging.py
+++ b/t/unit/test_messaging.py
@@ -122,6 +122,17 @@ class test_Producer:
         assert ctype == 'text/plain'
         assert cencoding == 'utf-8'
 
+    def test_publish_retry_policy(self):
+        p = self.connection.Producer()
+        p.channel = Mock()
+        p.channel.connection.client.declared_entities = set()
+        expected_retry_policy = {
+            'max_retries': 20
+        }
+        p.publish('hello', retry=True, retry_policy=expected_retry_policy)
+
+        assert self.connection.transport_options == expected_retry_policy
+
     def test_publish_with_Exchange_instance(self):
         p = self.connection.Producer()
         p.channel = Mock()


### PR DESCRIPTION
In https://github.com/celery/kombu/blob/2f5882331237147ccd34fef646e7b38c338430bb/kombu/messaging.py#L234
we ask for the default channel and since it is not created and the https://github.com/celery/kombu/blob/2f5882331237147ccd34fef646e7b38c338430bb/kombu/connection.py#L957 call relies on transport options and not the retry policy.