### PR TITLE
Fix: restrict google-cloud-pubsub version

### DIFF
--- a/requirements/extras/gcpubsub.txt
+++ b/requirements/extras/gcpubsub.txt
@@ -1,3 +1,3 @@
-google-cloud-pubsub>=2.18.4
+google-cloud-pubsub>=2.18.4,<=2.20.3
 google-cloud-monitoring>=2.16.0
 grpcio==1.67.0


### PR DESCRIPTION
- google-cloud-pubsub version in versions larger than 2.20.3 raises the following error:

site-packages/google/protobuf/internal/well_known_types.py", line 443, in FromTimedelta
    raise AttributeError(
AttributeError: Fail to convert to Duration.
Expected a timedelta like object got str: 'str' object has no attribute 'seconds'

  Fix this by restriction of the allowed package versions.