### PR TITLE
Revert "Update google-cloud-pubsub requirement from <=2.20.3,>=2.18.4 to >=2.18.4,<=2.25.2"

### DIFF
--- a/requirements/extras/gcpubsub.txt
+++ b/requirements/extras/gcpubsub.txt
@@ -1,3 +1,3 @@
-google-cloud-pubsub>=2.18.4,<=2.25.2
+google-cloud-pubsub>=2.18.4,<=2.20.3
 google-cloud-monitoring>=2.16.0
 grpcio==1.67.0


### PR DESCRIPTION
Reverts celery/kombu#2168 due to https://github.com/celery/kombu/pull/2161#issuecomment-2421317654

@auvipy FYI