### PR TITLE
Add documentation for py-amqp transport options

### DIFF
--- a/docs/userguide/connections.rst
+++ b/docs/userguide/connections.rst
@@ -248,3 +248,12 @@ Transport Comparison
          ``supports_fanout`` transport option.
 
 .. [#f3] AMQP Message priority support depends on broker implementation.
+
+Transport Options
+=================
+
+py-amqp
+~~~~~~~
+
+:read_timeout: Timeout for reading data from RabbitMQ.
+:write_timeout: Timeout for writing data to RabbitMQ.


### PR DESCRIPTION
This PR adds (incomplete) documentation for transport options of py-amqp.