### PR TITLE
Close connections in case of an exception

### DIFF
--- a/kombu/messaging.py
+++ b/kombu/messaging.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 from .common import maybe_declare
 from .compression import compress
-from .connection import is_connection, maybe_channel
+from .connection import PooledConnection, is_connection, maybe_channel
 from .entity import Exchange, Queue, maybe_delivery_mode
 from .exceptions import ContentDisallowed
 from .serialization import dumps, prepare_accept_content
@@ -257,6 +257,12 @@ class Producer:
         exc_val: BaseException | None,
         exc_tb: TracebackType | None
     ) -> None:
+        # In case the connection is part of a pool it needs to be
+        # replaced in case of an exception
+        if self.__connection__ is not None and exc_type is not None:
+            if isinstance(self.__connection__, PooledConnection):
+                self.__connection__._pool.replace(self.__connection__)
+
         self.release()
 
     def release(self):

--- a/t/integration/test_py_amqp.py
+++ b/t/integration/test_py_amqp.py
@@ -1,13 +1,23 @@
 from __future__ import annotations
 
 import os
+import uuid
 
 import pytest
 
 import kombu
+from amqp.exceptions import NotFound
 
-from .common import (BaseExchangeTypes, BaseFailover, BaseMessage,
-                     BasePriority, BaseTimeToLive, BasicFunctionality)
+from kombu.connection import ConnectionPool
+
+from .common import (
+    BaseExchangeTypes,
+    BaseFailover,
+    BaseMessage,
+    BasePriority,
+    BaseTimeToLive,
+    BasicFunctionality,
+)
 
 
 def get_connection(hostname, port, vhost):
@@ -17,6 +27,12 @@ def get_connection(hostname, port, vhost):
 def get_failover_connection(hostname, port, vhost):
     return kombu.Connection(
         f'pyamqp://localhost:12345;pyamqp://{hostname}:{port}'
+    )
+
+
+def get_confirm_connection(hostname, port):
+    return kombu.Connection(
+        f"pyamqp://{hostname}:{port}", transport_options={"confirm_publish": True}
     )
 
 
@@ -44,6 +60,14 @@ def failover_connection(request):
         vhost=getattr(
             request.config, "slaveinput", {}
         ).get("slaveid", None),
+    )
+
+
+@pytest.fixture()
+def confirm_publish_connection():
+    return get_confirm_connection(
+        hostname=os.environ.get("RABBITMQ_HOST", "localhost"),
+        port=os.environ.get("RABBITMQ_5672_TCP", "5672"),
     )
 
 
@@ -81,3 +105,49 @@ class test_PyAMQPFailover(BaseFailover):
 @pytest.mark.flaky(reruns=5, reruns_delay=2)
 class test_PyAMQPMessage(BaseMessage):
     pass
+
+
+@pytest.mark.env("py-amqp")
+@pytest.mark.flaky(reruns=5, reruns_delay=2)
+class test_PyAMQPConnectionPool:
+    def test_publish_confirm_does_not_block(self, confirm_publish_connection):
+        """Tests that the connection pool closes connections in case of an exception.
+
+        In case an exception occurs while the connection is in use, the pool should
+        close the exception. In case the connection is not closed before releasing it
+        back to the pool, the connection would remain in an unsuable state, causing
+        causing the next publish call to time out or block forever in case no
+        timeout is specified.
+        """
+        pool = ConnectionPool(connection=confirm_publish_connection, limit=1)
+
+        try:
+            with pool.acquire(block=True) as connection:
+                producer = kombu.Producer(connection)
+                queue = kombu.Queue(
+                    "test-queue-{}".format(uuid.uuid4()), channel=connection
+                )
+                queue.declare()
+                producer.publish(
+                    {"foo": "bar"}, routing_key=str(uuid.uuid4()), retry=False
+                )
+                assert connection.connected
+                queue.delete()
+                try:
+                    queue.get()
+                except NotFound:
+                    raise
+        except NotFound:
+            pass
+
+        with pool.acquire(block=True) as connection:
+            assert not connection.connected
+            producer = kombu.Producer(connection)
+            queue = kombu.Queue(
+                "test-queue-{}".format(uuid.uuid4()), channel=connection
+            )
+            queue.declare()
+            # In case the connection is broken, we should get a Timeout here
+            producer.publish(
+                {"foo": "bar"}, routing_key=str(uuid.uuid4()), retry=False, timeout=3
+            )

--- a/t/integration/test_py_amqp.py
+++ b/t/integration/test_py_amqp.py
@@ -4,20 +4,13 @@ import os
 import uuid
 
 import pytest
-
-import kombu
 from amqp.exceptions import NotFound
 
+import kombu
 from kombu.connection import ConnectionPool
 
-from .common import (
-    BaseExchangeTypes,
-    BaseFailover,
-    BaseMessage,
-    BasePriority,
-    BaseTimeToLive,
-    BasicFunctionality,
-)
+from .common import (BaseExchangeTypes, BaseFailover, BaseMessage,
+                     BasePriority, BaseTimeToLive, BasicFunctionality)
 
 
 def get_connection(hostname, port, vhost):
@@ -115,7 +108,7 @@ class test_PyAMQPConnectionPool:
 
         In case an exception occurs while the connection is in use, the pool should
         close the exception. In case the connection is not closed before releasing it
-        back to the pool, the connection would remain in an unsuable state, causing
+        back to the pool, the connection would remain in an unusable state, causing
         causing the next publish call to time out or block forever in case no
         timeout is specified.
         """
@@ -125,7 +118,7 @@ class test_PyAMQPConnectionPool:
             with pool.acquire(block=True) as connection:
                 producer = kombu.Producer(connection)
                 queue = kombu.Queue(
-                    "test-queue-{}".format(uuid.uuid4()), channel=connection
+                    f"test-queue-{uuid.uuid4()}", channel=connection
                 )
                 queue.declare()
                 producer.publish(
@@ -144,7 +137,7 @@ class test_PyAMQPConnectionPool:
             assert not connection.connected
             producer = kombu.Producer(connection)
             queue = kombu.Queue(
-                "test-queue-{}".format(uuid.uuid4()), channel=connection
+                f"test-queue-{uuid.uuid4()}", channel=connection
             )
             queue.declare()
             # In case the connection is broken, we should get a Timeout here


### PR DESCRIPTION
Fixes: https://github.com/celery/celery/issues/9259

### Issue
When an amqp exception occurs while a connection is in use, the connection becomes unusable. Any attempts to use the connection can potentially block indefinitely.  
Currently, such broken connections are placed back into the connection pool, which causes a later `acquire` call on the pool to return a broken connection. 


### Reproducer
See https://github.com/celery/celery/issues/9259
When a celery app is created with the `confirm_publish=True` option, it is possible for a celery task's `apply_async' method to block indefinitely if a broken connection is retrieved from the connection pool.

### Fix
The `ProducerPool::acquire` and `ConnectionPool::acquire` method now return a wrapped `Connection/Producer`, that ensures the connections are properly closed in case of an exception. A reproducer for the original bug was added as an integration test, to ensure that the fix worked. 

### Additional comments
I believe there is a similar issue with the `ChannelPool`, but in this case I think it is not possible to simply close the connection, as other channels acquired from the pool may still be in use.