### PR TITLE
Provide annotations for `kombu/utils/encoding.py`

### DIFF
--- a/kombu/utils/encoding.py
+++ b/kombu/utils/encoding.py
@@ -9,15 +9,14 @@ from __future__ import annotations
 
 import sys
 import traceback
-from typing import Any, Union, Literal, overload, TypeVar
-
+from typing import Any, Literal, TypeVar, overload
 
 T = TypeVar("T")
 
 #: safe_str takes encoding from this file by default.
 #: :func:`set_default_encoding_file` can used to set the
 #: default output file.
-default_encoding_file: Union[str, None] = None
+default_encoding_file: str | None = None
 
 
 def set_default_encoding_file(file: str) -> None:
@@ -71,7 +70,7 @@ def from_utf8(s: str, *args: Any, **kwargs: Any) -> str:
     return s
 
 
-def ensure_bytes(s: Union[str, bytes]) -> bytes:
+def ensure_bytes(s: str | bytes) -> bytes:
     """Ensure s is bytes, not str."""
     if not isinstance(s, bytes):
         return str_to_bytes(s)

--- a/kombu/utils/encoding.py
+++ b/kombu/utils/encoding.py
@@ -32,12 +32,12 @@ def get_default_encoding_file() -> str | None:
 
 if sys.platform.startswith('java'):  # pragma: no cover
 
-    def default_encoding(file: object = None) -> Literal['utf-8']:
+    def default_encoding(file: Any = None) -> Literal['utf-8']:
         """Get default encoding."""
         return 'utf-8'
 else:
 
-    def default_encoding(file: object = None) -> str:
+    def default_encoding(file: Any = None) -> str:
         """Get default encoding."""
         file = file or get_default_encoding_file()
         return getattr(file, 'encoding', None) or sys.getfilesystemencoding()
@@ -91,7 +91,7 @@ def default_encode(obj: T) -> T:
 
 
 def safe_str(
-    s: object,
+    s: Any,
     errors: str = 'replace',
 ) -> str:
     """Safe form of str(), void of unicode errors."""
@@ -102,7 +102,7 @@ def safe_str(
 
 
 def _safe_str(
-    s: object,
+    s: Any,
     errors: str = 'replace',
     file: Any = None
 ) -> str:
@@ -116,7 +116,7 @@ def _safe_str(
 
 
 def safe_repr(
-    o: object,
+    o: Any,
     errors: str = 'replace',
 ) -> str:
     """Safe form of repr, void of Unicode errors."""

--- a/kombu/utils/encoding.py
+++ b/kombu/utils/encoding.py
@@ -45,8 +45,12 @@ else:
 
 @overload
 def str_to_bytes(s: str) -> bytes: ...
+
+
 @overload
 def str_to_bytes(s: T) -> T: ...
+
+
 def str_to_bytes(s: Any) -> Any:
     """Convert str to bytes."""
     if isinstance(s, str):
@@ -56,8 +60,12 @@ def str_to_bytes(s: Any) -> Any:
 
 @overload
 def bytes_to_str(s: bytes) -> str: ...
+
+
 @overload
 def bytes_to_str(s: T) -> T: ...
+
+
 def bytes_to_str(s: Any) -> Any:
     """Convert bytes to str."""
     if isinstance(s, bytes):

--- a/kombu/utils/encoding.py
+++ b/kombu/utils/encoding.py
@@ -9,69 +9,84 @@ from __future__ import annotations
 
 import sys
 import traceback
+from typing import Any, Union, Literal, overload, TypeVar
+
+
+T = TypeVar("T")
 
 #: safe_str takes encoding from this file by default.
 #: :func:`set_default_encoding_file` can used to set the
 #: default output file.
-default_encoding_file = None
+default_encoding_file: Union[str, None] = None
 
 
-def set_default_encoding_file(file):
+def set_default_encoding_file(file: str) -> None:
     """Set file used to get codec information."""
     global default_encoding_file
     default_encoding_file = file
 
 
-def get_default_encoding_file():
+def get_default_encoding_file() -> str | None:
     """Get file used to get codec information."""
     return default_encoding_file
 
 
 if sys.platform.startswith('java'):  # pragma: no cover
 
-    def default_encoding(file=None):
+    def default_encoding(file: object = None) -> Literal['utf-8']:
         """Get default encoding."""
         return 'utf-8'
 else:
 
-    def default_encoding(file=None):
+    def default_encoding(file: object = None) -> str:
         """Get default encoding."""
         file = file or get_default_encoding_file()
         return getattr(file, 'encoding', None) or sys.getfilesystemencoding()
 
 
-def str_to_bytes(s):
+@overload
+def str_to_bytes(s: str) -> bytes: ...
+@overload
+def str_to_bytes(s: T) -> T: ...
+def str_to_bytes(s: Any) -> Any:
     """Convert str to bytes."""
     if isinstance(s, str):
         return s.encode()
     return s
 
 
-def bytes_to_str(s):
+@overload
+def bytes_to_str(s: bytes) -> str: ...
+@overload
+def bytes_to_str(s: T) -> T: ...
+def bytes_to_str(s: Any) -> Any:
     """Convert bytes to str."""
     if isinstance(s, bytes):
         return s.decode(errors='replace')
     return s
 
 
-def from_utf8(s, *args, **kwargs):
+def from_utf8(s: str, *args: Any, **kwargs: Any) -> str:
     """Get str from utf-8 encoding."""
     return s
 
 
-def ensure_bytes(s):
+def ensure_bytes(s: Union[str, bytes]) -> bytes:
     """Ensure s is bytes, not str."""
     if not isinstance(s, bytes):
         return str_to_bytes(s)
     return s
 
 
-def default_encode(obj):
+def default_encode(obj: T) -> T:
     """Encode using default encoding."""
     return obj
 
 
-def safe_str(s, errors='replace'):
+def safe_str(
+    s: object,
+    errors: str = 'replace',
+) -> str:
     """Safe form of str(), void of unicode errors."""
     s = bytes_to_str(s)
     if not isinstance(s, (str, bytes)):
@@ -79,7 +94,11 @@ def safe_str(s, errors='replace'):
     return _safe_str(s, errors)
 
 
-def _safe_str(s, errors='replace', file=None):
+def _safe_str(
+    s: object,
+    errors: str = 'replace',
+    file: Any = None
+) -> str:
     if isinstance(s, str):
         return s
     try:
@@ -89,7 +108,10 @@ def _safe_str(s, errors='replace', file=None):
             type(s), exc, '\n'.join(traceback.format_stack()))
 
 
-def safe_repr(o, errors='replace'):
+def safe_repr(
+    o: object,
+    errors: str = 'replace',
+) -> str:
     """Safe form of repr, void of Unicode errors."""
     try:
         return repr(o)

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,7 @@ ignore_missing_imports = True
 files =
     kombu/abstract.py,
     kombu/utils/debug.py,
+    kombu/utils/encoding.py,
     kombu/utils/time.py,
     kombu/utils/uuid.py,
     t/unit/utils/test_uuid.py,


### PR DESCRIPTION
Linked Issue: #1511

For this PR, I aimed to annotate the _existing implementation_ of the encoding functions, regardless of what I thought the function's intention is.

There are some functions e.g. `str_to_bytes`, `bytes_to_str`, or `safe_str` which I think may have potentially misleading implementations. I'm not sure whether this is under the scope of this PR, input on this would be appreciated :).