### PR TITLE
fix: interpret the ssl_check_hostname as a boolean

### DIFF
--- a/kombu/utils/url.py
+++ b/kombu/utils/url.py
@@ -39,7 +39,9 @@ def parse_url(url):
     if query:
         keys = [key for key in query.keys() if key.startswith('ssl_')]
         for key in keys:
-            if key == 'ssl_cert_reqs':
+            if key == "ssl_check_hostname":
+                query[key] = query[key].lower() != 'false'
+            elif key == 'ssl_cert_reqs':
                 query[key] = parse_ssl_cert_reqs(query[key])
                 if query[key] is None:
                     logger.warning('Defaulting to insecure SSL behaviour.')

--- a/requirements/pkgutils.txt
+++ b/requirements/pkgutils.txt
@@ -5,4 +5,4 @@ tox>=4.4.8
 sphinx2rst>=1.0
 bumpversion==0.6.0
 pydocstyle==6.3.0
-mypy==1.14.0
+mypy==1.14.1

--- a/t/integration/test_redis.py
+++ b/t/integration/test_redis.py
@@ -2,13 +2,10 @@ from __future__ import annotations
 
 import os
 import socket
-import ssl
-import traceback
 from time import sleep
 
 import pytest
 import redis
-from redis import RedisError
 
 import kombu
 from kombu.transport.redis import Transport

--- a/t/unit/utils/test_url.py
+++ b/t/unit/utils/test_url.py
@@ -51,10 +51,18 @@ def test_maybe_sanitize_url(url, expected):
 def test_ssl_parameters():
     url = 'rediss://user:password@host:6379/0?'
     querystring = urlencode({
+        "ssl_check_hostname": "on",
+    })
+    kwargs = parse_url(url + querystring)
+    assert kwargs['transport'] == 'rediss'
+    assert kwargs['ssl']['ssl_check_hostname'] is True
+
+    querystring = urlencode({
         'ssl_cert_reqs': 'required',
         'ssl_ca_certs': '/var/ssl/myca.pem',
         'ssl_certfile': '/var/ssl/server-cert.pem',
         'ssl_keyfile': '/var/ssl/priv/worker-key.pem',
+        "ssl_check_hostname": "false",
     })
     kwargs = parse_url(url + querystring)
     assert kwargs['transport'] == 'rediss'
@@ -62,6 +70,8 @@ def test_ssl_parameters():
     assert kwargs['ssl']['ssl_ca_certs'] == '/var/ssl/myca.pem'
     assert kwargs['ssl']['ssl_certfile'] == '/var/ssl/server-cert.pem'
     assert kwargs['ssl']['ssl_keyfile'] == '/var/ssl/priv/worker-key.pem'
+    assert kwargs['ssl']['ssl_check_hostname'] is False
+
 
     kombu.utils.url.ssl_available = False
 

--- a/t/unit/utils/test_url.py
+++ b/t/unit/utils/test_url.py
@@ -72,7 +72,6 @@ def test_ssl_parameters():
     assert kwargs['ssl']['ssl_keyfile'] == '/var/ssl/priv/worker-key.pem'
     assert kwargs['ssl']['ssl_check_hostname'] is False
 
-
     kombu.utils.url.ssl_available = False
 
     kwargs = parse_url(url + querystring)


### PR DESCRIPTION
!close #2210 

ssl_check_hostname is left as-is ("false"), and is evaluated to True when a Redis connection is created.