### PR TITLE
chore(mypy): switch to `pyproject.toml` configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,5 +45,5 @@ repos:
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.14.1
     hooks:
-    -   id: mypy
+      - id: mypy
         pass_filenames: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,35 @@ omit = [
     "*/pypy/*",
     "*kombu/utils/debug.py",
 ]
+
+[tool.mypy]
+warn_unused_configs = true
+strict = false
+follow_imports = "skip"
+show_error_codes = true
+disallow_untyped_defs = true
+ignore_missing_imports = true
+files = [
+    'kombu/abstract.py',
+    'kombu/utils/debug.py',
+    'kombu/utils/time.py',
+    'kombu/utils/uuid.py',
+    't/unit/utils/test_uuid.py',
+    'kombu/utils/text.py',
+    'kombu/exceptions.py',
+    't/unit/test_exceptions.py',
+    'kombu/clocks.py',
+    't/unit/test_clocks.py',
+    'kombu/__init__.py',
+    'kombu/asynchronous/__init__.py',
+    'kombu/asynchronous/aws/__init__.py',
+    'kombu/asynchronous/aws/ext.py',
+    'kombu/asynchronous/aws/sqs/__init__.py',
+    'kombu/asynchronous/aws/sqs/ext.py',
+    'kombu/asynchronous/http/__init__.py',
+    'kombu/transport/__init__.py',
+    'kombu/transport/virtual/__init__.py',
+    'kombu/utils/__init__.py',
+    'kombu/matcher.py',
+    'kombu/asynchronous/semaphore.py',
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,38 +42,6 @@ per-file-ignores =
 add_imports =
     from __future__ import annotations
 
-[mypy]
-warn_unused_configs = True
-strict = False
-follow_imports = skip
-show_error_codes = True
-disallow_untyped_defs = True
-ignore_missing_imports = True
-files =
-    kombu/abstract.py,
-    kombu/utils/debug.py,
-    kombu/utils/time.py,
-    kombu/utils/uuid.py,
-    t/unit/utils/test_uuid.py,
-    kombu/utils/text.py,
-    kombu/exceptions.py,
-    t/unit/test_exceptions.py,
-    kombu/clocks.py,
-    t/unit/test_clocks.py,
-    kombu/__init__.py,
-    kombu/asynchronous/__init__.py,
-    kombu/asynchronous/aws/__init__.py,
-    kombu/asynchronous/aws/ext.py,
-    kombu/asynchronous/aws/sqs/__init__.py,
-    kombu/asynchronous/aws/sqs/ext.py,
-    kombu/asynchronous/http/__init__.py,
-    kombu/transport/__init__.py,
-    kombu/transport/virtual/__init__.py,
-    kombu/utils/__init__.py,
-    kombu/matcher.py,
-    kombu/asynchronous/semaphore.py
-
-
 [pep257]
 ignore = D102,D107,D104,D203,D105,D213,D401,D413,D417
 

--- a/tox.ini
+++ b/tox.ini
@@ -142,7 +142,7 @@ commands =
     pydocstyle {toxinidir}/kombu
 
 [testenv:mypy]
-commands = python -m mypy --config-file setup.cfg
+commands = python -m mypy
 
 [testenv:lint]
 allowlist_externals = pre-commit


### PR DESCRIPTION
Towards https://github.com/celery/kombu/issues/2232.

## Description

This commit switches `mypy` configuration from `setup.cfg` to `pyproject.toml`.

## How this has been tested?

- `pyproject.toml` configuration is correctly read and same as before, cf. `mypy -vvv .` output.
- pre-commit works as before.
- CI jobs are successful.