### PR TITLE
chore(isort): switch from `isort` to `ruff`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,13 +37,13 @@ repos:
       - id: check-yaml
       - id: mixed-line-ending
 
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.14.1
     hooks:
     -   id: mypy
         pass_filenames: false
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.3
+    hooks:
+      - id: ruff

--- a/examples/delayed_infra.py
+++ b/examples/delayed_infra.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 from examples.experimental.async_consume import queue
 from kombu import Connection, Exchange, Queue
 from kombu.transport.native_delayed_delivery import (
-    bind_queue_to_native_delayed_delivery_exchange, calculate_routing_key,
-    declare_native_delayed_delivery_exchanges_and_queues, level_name)
+    bind_queue_to_native_delayed_delivery_exchange,
+    calculate_routing_key,
+    declare_native_delayed_delivery_exchanges_and_queues,
+    level_name,
+)
 
 with Connection('amqp://guest:guest@localhost:5672//') as connection:
     declare_native_delayed_delivery_exchanges_and_queues(connection, 'quorum')

--- a/kombu/serialization.py
+++ b/kombu/serialization.py
@@ -10,8 +10,13 @@ from collections import namedtuple
 from contextlib import contextmanager
 from io import BytesIO
 
-from .exceptions import (ContentDisallowed, DecodeError, EncodeError,
-                         SerializerNotInstalled, reraise)
+from .exceptions import (
+    ContentDisallowed,
+    DecodeError,
+    EncodeError,
+    SerializerNotInstalled,
+    reraise,
+)
 from .utils.compat import entrypoints
 from .utils.encoding import bytes_to_str, str_to_bytes
 

--- a/kombu/transport/azureservicebus.py
+++ b/kombu/transport/azureservicebus.py
@@ -64,14 +64,17 @@ from typing import Any
 import azure.core.exceptions
 import azure.servicebus.exceptions
 import isodate
-from azure.servicebus import (ServiceBusClient, ServiceBusMessage,
-                              ServiceBusReceiveMode, ServiceBusReceiver,
-                              ServiceBusSender)
+from azure.servicebus import (
+    ServiceBusClient,
+    ServiceBusMessage,
+    ServiceBusReceiveMode,
+    ServiceBusReceiver,
+    ServiceBusSender,
+)
 from azure.servicebus.management import ServiceBusAdministrationClient
 
 try:
-    from azure.identity import (DefaultAzureCredential,
-                                ManagedIdentityCredential)
+    from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 except ImportError:
     DefaultAzureCredential = None
     ManagedIdentityCredential = None

--- a/kombu/transport/azurestoragequeues.py
+++ b/kombu/transport/azurestoragequeues.py
@@ -70,8 +70,7 @@ except ImportError:  # pragma: no cover
     QueueServiceClient = None
 
 try:
-    from azure.identity import (DefaultAzureCredential,
-                                ManagedIdentityCredential)
+    from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 except ImportError:
     DefaultAzureCredential = None
     ManagedIdentityCredential = None

--- a/kombu/transport/confluentkafka.py
+++ b/kombu/transport/confluentkafka.py
@@ -69,8 +69,7 @@ from kombu.utils.json import dumps, loads
 
 try:
     import confluent_kafka
-    from confluent_kafka import (Consumer, KafkaException, Producer,
-                                 TopicPartition)
+    from confluent_kafka import Consumer, KafkaException, Producer, TopicPartition
     from confluent_kafka.admin import AdminClient, NewTopic
 
     KAFKA_CONNECTION_ERRORS = ()

--- a/kombu/transport/gcpubsub.py
+++ b/kombu/transport/gcpubsub.py
@@ -43,8 +43,9 @@ import dataclasses
 import datetime
 import string
 import threading
-from concurrent.futures import (FIRST_COMPLETED, Future, ThreadPoolExecutor,
-                                wait)
+from _socket import gethostname
+from _socket import timeout as socket_timeout
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from contextlib import suppress
 from os import getpid
 from queue import Empty
@@ -52,18 +53,14 @@ from threading import Lock
 from time import monotonic, sleep
 from uuid import NAMESPACE_OID, uuid3
 
-from _socket import gethostname
-from _socket import timeout as socket_timeout
-from google.api_core.exceptions import (AlreadyExists, DeadlineExceeded,
-                                        PermissionDenied)
+from google.api_core.exceptions import AlreadyExists, DeadlineExceeded, PermissionDenied
 from google.api_core.retry import Retry
 from google.cloud import monitoring_v3
 from google.cloud.monitoring_v3 import query
 from google.cloud.pubsub_v1 import PublisherClient, SubscriberClient
 from google.cloud.pubsub_v1 import exceptions as pubsub_exceptions
 from google.cloud.pubsub_v1.publisher import exceptions as publisher_exceptions
-from google.cloud.pubsub_v1.subscriber import \
-    exceptions as subscriber_exceptions
+from google.cloud.pubsub_v1.subscriber import exceptions as subscriber_exceptions
 from google.pubsub_v1 import gapic_version as package_version
 
 from kombu.entity import TRANSIENT_DELIVERY_MODE

--- a/kombu/transport/qpid.py
+++ b/kombu/transport/qpid.py
@@ -111,9 +111,8 @@ except ImportError:  # pragma: no cover
     qpidtoollibs = None
 
 try:
-    from qpid.messaging.exceptions import ConnectionError
+    from qpid.messaging.exceptions import ConnectionError, NotFound, SessionClosed
     from qpid.messaging.exceptions import Empty as QpidEmpty
-    from qpid.messaging.exceptions import NotFound, SessionClosed
 except ImportError:  # pragma: no cover
     ConnectionError = None
     NotFound = None

--- a/kombu/transport/sqlalchemy/models.py
+++ b/kombu/transport/sqlalchemy/models.py
@@ -4,8 +4,18 @@ from __future__ import annotations
 
 import datetime
 
-from sqlalchemy import (Boolean, Column, DateTime, ForeignKey, Index, Integer,
-                        Sequence, SmallInteger, String, Text)
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    Sequence,
+    SmallInteger,
+    String,
+    Text,
+)
 from sqlalchemy.orm import relationship
 from sqlalchemy.schema import MetaData
 

--- a/kombu/transport/virtual/__init__.py
+++ b/kombu/transport/virtual/__init__.py
@@ -1,8 +1,20 @@
 from __future__ import annotations
 
-from .base import (AbstractChannel, Base64, BrokerState, Channel, Empty,
-                   Management, Message, NotEquivalentError, QoS, Transport,
-                   UndeliverableWarning, binding_key_t, queue_binding_t)
+from .base import (
+                   AbstractChannel,
+                   Base64,
+                   BrokerState,
+                   Channel,
+                   Empty,
+                   Management,
+                   Message,
+                   NotEquivalentError,
+                   QoS,
+                   Transport,
+                   UndeliverableWarning,
+                   binding_key_t,
+                   queue_binding_t,
+)
 
 __all__ = (
     'Base64', 'NotEquivalentError', 'UndeliverableWarning', 'BrokerState',

--- a/kombu/utils/__init__.py
+++ b/kombu/utils/__init__.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 from .collections import EqualityDict
 from .compat import fileno, maybe_fileno, nested, register_after_fork
 from .div import emergency_dump_state
-from .functional import (fxrange, fxrangemax, maybe_list, reprcall,
-                         retry_over_time)
+from .functional import fxrange, fxrangemax, maybe_list, reprcall, retry_over_time
 from .imports import symbol_by_name
 from .objects import cached_property
 from .uuid import uuid

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,9 @@ omit = [
     "*/pypy/*",
     "*kombu/utils/debug.py",
 ]
+
+[tool.ruff.lint]
+select = ["I"]
+
+[tool.ruff.lint.isort]
+required-imports = ["from __future__ import annotations"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,10 +38,6 @@ per-file-ignores =
        # docstrings
        D,
 
-[isort]
-add_imports =
-    from __future__ import annotations
-
 [mypy]
 warn_unused_configs = True
 strict = False

--- a/t/integration/test_kafka.py
+++ b/t/integration/test_kafka.py
@@ -4,8 +4,7 @@ import pytest
 
 import kombu
 
-from .common import (BaseExchangeTypes, BaseFailover, BaseMessage,
-                     BasicFunctionality)
+from .common import BaseExchangeTypes, BaseFailover, BaseMessage, BasicFunctionality
 
 
 def get_connection(hostname, port):

--- a/t/integration/test_mongodb.py
+++ b/t/integration/test_mongodb.py
@@ -6,8 +6,7 @@ import pytest
 
 import kombu
 
-from .common import (BaseExchangeTypes, BaseMessage, BasePriority,
-                     BasicFunctionality)
+from .common import BaseExchangeTypes, BaseMessage, BasePriority, BasicFunctionality
 
 
 def get_connection(hostname, port, vhost):

--- a/t/integration/test_py_amqp.py
+++ b/t/integration/test_py_amqp.py
@@ -9,8 +9,14 @@ from amqp.exceptions import NotFound
 import kombu
 from kombu.connection import ConnectionPool
 
-from .common import (BaseExchangeTypes, BaseFailover, BaseMessage,
-                     BasePriority, BaseTimeToLive, BasicFunctionality)
+from .common import (
+    BaseExchangeTypes,
+    BaseFailover,
+    BaseMessage,
+    BasePriority,
+    BaseTimeToLive,
+    BasicFunctionality,
+)
 
 
 def get_connection(hostname, port, vhost):

--- a/t/integration/test_redis.py
+++ b/t/integration/test_redis.py
@@ -10,8 +10,7 @@ import redis
 import kombu
 from kombu.transport.redis import Transport
 
-from .common import (BaseExchangeTypes, BaseMessage, BasePriority,
-                     BasicFunctionality)
+from .common import BaseExchangeTypes, BaseMessage, BasePriority, BasicFunctionality
 
 
 def get_connection(

--- a/t/unit/asynchronous/aws/test_connection.py
+++ b/t/unit/asynchronous/aws/test_connection.py
@@ -8,10 +8,12 @@ import pytest
 from vine.abstract import Thenable
 
 from kombu.asynchronous import http
-from kombu.asynchronous.aws.connection import (AsyncAWSQueryConnection,
-                                               AsyncConnection,
-                                               AsyncHTTPResponse,
-                                               AsyncHTTPSConnection)
+from kombu.asynchronous.aws.connection import (
+    AsyncAWSQueryConnection,
+    AsyncConnection,
+    AsyncHTTPResponse,
+    AsyncHTTPSConnection,
+)
 from kombu.asynchronous.aws.ext import boto3
 from kombu.exceptions import HttpError
 from t.mocks import PromiseMock

--- a/t/unit/asynchronous/http/test_urllib3.py
+++ b/t/unit/asynchronous/http/test_urllib3.py
@@ -7,8 +7,7 @@ import pytest
 import urllib3
 
 import t.skip
-from kombu.asynchronous.http.urllib3_client import (Urllib3Client,
-                                                    _get_pool_key_parts)
+from kombu.asynchronous.http.urllib3_client import Urllib3Client, _get_pool_key_parts
 
 
 @t.skip.if_pypy

--- a/t/unit/asynchronous/test_hub.py
+++ b/t/unit/asynchronous/test_hub.py
@@ -9,8 +9,13 @@ from vine import promise
 from kombu.asynchronous import ERR, READ, WRITE, Hub
 from kombu.asynchronous import hub as _hub
 from kombu.asynchronous.debug import _rcb, callback_for, repr_flag
-from kombu.asynchronous.hub import (Stop, _dummy_context, _raise_stop_error,
-                                    get_event_loop, set_event_loop)
+from kombu.asynchronous.hub import (
+    Stop,
+    _dummy_context,
+    _raise_stop_error,
+    get_event_loop,
+    set_event_loop,
+)
 from kombu.asynchronous.semaphore import DummyLock, LaxBoundedSemaphore
 
 

--- a/t/unit/test_common.py
+++ b/t/unit/test_common.py
@@ -8,9 +8,17 @@ import pytest
 from amqp import RecoverableConnectionError
 
 from kombu import common
-from kombu.common import (PREFETCH_COUNT_MAX, Broadcast, QoS, collect_replies,
-                          declaration_cached, generate_oid, ignore_errors,
-                          maybe_declare, send_reply)
+from kombu.common import (
+    PREFETCH_COUNT_MAX,
+    Broadcast,
+    QoS,
+    collect_replies,
+    declaration_cached,
+    generate_oid,
+    ignore_errors,
+    maybe_declare,
+    send_reply,
+)
 from t.mocks import ContextMock, MockPool
 
 if TYPE_CHECKING:

--- a/t/unit/test_log.py
+++ b/t/unit/test_log.py
@@ -4,8 +4,14 @@ import logging
 import sys
 from unittest.mock import ANY, Mock, patch
 
-from kombu.log import (Log, LogMixin, get_logger, get_loglevel, safeify_format,
-                       setup_logging)
+from kombu.log import (
+    Log,
+    LogMixin,
+    get_logger,
+    get_loglevel,
+    safeify_format,
+    setup_logging,
+)
 
 
 class test_get_logger:

--- a/t/unit/test_matcher.py
+++ b/t/unit/test_matcher.py
@@ -2,8 +2,15 @@ from __future__ import annotations
 
 import pytest
 
-from kombu.matcher import (MatcherNotInstalled, fnmatch, match, register,
-                           registry, rematch, unregister)
+from kombu.matcher import (
+    MatcherNotInstalled,
+    fnmatch,
+    match,
+    register,
+    registry,
+    rematch,
+    unregister,
+)
 
 
 class test_Matcher:

--- a/t/unit/test_serialization.py
+++ b/t/unit/test_serialization.py
@@ -9,13 +9,23 @@ import pytest
 
 import t.skip
 from kombu.exceptions import ContentDisallowed, DecodeError, EncodeError
-from kombu.serialization import (SerializerNotInstalled,
-                                 disable_insecure_serializers, dumps,
-                                 enable_insecure_serializers, loads, pickle,
-                                 pickle_protocol, prepare_accept_content,
-                                 raw_encode, register, register_msgpack,
-                                 register_pickle, register_yaml, registry,
-                                 unregister)
+from kombu.serialization import (
+    SerializerNotInstalled,
+    disable_insecure_serializers,
+    dumps,
+    enable_insecure_serializers,
+    loads,
+    pickle,
+    pickle_protocol,
+    prepare_accept_content,
+    raw_encode,
+    register,
+    register_msgpack,
+    register_pickle,
+    register_yaml,
+    registry,
+    unregister,
+)
 from kombu.utils.encoding import str_to_bytes
 
 # For content_encoding tests

--- a/t/unit/transport/test_azureservicebus.py
+++ b/t/unit/transport/test_azureservicebus.py
@@ -17,8 +17,7 @@ import azure.servicebus.exceptions  # noqa
 from azure.servicebus import ServiceBusMessage, ServiceBusReceiveMode  # noqa
 
 try:
-    from azure.identity import (DefaultAzureCredential,
-                                ManagedIdentityCredential)
+    from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 except ImportError:
     DefaultAzureCredential = None
     ManagedIdentityCredential = None

--- a/t/unit/transport/test_base.py
+++ b/t/unit/transport/test_base.py
@@ -6,8 +6,12 @@ import pytest
 
 from kombu import Connection, Consumer, Exchange, Producer, Queue
 from kombu.message import Message
-from kombu.transport.base import (Management, StdChannel, Transport,
-                                  to_rabbitmq_queue_arguments)
+from kombu.transport.base import (
+    Management,
+    StdChannel,
+    Transport,
+    to_rabbitmq_queue_arguments,
+)
 
 
 @pytest.mark.parametrize('args,input,expected', [

--- a/t/unit/transport/test_gcpubsub.py
+++ b/t/unit/transport/test_gcpubsub.py
@@ -1,18 +1,22 @@
 from __future__ import annotations
 
+from _socket import timeout as socket_timeout
 from concurrent.futures import Future
 from datetime import datetime
 from queue import Empty
 from unittest.mock import MagicMock, call, patch
 
 import pytest
-from _socket import timeout as socket_timeout
-from google.api_core.exceptions import (AlreadyExists, DeadlineExceeded,
-                                        PermissionDenied)
+from google.api_core.exceptions import AlreadyExists, DeadlineExceeded, PermissionDenied
 from google.pubsub_v1.types.pubsub import Subscription
 
-from kombu.transport.gcpubsub import (AtomicCounter, Channel, QueueDescriptor,
-                                      Transport, UnackedIds)
+from kombu.transport.gcpubsub import (
+    AtomicCounter,
+    Channel,
+    QueueDescriptor,
+    Transport,
+    UnackedIds,
+)
 
 
 class test_UnackedIds:

--- a/t/unit/transport/test_native_delayed_delivery.py
+++ b/t/unit/transport/test_native_delayed_delivery.py
@@ -7,8 +7,11 @@ import pytest
 
 from kombu.transport.native_delayed_delivery import (
     CELERY_DELAYED_DELIVERY_EXCHANGE,
-    bind_queue_to_native_delayed_delivery_exchange, calculate_routing_key,
-    declare_native_delayed_delivery_exchanges_and_queues, level_name)
+    bind_queue_to_native_delayed_delivery_exchange,
+    calculate_routing_key,
+    declare_native_delayed_delivery_exchanges_and_queues,
+    level_name,
+)
 
 
 class test_native_delayed_delivery_level_name:

--- a/t/unit/transport/test_qpid.py
+++ b/t/unit/transport/test_qpid.py
@@ -13,9 +13,16 @@ from unittest.mock import Mock, call, patch
 
 import pytest
 
-from kombu.transport.qpid import (AuthenticationFailure, Channel, Connection,
-                                  ConnectionError, Message, NotFound, QoS,
-                                  Transport)
+from kombu.transport.qpid import (
+    AuthenticationFailure,
+    Channel,
+    Connection,
+    ConnectionError,
+    Message,
+    NotFound,
+    QoS,
+    Transport,
+)
 from kombu.transport.virtual import Base64
 
 QPID_MODULE = 'kombu.transport.qpid'

--- a/t/unit/utils/test_encoding.py
+++ b/t/unit/utils/test_encoding.py
@@ -4,8 +4,12 @@ import sys
 from contextlib import contextmanager
 from unittest.mock import patch
 
-from kombu.utils.encoding import (default_encoding, get_default_encoding_file,
-                                  safe_str, set_default_encoding_file)
+from kombu.utils.encoding import (
+    default_encoding,
+    get_default_encoding_file,
+    safe_str,
+    set_default_encoding_file,
+)
 
 
 @contextmanager

--- a/t/unit/utils/test_functional.py
+++ b/t/unit/utils/test_functional.py
@@ -7,10 +7,20 @@ from unittest.mock import Mock
 import pytest
 
 from kombu.utils import functional as utils
-from kombu.utils.functional import (ChannelPromise, LRUCache, accepts_argument,
-                                    fxrange, fxrangemax, lazy, maybe_evaluate,
-                                    maybe_list, memoize, reprcall, reprkwargs,
-                                    retry_over_time)
+from kombu.utils.functional import (
+    ChannelPromise,
+    LRUCache,
+    accepts_argument,
+    fxrange,
+    fxrangemax,
+    lazy,
+    maybe_evaluate,
+    maybe_list,
+    memoize,
+    reprcall,
+    reprkwargs,
+    retry_over_time,
+)
 
 
 class test_ChannelPromise:

--- a/t/unit/utils/test_json.py
+++ b/t/unit/utils/test_json.py
@@ -12,8 +12,7 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from kombu.utils.encoding import str_to_bytes
-from kombu.utils.json import (_register_default_types, dumps, loads,
-                              register_type)
+from kombu.utils.json import _register_default_types, dumps, loads, register_type
 
 if sys.version_info >= (3, 9):
     from zoneinfo import ZoneInfo

--- a/t/unit/utils/test_url.py
+++ b/t/unit/utils/test_url.py
@@ -10,8 +10,7 @@ import ssl
 import pytest
 
 import kombu.utils.url
-from kombu.utils.url import (as_url, maybe_sanitize_url, parse_ssl_cert_reqs,
-                             parse_url)
+from kombu.utils.url import as_url, maybe_sanitize_url, parse_ssl_cert_reqs, parse_url
 
 
 def test_parse_url():


### PR DESCRIPTION
Towards https://github.com/celery/kombu/issues/2232.

This PR replaces `isort` with `ruff`:
- `ruff` hook has been added to pre-commit
- `setup.cfg` configuration disappears in favor of `pyproject.toml`

Note that only `I` rule is selected, other linters (flake8, ...) can be migrated in follow-up steps.

First commit updates configuration, second commit fixes import formatting to comply with `I001` rule.

## How this has been tested?
Successful `pre-commit` job run: https://github.com/celery/kombu/actions/runs/12990145844/job/36224652021?pr=2234

## Documentation
As `ruff` is installed through `pre-commit`, this change should be pretty transparent, however I can mention this change in documentation if needed.