### PR TITLE
Fix: expiration ttl as timedelta on gcpubsub

### DIFF
--- a/kombu/transport/gcpubsub.py
+++ b/kombu/transport/gcpubsub.py
@@ -49,6 +49,7 @@ from contextlib import suppress
 from os import getpid
 from queue import Empty
 from threading import Lock
+from datetime import timedelta
 from time import monotonic, sleep
 from uuid import NAMESPACE_OID, uuid3
 
@@ -318,7 +319,7 @@ class Channel(virtual.Channel):
                     "topic": topic_path,
                     'ack_deadline_seconds': self.ack_deadline_seconds,
                     'expiration_policy': {
-                        'ttl': f'{self.expiration_seconds}s'
+                        'ttl': timedelta(seconds=self.expiration_seconds)
                     },
                     'message_retention_duration': f'{msg_retention}s',
                     **(filter_args or {}),

--- a/kombu/transport/gcpubsub.py
+++ b/kombu/transport/gcpubsub.py
@@ -46,10 +46,10 @@ import threading
 from concurrent.futures import (FIRST_COMPLETED, Future, ThreadPoolExecutor,
                                 wait)
 from contextlib import suppress
+from datetime import timedelta
 from os import getpid
 from queue import Empty
 from threading import Lock
-from datetime import timedelta
 from time import monotonic, sleep
 from uuid import NAMESPACE_OID, uuid3
 


### PR DESCRIPTION
<img width="1020" alt="image" src="https://github.com/user-attachments/assets/037d481a-3838-43ef-a7c6-2db46fa810d8" />

With protobuf version 5.29.3,  ttl value as string is not supported.