### PR TITLE
Update delayed_infra example for better clarity

### DIFF
--- a/examples/delayed_infra.py
+++ b/examples/delayed_infra.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from examples.experimental.async_consume import queue
 from kombu import Connection, Exchange, Queue
 from kombu.transport.native_delayed_delivery import (
     bind_queue_to_native_delayed_delivery_exchange, calculate_routing_key,
@@ -8,15 +7,15 @@ from kombu.transport.native_delayed_delivery import (
 
 with Connection('amqp://guest:guest@localhost:5672//') as connection:
     declare_native_delayed_delivery_exchanges_and_queues(connection, 'quorum')
-
-    destination_exchange = Exchange(
-        'destination', type='topic')
-    destination_queue = Queue("destination", exchange=destination_exchange)
-    bind_queue_to_native_delayed_delivery_exchange(connection, queue)
-
     channel = connection.channel()
+
+    destination_exchange = Exchange('destination_exchange', type='topic')
+    queue = Queue("destination", exchange=destination_exchange, routing_key='destination_route')
+    queue.declare(channel=connection.channel())
+
+    bind_queue_to_native_delayed_delivery_exchange(connection, queue)
     with connection.Producer(channel=channel) as producer:
-        routing_key = calculate_routing_key(30, 'destination')
+        routing_key = calculate_routing_key(30, 'destination_route')
         producer.publish(
             "delayed msg",
             routing_key=routing_key,


### PR DESCRIPTION
Hello!

I tried running the example code (`examples/delayed_infra.py`) because I wanted to better understand the newly added native delayed delivery.

However, I noticed that the generated example message was stuck in the `celery_delayed_1` queue.

After investigating, I found that there was no queue bound to `celery_delayed_delivery`. 
To resolve this, I declared the `destination` queue and set the appropriate routing key.

I hope this helps clarify things for others exploring the example code.

If I missed anything, please feel free to let me know! Thank you.