### PR TITLE
SQS: Fix Query Protocol Content-Type header

### DIFF
--- a/kombu/asynchronous/aws/sqs/connection.py
+++ b/kombu/asynchronous/aws/sqs/connection.py
@@ -39,10 +39,13 @@ class AsyncSQSConnection(AsyncAWSQueryConnection):
             params['Action'] = operation
 
         # defaults for non-get
-        param_payload = {'data': params}
+        param_payload = {'data': params, "headers": {}}
         if method.lower() == 'get':
             # query-based opts
             param_payload = {'params': params}
+
+        if method.lower() == 'post':
+            param_payload["headers"]['Content-Type'] = 'application/x-www-form-urlencoded'
 
         return AWSRequest(method=method, url=queue_url, **param_payload)
 

--- a/kombu/asynchronous/aws/sqs/connection.py
+++ b/kombu/asynchronous/aws/sqs/connection.py
@@ -39,15 +39,16 @@ class AsyncSQSConnection(AsyncAWSQueryConnection):
             params['Action'] = operation
 
         # defaults for non-get
-        param_payload = {'data': params, "headers": {}}
+        param_payload = {'data': params}
+        headers = {}
         if method.lower() == 'get':
             # query-based opts
             param_payload = {'params': params}
 
         if method.lower() == 'post':
-            param_payload["headers"]['Content-Type'] = 'application/x-www-form-urlencoded'
+            headers['Content-Type'] = 'application/x-www-form-urlencoded; charset=utf-8'
 
-        return AWSRequest(method=method, url=queue_url, **param_payload)
+        return AWSRequest(method=method, url=queue_url, headers=headers, **param_payload)
 
     def _create_json_request(self, operation, params, queue_url):
         params = params.copy()

--- a/t/unit/asynchronous/aws/sqs/test_connection.py
+++ b/t/unit/asynchronous/aws/sqs/test_connection.py
@@ -98,10 +98,12 @@ class test_AsyncSQSConnection(AWSCase):
             url=queue_url,
             method=verb,
             data={
-                'Action': (operation_name),
+                'Action': operation_name,
                 **params
             },
-            headers={},
+            headers={
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
         ))
 
     def test_create_json_request(self):

--- a/t/unit/asynchronous/aws/sqs/test_connection.py
+++ b/t/unit/asynchronous/aws/sqs/test_connection.py
@@ -102,7 +102,7 @@ class test_AsyncSQSConnection(AWSCase):
                 **params
             },
             headers={
-                'Content-Type': 'application/x-www-form-urlencoded',
+                'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
             },
         ))
 


### PR DESCRIPTION
Fixes #2257, which is from the error introduced by the JSON API patch in #2226.

Related: #2260

The lack of `Content-Type: application/x-www-form-urlencoded` prevented the SQS endpoint from getting the Action parameter from the body. 

I am still investigating exactly how/why that got dropped from my PR, but this is a patch that should unblock kombu consumers.