### PR TITLE
SQS: More Protocol Tests

### DIFF
--- a/kombu/asynchronous/aws/sqs/connection.py
+++ b/kombu/asynchronous/aws/sqs/connection.py
@@ -73,7 +73,7 @@ class AsyncSQSConnection(AsyncAWSQueryConnection):
         headers['X-Amz-Target'] = target
 
         param_payload = {
-            'data': json.dumps(params),
+            'data': json.dumps(params).encode(),
             'headers': headers
         }
 

--- a/t/unit/asynchronous/aws/sqs/test_connection.py
+++ b/t/unit/asynchronous/aws/sqs/test_connection.py
@@ -109,7 +109,7 @@ class test_AsyncSQSConnection(AWSCase):
         prepared = req.prepare()  # without signing for test
 
         assert prepared.method == 'GET'
-        assert prepared.url ==  (
+        assert prepared.url == (
             'https://sqs.us-west-2.amazonaws.com/?'
             'DefaultVisibilityTimeout=40'
             '&QueueName=celery-test'
@@ -183,7 +183,7 @@ class test_AsyncSQSConnection(AWSCase):
             data=json.dumps({
                 **params,
                 "QueueUrl": queue_url
-            }),
+            }).encode(),
             headers={
                 'Content-Type': 'application/x-amz-json-1.0',
                 'X-Amz-Target': f'sqs.{operation_name}'


### PR DESCRIPTION
Adding more tests as requested in #2266.

I extended a few tests to also call `prepare()` and compare the final request attributes before they go over the network. 

This exposed a few issues where botocore does str-to-bytes comparison, which fails the test in pytest. I cleaned that up -- though it's worth noting that botocore is fairly lenient -- you can provide either str, bytes, a dict, or None. But for testing sanity I cleaned it up.

Verified this is working both with old versions of botocore and new versions.