### PR TITLE
Do not pin package tzdata anymore

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,4 +1,4 @@
 amqp>=5.1.1,<6.0.0
 vine==5.1.0
 backports.zoneinfo[tzdata]>=0.2.1; python_version<"3.9"
-tzdata==2025.2; python_version>="3.9"
+tzdata>=2025.2; python_version>="3.9"


### PR DESCRIPTION
Hello everyone,

I think we can safely upgrade tzdata to newer versions and do not require a version pin, because it is just a timezone database.

This will help other projects upgrading their dependencies without running into dependency conflicts.

Thanks