### PR TITLE
Attempt to fix retry loop in `maybe_declare()` when broken connection

### DIFF
--- a/kombu/common.py
+++ b/kombu/common.py
@@ -135,7 +135,9 @@ def _maybe_declare(entity, channel):
 
     _ensure_channel_is_bound(entity, channel)
 
-    if channel is None:
+    if channel is None or channel.connection is None:
+        # If this was called from the `ensure()` method then the channel could have been invalidated
+        # and the correct channel was re-bound to the entity by calling the `entity.revive()` method.
         if not entity.is_bound:
             raise ChannelError(
                 f"channel is None and entity {entity} not bound.")


### PR DESCRIPTION
This addresses the issue I found after updating Kombu. Commit by commit, I identified 1686c35a063761f10f6391b57b06ee1383ef1259 as a source of problems.

This is just my quick attempt to fix the issue. What I still see as a problem is this convoluted code flow:
* (1) publish is called with retrying,
* (2) publish function tries to declare entities if they have not been declared yet,
* (3) declare is called with retrying too, instead of failing early because of the outer retry logic in publish,
* ---
* Closed channels/connections are passed down the stack as args/kwargs without any possibility to refresh them - logic in `Connection.ensure()` just passes args and kwargs to nested calls even if the object (or entity) itself is given a new connection.


This PR does not contain any tests. I am unable to reproduce it in the isolated environment. It fails only in our tests of our project. Tests must be run in a certain order for this problem to manifest. I believe it must be something with `register_after_fork()`  where methods that close sockets are called. 

I am not aware of edge cases where this patch wouldn't work.  If you do, please let me know, or prepare a systematic fix and we can close this PR.

Here is a similar issue that also describes a large connection churn rate: https://github.com/celery/kombu/issues/2273