### PR TITLE
Loosen pin on typing_extensions

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,4 +1,4 @@
-typing_extensions==4.12.2; python_version<"3.10"
+typing_extensions>=4.12.2; python_version<"3.10"
 amqp>=5.1.1,<6.0.0
 vine==5.1.0
 backports.zoneinfo[tzdata]>=0.2.1; python_version<"3.9"


### PR DESCRIPTION
Hi, thanks for this tool!

This PR relaxes the dependency on `typing_extensions==` to be a `>=`: tightly pinning this (very prevalent) package creates all kinds of issues when used in more complex environments. I didn't look deep enough, but it is likely this could be pinned to an even lower value, as `ParamSpec` and `TypeGuard` have been stable for some time.