### PR TITLE
Move use of typing_extensions into TYPE_CHECKING block

### DIFF
--- a/kombu/asynchronous/semaphore.py
+++ b/kombu/asynchronous/semaphore.py
@@ -3,20 +3,19 @@ from __future__ import annotations
 
 import sys
 from collections import deque
-from typing import TYPE_CHECKING, Callable, Deque
-
-if sys.version_info < (3, 10):
-    from typing_extensions import ParamSpec
-else:
-    from typing import ParamSpec
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from types import TracebackType
+    from typing import Callable, Deque
+    if sys.version_info < (3, 10):
+        from typing_extensions import ParamSpec
+    else:
+        from typing import ParamSpec
 
+    P = ParamSpec("P")
 
 __all__ = ('DummyLock', 'LaxBoundedSemaphore')
-
-P = ParamSpec("P")
 
 
 class LaxBoundedSemaphore:

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,4 +1,3 @@
-typing_extensions==4.12.2; python_version<"3.10"
 amqp>=5.1.1,<6.0.0
 vine==5.1.0
 backports.zoneinfo[tzdata]>=0.2.1; python_version<"3.9"

--- a/requirements/pkgutils.txt
+++ b/requirements/pkgutils.txt
@@ -6,3 +6,4 @@ sphinx2rst>=1.0
 bumpversion==0.6.0
 pydocstyle==6.3.0
 mypy==1.14.1
+typing_extensions==4.12.2; python_version<"3.10"


### PR DESCRIPTION
This PR moves all (one) usage of `typing_extensions` into a `if TYPE_CHECKING` block, so that the `typing-extensions` package is not required at runtime.

This might relate to #2281.

First-time contributor, sorry if I haven't followed the right contributing procedure.