### PR TITLE
Typo in pools's documentation

### DIFF
--- a/docs/userguide/pools.rst
+++ b/docs/userguide/pools.rst
@@ -189,4 +189,4 @@ argument:
 
     from kombu import pools
 
-    connections = pools.Connections(limit=pools.use_default_limit)
+    connections = pools.Connections(limit=pools.use_global_limit)


### PR DESCRIPTION
just a typo in documentation about pools.use_global_limit