### PR TITLE
Resolve logger warnings

### DIFF
--- a/kombu/transport/native_delayed_delivery.py
+++ b/kombu/transport/native_delayed_delivery.py
@@ -112,7 +112,7 @@ def bind_queue_to_native_delayed_delivery_exchange(connection: Connection, queue
     for binding_entry in bindings:
         exchange: Exchange = binding_entry.exchange.bind(channel)
         if exchange.type == 'direct':
-            logger.warn(f"Exchange {exchange.name} is a direct exchange "
+            logger.warning(f"Exchange {exchange.name} is a direct exchange "
                         f"and native delayed delivery do not support direct exchanges.\n"
                         f"ETA tasks published to this exchange will block the worker until the ETA arrives.")
             continue


### PR DESCRIPTION
# PR Summary
This small PR resolves the annoying deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```
