### PR TITLE
Allow setting `tags` in initial `boto3.sqs.create_queue` call via `transport_options`

### DIFF
--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -425,7 +425,7 @@ class Channel(virtual.Channel):
             self.transport_options.get('sqs-creation-attributes') or {},
         )
 
-        queue_tags = self.transport_options.get('sqs-queue-tags')
+        queue_tags = self.transport_options.get('queue_tags')
 
         create_params = {
             'QueueName': queue_name,
@@ -1094,7 +1094,7 @@ class Transport(virtual.Transport):
     .. _CreateQueue SQS API: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_CreateQueue.html#API_CreateQueue_RequestParameters
 
     Queue tags can be applied to SQS queues during creation by passing an
-    ``sqs-queue-tags`` key in transport_options. ``sqs-queue-tags`` must be
+    ``queue_tags`` key in transport_options. ``queue_tags`` must be
     a dict of tag key-value pairs.
 
     .. code-block:: python
@@ -1104,7 +1104,7 @@ class Transport(virtual.Transport):
         transport = Transport(
             ...,
             transport_options={
-                'sqs-queue-tags': {
+                'queue_tags': {
                     'Environment': 'production',
                     'Team': 'backend',
                 },

--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -1093,6 +1093,7 @@ class Transport(virtual.Transport):
 
     .. _CreateQueue SQS API: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_CreateQueue.html#API_CreateQueue_RequestParameters
 
+    .. versionadded:: 5.6
     Queue tags can be applied to SQS queues during creation by passing an
     ``queue_tags`` key in transport_options. ``queue_tags`` must be
     a dict of tag key-value pairs.

--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -425,10 +425,17 @@ class Channel(virtual.Channel):
             self.transport_options.get('sqs-creation-attributes') or {},
         )
 
-        return self.sqs(queue=queue_name).create_queue(
-            QueueName=queue_name,
-            Attributes=attributes,
-        )
+        queue_tags = self.transport_options.get('sqs-queue-tags')
+
+        create_params = {
+            'QueueName': queue_name,
+            'Attributes': attributes,
+        }
+
+        if queue_tags:
+            create_params['tags'] = queue_tags
+
+        return self.sqs(queue=queue_name).create_queue(**create_params)
 
     def _delete(self, queue, *args, **kwargs):
         """Delete queue by name."""
@@ -1085,6 +1092,24 @@ class Transport(virtual.Transport):
         )
 
     .. _CreateQueue SQS API: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_CreateQueue.html#API_CreateQueue_RequestParameters
+
+    Queue tags can be applied to SQS queues during creation by passing an
+    ``sqs-queue-tags`` key in transport_options. ``sqs-queue-tags`` must be
+    a dict of tag key-value pairs.
+
+    .. code-block:: python
+
+        from kombu.transport.SQS import Transport
+
+        transport = Transport(
+            ...,
+            transport_options={
+                'sqs-queue-tags': {
+                    'Environment': 'production',
+                    'Team': 'backend',
+                },
+            }
+        )
 
     The ``ApproximateReceiveCount`` message attribute is fetched by this
     transport by default. Requested message attributes can be changed by

--- a/t/unit/transport/test_SQS.py
+++ b/t/unit/transport/test_SQS.py
@@ -312,6 +312,8 @@ class test_Channel:
 
         # For cleanup purposes, delete the queue and the queue file
         self.channel._delete(queue_name)
+        # Reset transport options to avoid leaking state into other tests
+        self.connection.transport_options.pop('sqs-creation-attributes', None)
 
     def test_new_queue_with_tags(self):
         self.connection.transport_options['sqs-queue-tags'] = {
@@ -330,6 +332,8 @@ class test_Channel:
 
         # For cleanup purposes, delete the queue and the queue file
         self.channel._delete(queue_name)
+        # Reset transport options to avoid leaking state into other tests
+        self.connection.transport_options.pop('sqs-queue-tags', None)
 
     def test_botocore_config_override(self):
         expected_connect_timeout = 5

--- a/t/unit/transport/test_SQS.py
+++ b/t/unit/transport/test_SQS.py
@@ -316,7 +316,7 @@ class test_Channel:
         self.connection.transport_options.pop('sqs-creation-attributes', None)
 
     def test_new_queue_with_tags(self):
-        self.connection.transport_options['sqs-queue-tags'] = {
+        self.connection.transport_options['queue_tags'] = {
             'Environment': 'test',
             'Team': 'backend',
         }
@@ -333,7 +333,7 @@ class test_Channel:
         # For cleanup purposes, delete the queue and the queue file
         self.channel._delete(queue_name)
         # Reset transport options to avoid leaking state into other tests
-        self.connection.transport_options.pop('sqs-queue-tags', None)
+        self.connection.transport_options.pop('queue_tags', None)
 
     def test_botocore_config_override(self):
         expected_connect_timeout = 5

--- a/t/unit/transport/test_SQS.py
+++ b/t/unit/transport/test_SQS.py
@@ -60,10 +60,11 @@ class SQSMessageMock:
 class QueueMock:
     """ Hold information about a queue. """
 
-    def __init__(self, url, creation_attributes=None):
+    def __init__(self, url, creation_attributes=None, tags=None):
         self.url = url
         # arguments of boto3.sqs.create_queue
         self.creation_attributes = creation_attributes
+        self.tags = tags
         self.attributes = {'ApproximateNumberOfMessages': '0'}
 
         self.messages = []
@@ -91,10 +92,11 @@ class SQSClientMock:
                 return q
         raise Exception(f"Queue url {url} not found")
 
-    def create_queue(self, QueueName=None, Attributes=None):
+    def create_queue(self, QueueName=None, Attributes=None, tags=None):
         q = self._queues[QueueName] = QueueMock(
             'https://sqs.us-east-1.amazonaws.com/xxx/' + QueueName,
             Attributes,
+            tags,
         )
         return {'QueueUrl': q.url}
 
@@ -307,6 +309,24 @@ class test_Channel:
 
         assert 'KmsMasterKeyId' in queue.creation_attributes
         assert queue.creation_attributes['KmsMasterKeyId'] == 'alias/aws/sqs'
+
+        # For cleanup purposes, delete the queue and the queue file
+        self.channel._delete(queue_name)
+
+    def test_new_queue_with_tags(self):
+        self.connection.transport_options['sqs-queue-tags'] = {
+            'Environment': 'test',
+            'Team': 'backend',
+        }
+        queue_name = 'new_tagged_queue'
+        self.channel._new_queue(queue_name)
+
+        assert queue_name in self.sqs_conn_mock._queues.keys()
+        queue = self.sqs_conn_mock._queues[queue_name]
+
+        assert queue.tags is not None
+        assert queue.tags['Environment'] == 'test'
+        assert queue.tags['Team'] == 'backend'
 
         # For cleanup purposes, delete the queue and the queue file
         self.channel._delete(queue_name)


### PR DESCRIPTION
This adds support for tagging SQS queues provisioned by Kombu. This helps with grouping/filtering queues and metrics reported from queues.

There is no existing issue this fixes, but I can create one if that is a requirement. It wasn't clear from the Contributing section in the README if it is.