### PR TITLE
Hotfix(aws_ssl): validate secure connection

### DIFF
--- a/kombu/asynchronous/aws/connection.py
+++ b/kombu/asynchronous/aws/connection.py
@@ -7,7 +7,7 @@ from email.mime.message import MIMEMessage
 
 from vine import promise, transform
 
-from kombu.asynchronous.aws.ext import AWSRequest, get_response
+from kombu.asynchronous.aws.ext import AWSRequest, get_cert_path, get_response
 from kombu.asynchronous.http import Headers, Request, get_client
 
 
@@ -92,7 +92,8 @@ class AsyncHTTPSConnection:
         headers = Headers(self.headers)
         return self.Request(self.path, method=self.method, headers=headers,
                             body=self.body, connect_timeout=self.timeout,
-                            request_timeout=self.timeout, validate_cert=False)
+                            request_timeout=self.timeout,
+                            validate_cert=True, ca_certs=get_cert_path(True))
 
     def getresponse(self, callback=None):
         request = self.getrequest()

--- a/kombu/asynchronous/aws/ext.py
+++ b/kombu/asynchronous/aws/ext.py
@@ -6,6 +6,7 @@ try:
     import boto3
     from botocore import exceptions
     from botocore.awsrequest import AWSRequest
+    from botocore.httpsession import get_cert_path
     from botocore.response import get_response
 except ImportError:
     boto3 = None
@@ -19,8 +20,9 @@ except ImportError:
     exceptions.BotoCoreError = BotoCoreError
     AWSRequest = _void()
     get_response = _void()
+    get_cert_path = _void()
 
 
 __all__ = (
-    'exceptions', 'AWSRequest', 'get_response'
+    'exceptions', 'AWSRequest', 'get_response', 'get_cert_path',
 )

--- a/t/unit/asynchronous/aws/test_connection.py
+++ b/t/unit/asynchronous/aws/test_connection.py
@@ -90,6 +90,13 @@ class test_AsyncHTTPSConnection(AWSCase):
             validate_cert=VALIDATES_CERT,
         )
 
+    def test_request_with_cert_path_https(self):
+        x = AsyncHTTPSConnection("https://example.com")
+        request = x.getrequest()
+        assert request.validate_cert is True
+        assert request.ca_certs is not None
+        assert request.ca_certs.endswith('.pem')
+
     def test_getresponse(self):
         client = Mock(name='client')
         client.add_request = passthrough(name='client.add_request')


### PR DESCRIPTION
same as in boto3

originally disabled
fixed in https://github.com/celery/kombu/pull/2094
re-introduced in https://github.com/celery/kombu/pull/2114
fixed (like this) in https://github.com/celery/kombu/pull/2134
re-introduced in https://github.com/celery/kombu/pull/2261
fixed again here