### PR TITLE
Docs: Fix incorrect "added in 5.6.0" note for sts_token_timeout in SQS transport docs

### DIFF
--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -76,7 +76,7 @@ exist in AWS) you can tell this transport about them as follows:
         },
       }
     'sts_role_arn': 'arn:aws:iam::<xxx>:role/STSTest', # optional
-    'sts_token_timeout': 900, # optional, added in 5.6.0
+    'sts_token_timeout': 900, # optional
     'sts_token_buffer_time': 0, # optional, added in 5.6.0
     }
 


### PR DESCRIPTION
@auvipy This PR corrects the documentation error introduced in merged PR [#2216](https://github.com/celery/kombu/pull/2216) where `sts_token_timeout` was incorrectly marked as "added in 5.6.0". The sts_token_timeout configuration option actually existed prior to version 5.6.0. Please merge this to fix the documentation