### PR TITLE
Switch to the next host on connection error

### DIFF
--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -560,6 +560,7 @@ class Connection:
                         self._debug('ensure retry policy error: %r',
                                     exc, exc_info=1)
                     except conn_errors as exc:
+                        self.maybe_switch_next()  # select next host
                         if got_connection and not has_modern_errors:
                             # transport can not distinguish between
                             # recoverable/irrecoverable errors, so we propagate


### PR DESCRIPTION
When having a connection error, like a PRECONDITION_FAILED because of missing replica of a stream queue in RabbitMQ, then we can safely cycle through the list of hosts given in the connection string instead of keep retrying on the same one.