### PR TITLE
Cycle through host before calling errback

### DIFF
--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -446,11 +446,14 @@ class Connection:
 
         def on_error(exc, intervals, retries, interval=0):
             round = self.completes_cycle(retries)
+            # NOTE(arnaud/OVH) we changed this to select next host
+            # before going down to errback, because errback was raising
+            # a TimeoutError, preventing the retry to cycle through hosts
+            self.maybe_switch_next()  # select next host
             if round:
                 interval = next(intervals)
             if errback:
                 errback(exc, interval)
-            self.maybe_switch_next()  # select next host
 
             return interval if round else 0
 

--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -565,6 +565,7 @@ class Connection:
                         self._debug('ensure retry policy error: %r',
                                     exc, exc_info=1)
                     except conn_errors as exc:
+                        self.maybe_switch_next()  # select next host
                         if got_connection and not has_modern_errors:
                             # transport can not distinguish between
                             # recoverable/irrecoverable errors, so we propagate

--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -446,14 +446,16 @@ class Connection:
 
         def on_error(exc, intervals, retries, interval=0):
             round = self.completes_cycle(retries)
-            # NOTE(arnaud/OVH) we changed this to select next host
-            # before going down to errback, because errback was raising
-            # a TimeoutError, preventing the retry to cycle through hosts
-            self.maybe_switch_next()  # select next host
             if round:
                 interval = next(intervals)
-            if errback:
-                errback(exc, interval)
+            try:
+                if errback:
+                    errback(exc, interval)
+            finally:
+                # Select next host after invoking errback so that the
+                # callback can inspect the failing host, but always
+                # switch even if errback raises.
+                self.maybe_switch_next()
 
             return interval if round else 0
 


### PR DESCRIPTION
In oslo.messaging error callback (named _recoverable_error_callback), the code is raising an TimeoutError, which is preventing continuation of the retry in some situation.
This quick fix switch the selection of next host (cycle) before calling the error callback. Then, on next ensure_connection, the new host is selected and we expect it to work correctly :)

See: lp-2096926