### PR TITLE
Normalize mongodb options keys

### DIFF
--- a/kombu/transport/mongodb.py
+++ b/kombu/transport/mongodb.py
@@ -329,12 +329,16 @@ class Channel(virtual.Channel):
             # Only set the lowercase key if it does not exist, or if it exists and has the same value
             if lk not in normalized or normalized[lk] == val:
                 normalized[lk] = val
+            elif normalized[lk] == val:
+                # Values match, no action needed
+                pass
             else:
                 # Conflict: keys differ only in case and have different values; log a warning
                 warnings.warn(
                     f"MongoDB transport: Option conflict for key '{k}' and '{lk}' with different values: "
                     f"{normalized.get(lk)!r} vs {val!r}. Using value for '{k}'."
                 )
+                # Do not overwrite the existing value for lk
         options = normalized
         options = self._prepare_client_options(options)
 

--- a/kombu/transport/mongodb.py
+++ b/kombu/transport/mongodb.py
@@ -327,7 +327,7 @@ class Channel(virtual.Channel):
             normalized[k] = val
             lk = k.lower()
             # Only set the lowercase key if it does not exist, or if it exists and has the same value
-            if lk not in normalized:
+            if lk not in normalized or normalized[lk] == val:
                 normalized[lk] = val
             else:
                 # Conflict: keys differ only in case and have different values; log a warning

--- a/kombu/transport/mongodb.py
+++ b/kombu/transport/mongodb.py
@@ -321,6 +321,14 @@ class Channel(virtual.Channel):
                                  if self.connect_timeout else None),
         }
         options.update(parsed['options'])
+        normalized = {}
+        for k, v in options.items():
+            val = v[0] if isinstance(v, list) and len(v) == 1 else v
+            normalized[k] = val
+            lk = k.lower()
+            if lk not in normalized:
+                normalized[lk] = val
+        options = normalized
         options = self._prepare_client_options(options)
 
         if 'tls' in options:

--- a/kombu/transport/mongodb.py
+++ b/kombu/transport/mongodb.py
@@ -329,8 +329,6 @@ class Channel(virtual.Channel):
             # Only set the lowercase key if it does not exist, or if it exists and has the same value
             if lk not in normalized:
                 normalized[lk] = val
-            elif normalized[lk] == val:
-                pass  # already set to the same value, do nothing
             else:
                 # Conflict: keys differ only in case and have different values; skip or handle as needed
                 pass  # Optionally, log a warning here

--- a/kombu/transport/mongodb.py
+++ b/kombu/transport/mongodb.py
@@ -36,6 +36,7 @@ Transport Options
 from __future__ import annotations
 
 import datetime
+import warnings
 from queue import Empty
 
 import pymongo

--- a/kombu/transport/mongodb.py
+++ b/kombu/transport/mongodb.py
@@ -330,8 +330,11 @@ class Channel(virtual.Channel):
             if lk not in normalized:
                 normalized[lk] = val
             else:
-                # Conflict: keys differ only in case and have different values; skip or handle as needed
-                pass  # Optionally, log a warning here
+                # Conflict: keys differ only in case and have different values; log a warning
+                warnings.warn(
+                    f"MongoDB transport: Option conflict for key '{k}' and '{lk}' with different values: "
+                    f"{normalized.get(lk)!r} vs {val!r}. Using value for '{k}'."
+                )
         options = normalized
         options = self._prepare_client_options(options)
 

--- a/kombu/transport/mongodb.py
+++ b/kombu/transport/mongodb.py
@@ -326,9 +326,14 @@ class Channel(virtual.Channel):
             val = v[0] if isinstance(v, list) and len(v) == 1 else v
             normalized[k] = val
             lk = k.lower()
-            # Always set the lowercase key, unless it already exists with a different value
-            if lk not in normalized or normalized[lk] == normalized[k]:
+            # Only set the lowercase key if it does not exist, or if it exists and has the same value
+            if lk not in normalized:
                 normalized[lk] = val
+            elif normalized[lk] == val:
+                pass  # already set to the same value, do nothing
+            else:
+                # Conflict: keys differ only in case and have different values; skip or handle as needed
+                pass  # Optionally, log a warning here
         options = normalized
         options = self._prepare_client_options(options)
 

--- a/kombu/transport/mongodb.py
+++ b/kombu/transport/mongodb.py
@@ -326,7 +326,8 @@ class Channel(virtual.Channel):
             val = v[0] if isinstance(v, list) and len(v) == 1 else v
             normalized[k] = val
             lk = k.lower()
-            if lk not in normalized:
+            # Always set the lowercase key, unless it already exists with a different value
+            if lk not in normalized or normalized[lk] == normalized[k]:
                 normalized[lk] = val
         options = normalized
         options = self._prepare_client_options(options)


### PR DESCRIPTION
This PR fixes a failing test in test_mongodb_uri_parsing.test_replicaset_hosts caused by options retaining camelCase keys (replicaSet) and list values from uri_parser.parse_uri.


### Changes:

-     Added normalization step to lowercase all option keys and flatten single-item lists.

This restores expected behavior where options['replicaset'] == 'test_rs' and aligns with how Kombu handles other parsed URI options.