### PR TITLE
Remove misused argument for autoflake

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     rev: v2.3.1
     hooks:
       - id: autoflake
-        args: ["--in-place", "--ignore-pass-after-docstring", "--imports"]
+        args: ["--in-place", "--ignore-pass-after-docstring"]
 
   - repo: https://github.com/PyCQA/flake8
     rev: 7.1.1


### PR DESCRIPTION
## Problem 
The flag `--imports` [requires a comma separated list of additional modules/packages to remove](https://github.com/PyCQA/autoflake/blob/main/autoflake.py#L1378), but none were given.
The `pre-commit` doesn't fail whenever there is more than one file in the same commit, as the first file will be fed into the `--imports` parameter - and effectively ignored - while the second file will be fed into the `files` positional parameter.
This meant that single file commits were failing the pre-commit checks.

## Fix
Remove the `--imports` flag as practically it wasn't used, this way all files are passed into the `files` positional parameter.

### Before
```shell
$ pre-commit run autoflake --files kombu/transport/redis.py
autoflake................................................................Failed
- hook id: autoflake
- exit code: 2

usage: autoflake [-h] [-c | -cd] [--imports IMPORTS |
                 --remove-all-unused-imports] [-r] [-j n] [--exclude globs]
                 [--expand-star-imports] [--ignore-init-module-imports]
                 [--remove-duplicate-keys] [--remove-unused-variables]
                 [--remove-rhs-for-unused-variables]
                 [--ignore-pass-statements] [--ignore-pass-after-docstring]
                 [--version] [--quiet] [-v]
                 [--stdin-display-name STDIN_DISPLAY_NAME]
                 [--config CONFIG_FILE] [-i | -s]
                 files [files ...]
autoflake: error: the following arguments are required: files
```

### After
```shell
$ pre-commit run autoflake --files kombu/transport/redis.py         
autoflake................................................................Passed
```