### PR TITLE
Prepare for (pre) release: v5.6.0rc1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.6.0b3
+current_version = 5.6.0rc1
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?P<releaselevel>[a-z]+)?

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -4,6 +4,87 @@
  Change history
 ================
 
+.. _version-5.6.0rc1:
+
+5.6.0rc1
+=======
+:release-date: 28 September, 2025
+:release-by: Tomer Nosrati
+
+Key Highlights
+~~~~~~~~~~~~~~
+
+QoS Max Prefetch Limit
+----------------------
+
+`PR #2348 <https://github.com/celery/kombu/pull/2348>`_
+
+Prevent Out Of Memory crashes when queues flood with ETA/countdown tasks. The new optional ``max_prefetch`` parameter caps how many messages workers hold in memory. Defaults to unlimited (``None``) to preserve existing behavior.
+
+.. code-block:: python
+
+    from kombu.common import QoS
+
+    # Limit prefetch to maximum 100 messages
+    qos = QoS(callback=consumer.qos, initial_value=10, max_prefetch=100)
+
+Redis Polling Interval Support
+------------------------------
+
+`PR #2346 <https://github.com/celery/kombu/pull/2346>`_
+
+Fix Redis transport to properly propagate ``polling_interval`` and ``brpop_timeout`` from ``transport_options`` to the Channel's ``_brpop_start`` timeout.
+
+.. code-block:: python
+
+    app.conf.broker_transport_options = {"polling_interval": 10}
+
+Leave it unset to keep the familiar 1-second default, or raise it to slow down idle polling.
+
+Pidbox RabbitMQ 4.x Compatibility
+---------------------------------
+
+`PR #2338 <https://github.com/celery/kombu/pull/2338>`_
+
+Let pidbox queues work on RabbitMQ 4.x brokers that reject transient, non-exclusive queues.
+
+MongoDB Transport Improvements
+------------------------------
+
+`PR #2347 <https://github.com/celery/kombu/pull/2347>`_
+
+URI options now come through lowercase and flattened again, so settings like ``replicaSet=test_rs`` show up as ``options['replicaset']``.
+
+Resource Pool Gevent Compatibility
+----------------------------------
+
+`PR #2314 <https://github.com/celery/kombu/pull/2314>`_
+
+Restore compatibility with recent gevent releases that monkey-patch the standard library queue.
+
+Timezone-aware UTC Timestamps
+-----------------------------
+
+`PR #2355 <https://github.com/celery/kombu/pull/2355>`_
+
+Replace every usage of ``datetime.utcnow()`` with ``datetime.now(timezone.utc)`` to return timezone-aware UTC datetimes.
+
+Redis Client Name Support
+----------------------------------
+
+`PR #2367 <https://github.com/celery/kombu/pull/2367>`_
+
+Support for propagating the ``client_name`` connection parameter through the Redis transport (including Sentinel) so that connections appear with meaningful names in monitoring tools.
+
+What's Changed
+~~~~~~~~~~~~~~
+
+- Bump mypy from 1.14.1 to 1.18.1 AGAIN (#2363)
+- Remove nested query from sqlalchemy _size (#2315)
+- Remove misused argument for autoflake (#2368)
+- Support client_name connection parameter for redis transport (#2367)
+- Prepare for (pre) release: v5.6.0rc1 (#2369)
+
 .. _version-5.6.0b3:
 
 5.6.0b3

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@
 
 |build-status| |coverage| |license| |wheel| |pyversion| |pyimp| |downloads|
 
-:Version: 5.6.0b3
+:Version: 5.6.0rc1
 :Documentation: https://kombu.readthedocs.io/
 :Download: https://pypi.org/project/kombu/
 :Source: https://github.com/celery/kombu/

--- a/docs/includes/introduction.txt
+++ b/docs/includes/introduction.txt
@@ -1,4 +1,4 @@
-:Version: 5.6.0b3
+:Version: 5.6.0rc1
 :Web: https://kombu.readthedocs.io/
 :Download: https://pypi.org/project/kombu/
 :Source: https://github.com/celery/kombu/

--- a/kombu/__init__.py
+++ b/kombu/__init__.py
@@ -8,7 +8,7 @@ import sys
 from collections import namedtuple
 from typing import Any, cast
 
-__version__ = '5.6.0b3'
+__version__ = '5.6.0rc1'
 __author__ = 'Ask Solem'
 __contact__ = 'auvipy@gmail.com'
 __homepage__ = 'https://kombu.readthedocs.io'


### PR DESCRIPTION
CI passes locally on Mac:
```console
  3.13-unit: OK (221.86=setup[110.92]+cmd[110.94] seconds)
  3.13-linux-integration-py-amqp: OK (215.55=setup[168.75]+cmd[46.81] seconds)
  3.13-linux-integration-redis: OK (159.48=setup[139.54]+cmd[19.94] seconds)
  3.13-linux-integration-mongodb: OK (443.21=setup[217.08]+cmd[226.14] seconds)
  3.13-linux-integration-kafka: OK (219.04=setup[157.99]+cmd[61.06] seconds)
  congratulations :) (443.82 seconds)
  clean: OK (20.41=setup[17.92]+cmd[1.23,1.26] seconds)
  lint: OK (90.73=setup[17.56]+cmd[73.17] seconds)
  mypy: OK (86.94=setup[45.75]+cmd[41.19] seconds)
  parallel: OK (467.09=setup[21.78]+cmd[445.31] seconds)
  congratulations :) (467.78 seconds)
```