### PR TITLE
Update requirements to remove backports.zoneinfo

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,5 +1,4 @@
 amqp>=5.1.1,<6.0.0
 vine==5.1.0
-backports.zoneinfo[tzdata]>=0.2.1; python_version<"3.9"
 tzdata>=2025.2; python_version>="3.9"
 packaging


### PR DESCRIPTION
Remove backports.zoneinfo dependency for Python < 3.9.