### PR TITLE
fix: default value for SQS's receive message

### DIFF
--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -545,14 +545,10 @@ class Channel(virtual.Channel):
         client = self.sqs(queue=queue)
 
         message_system_attribute_names = self.get_message_attributes.get(
-            'MessageSystemAttributeNames')
-        if message_system_attribute_names is None:
-            message_attribute_names = ['All']
+            'MessageSystemAttributeNames') or []
 
         message_attribute_names = self.get_message_attributes.get(
-            'MessageAttributeNames')
-        if message_attribute_names is None:
-            message_attribute_names = ['All']
+            'MessageAttributeNames') or []
 
         params: dict[str, Any] = {
             'QueueUrl': q_url,
@@ -969,7 +965,7 @@ class Channel(virtual.Channel):
 
         if fetch is None or isinstance(fetch, str):
             return {
-                'MessageAttributeNames': ['All'],
+                'MessageAttributeNames': [],
                 'MessageSystemAttributeNames': [APPROXIMATE_RECEIVE_COUNT],
             }
 
@@ -993,7 +989,7 @@ class Channel(virtual.Channel):
                 )
 
         return {
-            'MessageAttributeNames': sorted(message_attrs) if message_attrs else ['All'],
+            'MessageAttributeNames': sorted(message_attrs) if message_attrs else [],
             'MessageSystemAttributeNames': (
                 sorted(message_system_attrs) if message_system_attrs else [APPROXIMATE_RECEIVE_COUNT]
             )

--- a/t/unit/transport/test_SQS.py
+++ b/t/unit/transport/test_SQS.py
@@ -125,8 +125,8 @@ class SQSClientMock:
         QueueUrl=None,
         MaxNumberOfMessages=1,
         WaitTimeSeconds=10,
-        MessageAttributeNames=None,
-        MessageSystemAttributeNames=None
+        MessageAttributeNames=[],
+        MessageSystemAttributeNames=[],
     ):
         assert isinstance(MessageAttributeNames, (list, tuple))
         assert isinstance(MessageSystemAttributeNames, (list, tuple))


### PR DESCRIPTION
After #2300, `MessageAttributeNames` and `MessageSystemAttributeNames` had `None` as default values, but `None` is not a valid value for those fields. See:

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sqs/client/receive_message.html

This commit suggests adding `[]` as the new default value for those fields following the error message below and the docs above.

Closes #2403