### PR TITLE
Simplify requirements given Py3.9+ baseline

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,4 +1,4 @@
 amqp>=5.1.1,<6.0.0
 vine==5.1.0
-tzdata>=2025.2; python_version>="3.9"
+tzdata>=2025.2
 packaging

--- a/requirements/test-ci.txt
+++ b/requirements/test-ci.txt
@@ -1,5 +1,4 @@
-pytest-cov==5.0.0; python_version<"3.9"
-pytest-cov==7.0.0; python_version>="3.9"
+pytest-cov==7.0.0
 codecov==2.1.13; sys_platform == 'win32'
 librabbitmq>=2.0.0; sys_platform == 'win32'
 -r extras/redis.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,5 +3,4 @@ Pyro4==4.82
 pytest-freezer==0.4.9
 pytest-sugar==1.1.1
 pytest==8.4.2
-pre-commit>=3.5.0,<3.8.0; python_version < '3.9'
-pre-commit>=4.0.1; python_version >= '3.9'
+pre-commit>=4.0.1


### PR DESCRIPTION
Some nitpicky/pedantic cleanups for the `requirements.txt` files, given that the [baseline installation Python version is Python3.9-or-later](https://github.com/celery/kombu/blob/88225114201a6a0e13f9fb67f49131a250cc7bf7/setup.py#L97).

Follow-up to PR #2241.