### PR TITLE
Add support for MessageGroupId in standard queues

### DIFF
--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -460,24 +460,21 @@ class Channel(virtual.Channel):
         kwargs = {'QueueUrl': q_url}
         if 'properties' in message:
             if 'message_attributes' in message['properties']:
-                # we don't want to want to have the attribute in the body
-                kwargs['MessageAttributes'] = \
-                    message['properties'].pop('message_attributes')
+                kwargs['MessageAttributes'] = message['properties'].pop('message_attributes')
+
             if queue.endswith('.fifo'):
-                if 'MessageGroupId' in message['properties']:
-                    kwargs['MessageGroupId'] = \
-                        message['properties']['MessageGroupId']
-                else:
-                    kwargs['MessageGroupId'] = 'default'
+                kwargs['MessageGroupId'] = message['properties'].get('MessageGroupId') or 'default'
+
                 if 'MessageDeduplicationId' in message['properties']:
-                    kwargs['MessageDeduplicationId'] = \
-                        message['properties']['MessageDeduplicationId']
+                    kwargs['MessageDeduplicationId'] = message['properties']['MessageDeduplicationId']
                 else:
                     kwargs['MessageDeduplicationId'] = str(uuid.uuid4())
             else:
-                if "DelaySeconds" in message['properties']:
-                    kwargs['DelaySeconds'] = \
-                        message['properties']['DelaySeconds']
+                if 'DelaySeconds' in message['properties']:
+                    kwargs['DelaySeconds'] = message['properties']['DelaySeconds']
+
+                if 'MessageGroupId' in message['properties']:
+                    kwargs['MessageGroupId'] = message['properties']['MessageGroupId']
 
         if self.sqs_base64_encoding:
             body = AsyncMessage().encode(dumps(message))


### PR DESCRIPTION
AWS now supports MessageGroupId on standard queues to enable fair queues, which mitigate the “noisy neighbor” impact in multi-tenant queues and help maintain consistent message dwell times across tenants
(https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-fair-queues.html).

This change ensures:

FIFO queues always get MessageGroupId (defaulting to default) and MessageDeduplicationId.
Standard queues can pass MessageGroupId without triggering FIFO-only logic.

Note: reopened PR from branch instead of main** 