### PR TITLE
Add support for MessageGroupId in standard queues

### DIFF
--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -463,7 +463,10 @@ class Channel(virtual.Channel):
                 kwargs['MessageAttributes'] = message['properties'].pop('message_attributes')
 
             if queue.endswith('.fifo'):
-                kwargs['MessageGroupId'] = message['properties'].get('MessageGroupId') or 'default'
+                message_group_id = message['properties'].get('MessageGroupId')
+                if message_group_id is None:
+                    message_group_id = 'default'
+                kwargs['MessageGroupId'] = message_group_id
 
                 if 'MessageDeduplicationId' in message['properties']:
                     kwargs['MessageDeduplicationId'] = message['properties']['MessageDeduplicationId']

--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -460,24 +460,21 @@ class Channel(virtual.Channel):
         kwargs = {'QueueUrl': q_url}
         if 'properties' in message:
             if 'message_attributes' in message['properties']:
-                # we don't want to want to have the attribute in the body
-                kwargs['MessageAttributes'] = \
-                    message['properties'].pop('message_attributes')
+                kwargs['MessageAttributes'] = message['properties'].pop('message_attributes')
+
             if queue.endswith('.fifo'):
-                if 'MessageGroupId' in message['properties']:
-                    kwargs['MessageGroupId'] = \
-                        message['properties']['MessageGroupId']
-                else:
-                    kwargs['MessageGroupId'] = 'default'
+                kwargs['MessageGroupId'] = message['properties'].get('MessageGroupId') or 'default'
+
                 if 'MessageDeduplicationId' in message['properties']:
-                    kwargs['MessageDeduplicationId'] = \
-                        message['properties']['MessageDeduplicationId']
+                    kwargs['MessageDeduplicationId'] = message['properties']['MessageDeduplicationId']
                 else:
                     kwargs['MessageDeduplicationId'] = str(uuid.uuid4())
             else:
-                if "DelaySeconds" in message['properties']:
-                    kwargs['DelaySeconds'] = \
-                        message['properties']['DelaySeconds']
+                if 'DelaySeconds' in message['properties']:
+                    kwargs['DelaySeconds'] = message['properties']['DelaySeconds']
+
+                if 'MessageGroupId' in message['properties']:
+                    kwargs['MessageGroupId'] = message['properties']['MessageGroupId']
 
         if self.sqs_base64_encoding:
             body = AsyncMessage().encode(dumps(message))

--- a/t/unit/transport/test_SQS.py
+++ b/t/unit/transport/test_SQS.py
@@ -1183,6 +1183,41 @@ class test_Channel:
         assert sqs_queue_mock.send_message.call_args[1]['MessageGroupId'] == expected
         assert 'MessageDeduplicationId' in sqs_queue_mock.send_message.call_args[1]
 
+    @pytest.mark.parametrize('dedup_id,should_match', [
+        ('custom-dedup-id', True),
+        (None, False),
+    ])
+    def test_predefined_queues_put_to_fifo_queue_message_deduplication_id(
+            self, dedup_id, should_match):
+        connection = Connection(transport=SQS.Transport, transport_options={
+            'predefined_queues': example_predefined_queues,
+        })
+        channel = connection.channel()
+
+        queue_name = 'queue-3.fifo'
+
+        exchange = Exchange('test_SQS', type='direct')
+        p = messaging.Producer(channel, exchange, routing_key=queue_name)
+
+        queue = Queue(queue_name, exchange, queue_name)
+        queue(channel).declare()
+
+        channel.sqs = Mock()
+        sqs_queue_mock = Mock()
+        channel.sqs.return_value = sqs_queue_mock
+
+        if dedup_id is not None:
+            p.publish('message', MessageDeduplicationId=dedup_id)
+        else:
+            p.publish('message')
+
+        sqs_queue_mock.send_message.assert_called_once()
+        assert 'MessageDeduplicationId' in sqs_queue_mock.send_message.call_args[1]
+        if should_match:
+            assert sqs_queue_mock.send_message.call_args[1]['MessageDeduplicationId'] == dedup_id
+        else:
+            assert len(sqs_queue_mock.send_message.call_args[1]['MessageDeduplicationId']) == 36
+
     def test_predefined_queues_put_to_queue(self):
         connection = Connection(transport=SQS.Transport, transport_options={
             'predefined_queues': example_predefined_queues,

--- a/t/unit/transport/test_SQS.py
+++ b/t/unit/transport/test_SQS.py
@@ -1277,7 +1277,6 @@ class test_Channel:
             assert sqs_queue_mock.send_message.call_args[1]['MessageGroupId'] == message_group_id
         else:
             assert 'MessageGroupId' not in sqs_queue_mock.send_message.call_args[1]
-        # MessageDeduplicationId should NOT be set for standard queues
         assert 'MessageDeduplicationId' not in sqs_queue_mock.send_message.call_args[1]
 
     @pytest.mark.parametrize('predefined_queues', (


### PR DESCRIPTION
AWS now supports MessageGroupId on standard queues to enable fair queues, which mitigate the “noisy neighbor” impact in multi-tenant queues and help maintain consistent message dwell times across tenants
(https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-fair-queues.html).

This change ensures:

FIFO queues always get MessageGroupId (defaulting to default) and MessageDeduplicationId.
Standard queues can pass MessageGroupId without triggering FIFO-only logic.

Note: reopened PR from branch instead of main**