### PR TITLE
feat(gcpubsub): update existing subscriptions on config changes

### DIFF
--- a/kombu/transport/gcpubsub.py
+++ b/kombu/transport/gcpubsub.py
@@ -55,7 +55,7 @@ from uuid import NAMESPACE_OID, uuid3
 from _socket import gethostname
 from _socket import timeout as socket_timeout
 from google.api_core.exceptions import (AlreadyExists, DeadlineExceeded,
-                                        PermissionDenied)
+                                        GoogleAPICallError, PermissionDenied)
 from google.api_core.retry import Retry
 from google.cloud import monitoring_v3
 from google.cloud.monitoring_v3 import query
@@ -346,9 +346,7 @@ class Channel(virtual.Channel):
                     }
                 )
                 logger.info('subscription updated: %s', subscription_path)
-            except Exception as e:
-                # Log error but don't fail - allow worker to continue
-                # with existing subscription settings
+            except (GoogleAPICallError, PermissionDenied) as e:
                 logger.warning(
                     'failed to update subscription: %s, error: %s',
                     subscription_path,

--- a/kombu/transport/gcpubsub.py
+++ b/kombu/transport/gcpubsub.py
@@ -64,6 +64,8 @@ from google.cloud.pubsub_v1 import exceptions as pubsub_exceptions
 from google.cloud.pubsub_v1.publisher import exceptions as publisher_exceptions
 from google.cloud.pubsub_v1.subscriber import \
     exceptions as subscriber_exceptions
+from google.cloud.pubsub_v1.types import Subscription
+from google.protobuf.field_mask_pb2 import FieldMask
 from google.pubsub_v1 import gapic_version as package_version
 
 from kombu.entity import TRANSIENT_DELIVERY_MODE
@@ -304,6 +306,18 @@ class Channel(virtual.Channel):
         topic_path = topic_path or self.publisher.topic_path(
             project_id, topic_id
         )
+        msg_retention = msg_retention or self.expiration_seconds
+        subscription_config = {
+            "name": subscription_path,
+            "topic": topic_path,
+            'ack_deadline_seconds': self.ack_deadline_seconds,
+            'expiration_policy': {
+                'ttl': f'{self.expiration_seconds}s'
+            },
+            'message_retention_duration': f'{msg_retention}s',
+            **(filter_args or {}),
+        }
+        
         try:
             logger.debug(
                 'creating subscription: %s, topic: %s, filter: %s',
@@ -311,21 +325,35 @@ class Channel(virtual.Channel):
                 topic_path,
                 filter_args,
             )
-            msg_retention = msg_retention or self.expiration_seconds
-            self.subscriber.create_subscription(
-                request={
-                    "name": subscription_path,
-                    "topic": topic_path,
-                    'ack_deadline_seconds': self.ack_deadline_seconds,
-                    'expiration_policy': {
-                        'ttl': f'{self.expiration_seconds}s'
-                    },
-                    'message_retention_duration': f'{msg_retention}s',
-                    **(filter_args or {}),
-                }
-            )
+            self.subscriber.create_subscription(request=subscription_config)
         except AlreadyExists:
-            pass
+            # Subscription exists, update with current configuration
+            logger.debug('subscription exists, updating: %s', subscription_path)
+            try:
+                subscription = Subscription(subscription_config)
+                update_mask = FieldMask(paths=[
+                    'ack_deadline_seconds',
+                    'expiration_policy.ttl',
+                    'message_retention_duration',
+                ])
+                if filter_args:
+                    update_mask.paths.append('filter')
+                
+                self.subscriber.update_subscription(
+                    request={
+                        'subscription': subscription,
+                        'update_mask': update_mask
+                    }
+                )
+                logger.info('subscription updated: %s', subscription_path)
+            except Exception as e:
+                # Log error but don't fail - allow worker to continue
+                # with existing subscription settings
+                logger.warning(
+                    'failed to update subscription: %s, error: %s',
+                    subscription_path,
+                    e,
+                )
         return subscription_path
 
     def _delete(self, queue, *args, **kwargs):

--- a/kombu/transport/gcpubsub.py
+++ b/kombu/transport/gcpubsub.py
@@ -317,7 +317,7 @@ class Channel(virtual.Channel):
             'message_retention_duration': f'{msg_retention}s',
             **(filter_args or {}),
         }
-        
+
         try:
             logger.debug(
                 'creating subscription: %s, topic: %s, filter: %s',
@@ -338,7 +338,7 @@ class Channel(virtual.Channel):
                 ])
                 if filter_args:
                     update_mask.paths.append('filter')
-                
+
                 self.subscriber.update_subscription(
                     request={
                         'subscription': subscription,

--- a/kombu/transport/gcpubsub.py
+++ b/kombu/transport/gcpubsub.py
@@ -346,7 +346,7 @@ class Channel(virtual.Channel):
                     }
                 )
                 logger.info('subscription updated: %s', subscription_path)
-            except (GoogleAPICallError, PermissionDenied) as e:
+            except GoogleAPICallError as e:
                 logger.warning(
                     'failed to update subscription: %s, error: %s',
                     subscription_path,

--- a/t/unit/transport/test_gcpubsub.py
+++ b/t/unit/transport/test_gcpubsub.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 from _socket import timeout as socket_timeout
 from google.api_core.exceptions import (AlreadyExists, DeadlineExceeded,
-                                        PermissionDenied)
+                                        GoogleAPICallError, PermissionDenied)
 from google.pubsub_v1.types.pubsub import Subscription
 
 from kombu.transport.gcpubsub import (AtomicCounter, Channel, QueueDescriptor,
@@ -389,9 +389,9 @@ class test_Channel:
         channel.subscriber.create_subscription = MagicMock(
             side_effect=AlreadyExists("Subscription exists")
         )
-        # Mock update fails
+        # Mock update fails with Google API error
         channel.subscriber.update_subscription = MagicMock(
-            side_effect=Exception("API Error")
+            side_effect=GoogleAPICallError("API Error")
         )
 
         # Should not raise exception - just log warning

--- a/t/unit/transport/test_gcpubsub.py
+++ b/t/unit/transport/test_gcpubsub.py
@@ -322,7 +322,7 @@ class test_Channel:
             subscription_path=subscription_path,
             topic_path=topic_path,
         )
-        
+
         assert result == subscription_path
         channel.subscriber.create_subscription.assert_called_once()
         # Verify update was called
@@ -401,7 +401,7 @@ class test_Channel:
             subscription_path=subscription_path,
             topic_path=topic_path,
         )
-        
+
         assert result == subscription_path
         channel.subscriber.update_subscription.assert_called_once()
 

--- a/t/unit/transport/test_gcpubsub.py
+++ b/t/unit/transport/test_gcpubsub.py
@@ -334,6 +334,7 @@ class test_Channel:
         # Verify the subscription object contains correct values
         subscription = update_call['request']['subscription']
         assert subscription.name == subscription_path
+        assert subscription.topic == topic_path
         assert subscription.ack_deadline_seconds == 60
         assert subscription.expiration_policy.ttl.total_seconds() == 86400
         assert subscription.message_retention_duration.total_seconds() == 86400

--- a/t/unit/transport/test_gcpubsub.py
+++ b/t/unit/transport/test_gcpubsub.py
@@ -305,7 +305,7 @@ class test_Channel:
         topic_path = "topic_path"
         channel.ack_deadline_seconds = 60
         channel.expiration_seconds = 86400
-        
+
         # Mock subscription already exists
         channel.subscriber.subscription_path = MagicMock(
             return_value=subscription_path
@@ -315,7 +315,7 @@ class test_Channel:
             side_effect=AlreadyExists("Subscription exists")
         )
         channel.subscriber.update_subscription = MagicMock()
-        
+
         result = channel._create_subscription(
             project_id=channel.project_id,
             topic_id=topic_id,
@@ -330,14 +330,14 @@ class test_Channel:
         update_call = channel.subscriber.update_subscription.call_args[1]
         assert 'subscription' in update_call['request']
         assert 'update_mask' in update_call['request']
-        
+
         # Verify the subscription object contains correct values
         subscription = update_call['request']['subscription']
         assert subscription.name == subscription_path
         assert subscription.ack_deadline_seconds == 60
         assert subscription.expiration_policy.ttl.total_seconds() == 86400
         assert subscription.message_retention_duration.total_seconds() == 86400
-        
+
         # Verify update mask includes all fields
         update_mask_paths = update_call['request']['update_mask'].paths
         assert 'ack_deadline_seconds' in update_mask_paths
@@ -351,7 +351,7 @@ class test_Channel:
         subscription_path = "subscription_path"
         topic_path = "topic_path"
         filter_args = {'filter': 'attributes.routing_key="test"'}
-        
+
         channel.subscriber.subscription_path = MagicMock(
             return_value=subscription_path
         )
@@ -360,7 +360,7 @@ class test_Channel:
             side_effect=AlreadyExists("Subscription exists")
         )
         channel.subscriber.update_subscription = MagicMock()
-        
+
         channel._create_subscription(
             project_id=channel.project_id,
             topic_id=topic_id,
@@ -368,7 +368,7 @@ class test_Channel:
             topic_path=topic_path,
             filter_args=filter_args,
         )
-        
+
         # Verify filter was included in update mask
         channel.subscriber.update_subscription.assert_called_once()
         update_call = channel.subscriber.update_subscription.call_args[1]
@@ -381,7 +381,7 @@ class test_Channel:
         topic_id = "topic_id"
         subscription_path = "subscription_path"
         topic_path = "topic_path"
-        
+
         channel.subscriber.subscription_path = MagicMock(
             return_value=subscription_path
         )
@@ -393,7 +393,7 @@ class test_Channel:
         channel.subscriber.update_subscription = MagicMock(
             side_effect=Exception("API Error")
         )
-        
+
         # Should not raise exception - just log warning
         result = channel._create_subscription(
             project_id=channel.project_id,


### PR DESCRIPTION
When a subscription already exists, update it with current configuration instead of silently ignoring the AlreadyExists exception.  This allows workers to automatically sync subscription settings (ack_deadline_seconds, expiration_policy, message_retention_duration, filters) without manual intervention in GCP Console.

Fixes https://github.com/celery/kombu/issues/2444