### PR TITLE
Remove Python 3.9 from CI workflow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
         os: ["blacksmith-4vcpu-ubuntu-2404"]
 
 
@@ -81,7 +81,7 @@ jobs:
       strategy:
           fail-fast: false
           matrix:
-              python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
+              python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
               toxenv: [
                   'py-amqp',
                   'py-redis',


### PR DESCRIPTION
initially drop from CI to start v5.7.x release cycle