### PR TITLE
Remove invalid Python version from workflow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         os: ["blacksmith-4vcpu-ubuntu-2404"]
 
 
@@ -81,7 +81,7 @@ jobs:
       strategy:
           fail-fast: false
           matrix:
-              python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
+              python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
               toxenv: [
                   'py-amqp',
                   'py-redis',


### PR DESCRIPTION
we do not need this slow 3.14t for now. may be after python 3.15 release we reconsider this