### PR TITLE
Fix Logwrapped not supporting context manager protocol

### DIFF
--- a/kombu/utils/debug.py
+++ b/kombu/utils/debug.py
@@ -78,8 +78,8 @@ class Logwrapped:
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: TracebackType | None
-    ) -> None:
-        self.instance.__exit__(exc_type, exc_val, exc_tb)
+    ) -> bool | None:
+        return self.instance.__exit__(exc_type, exc_val, exc_tb)
 
     def __repr__(self) -> str:
         return repr(self.instance)

--- a/kombu/utils/debug.py
+++ b/kombu/utils/debug.py
@@ -11,6 +11,7 @@ from kombu.log import get_logger
 
 if TYPE_CHECKING:
     from logging import Logger
+    from types import TracebackType
     from typing import Any, Callable
 
     from kombu.transport.base import Transport
@@ -33,8 +34,6 @@ def setup_logging(
 class Logwrapped:
     """Wrap all object methods, to log on call."""
 
-    __ignore = ('__enter__', '__exit__')
-
     def __init__(
         self,
         instance: Transport,
@@ -48,7 +47,7 @@ class Logwrapped:
     def __getattr__(self, key: str) -> Callable:
         meth = getattr(self.instance, key)
 
-        if not callable(meth) or key in self.__ignore:
+        if not callable(meth):
             return meth
 
         @wraps(meth)
@@ -69,6 +68,18 @@ class Logwrapped:
             return meth(*args, **kwargs)
 
         return __wrapped
+
+    def __enter__(self) -> Logwrapped:
+        self.instance.__enter__()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None
+    ) -> None:
+        self.instance.__exit__(exc_type, exc_val, exc_tb)
 
     def __repr__(self) -> str:
         return repr(self.instance)

--- a/t/unit/utils/test_debug.py
+++ b/t/unit/utils/test_debug.py
@@ -92,3 +92,24 @@ class test_Logwrapped:
             args = instance.__exit__.call_args[0]
             assert args[0] is TestError
             assert isinstance(args[1], TestError)
+
+    def test_context_manager_suppresses_exception(self):
+        """Test that Logwrapped suppresses exceptions when __exit__ returns True."""
+        with patch('kombu.utils.debug.get_logger'):
+            instance = Mock()
+            instance.__enter__ = Mock(return_value=instance)
+            instance.__exit__ = Mock(return_value=True)
+
+            W = Logwrapped(instance, 'kombu.test')
+
+            class TestError(Exception):
+                pass
+
+            # Exception should be suppressed because __exit__ returns True
+            with W:
+                raise TestError("this should be suppressed")
+
+            instance.__exit__.assert_called_once()
+            args = instance.__exit__.call_args[0]
+            assert args[0] is TestError
+            assert isinstance(args[1], TestError)

--- a/t/unit/utils/test_debug.py
+++ b/t/unit/utils/test_debug.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import logging
 from unittest.mock import Mock, patch
 
+import pytest
+
 from kombu.utils.debug import Logwrapped, setup_logging
 
 
@@ -51,3 +53,42 @@ class test_Logwrapped:
             assert 'ident' in logger.debug.call_args[0][0]
 
             assert dir(W) == dir(W.instance)
+
+    def test_context_manager(self):
+        """Test that Logwrapped supports the context manager protocol.
+
+        Regression test for https://github.com/celery/kombu/issues/2422
+        """
+        with patch('kombu.utils.debug.get_logger'):
+            instance = Mock()
+            instance.__enter__ = Mock(return_value=instance)
+            instance.__exit__ = Mock(return_value=None)
+
+            W = Logwrapped(instance, 'kombu.test')
+
+            with W as ctx:
+                assert ctx is W
+
+            instance.__enter__.assert_called_once()
+            instance.__exit__.assert_called_once_with(None, None, None)
+
+    def test_context_manager_propagates_exception(self):
+        """Test that Logwrapped propagates exceptions through __exit__."""
+        with patch('kombu.utils.debug.get_logger'):
+            instance = Mock()
+            instance.__enter__ = Mock(return_value=instance)
+            instance.__exit__ = Mock(return_value=False)
+
+            W = Logwrapped(instance, 'kombu.test')
+
+            class TestError(Exception):
+                pass
+
+            with pytest.raises(TestError):
+                with W:
+                    raise TestError("test")
+
+            instance.__exit__.assert_called_once()
+            args = instance.__exit__.call_args[0]
+            assert args[0] is TestError
+            assert isinstance(args[1], TestError)


### PR DESCRIPTION
## Summary

Fixes #2422.

`Logwrapped` wraps channel objects to add debug logging, but it did not support the context manager protocol (`with channel as ch:`). This caused a `TypeError: 'Logwrapped' object does not support the context manager protocol` whenever debug logging was enabled via `KOMBU_LOG_CHANNEL=1` or `KOMBU_LOG_DEBUG=1`.

### Root cause

The class had an `__ignore = ('__enter__', '__exit__')` tuple and attempted to handle these methods in `__getattr__` by returning them unwrapped. However, Python's data model looks up dunder/magic methods on the **type** (class), not the instance, so `__getattr__` is never invoked for `__enter__`/`__exit__`. The `__ignore` mechanism was entirely ineffective.

### Fix

- Add explicit `__enter__` and `__exit__` methods that delegate to the wrapped instance
- `__enter__` returns the `Logwrapped` wrapper itself (not the raw instance) so that method calls inside the `with` block continue to be logged
- Remove the now-useless `__ignore` class variable and the dead `key in self.__ignore` check in `__getattr__`

### Tests added

- `test_context_manager`: verifies `Logwrapped` works as a context manager and delegates to the wrapped instance
- `test_context_manager_propagates_exception`: verifies exceptions are correctly propagated through `__exit__`

## Test plan

- [x] All existing tests pass (`pytest t/unit/utils/test_debug.py`)
- [x] Two new tests cover the context manager protocol
- [x] Manual verification: `Logwrapped(channel)` works in a `with` statement

🤖 Generated with [Claude Code](https://claude.com/claude-code)