### PR TITLE
Fix active_queues to preserve queue ordering

### DIFF
--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -1381,9 +1381,11 @@ class Channel(virtual.Channel):
 
     @property
     def active_queues(self):
-        """Set of queues being consumed from (excluding fanout queues)."""
-        return {queue for queue in self._active_queues
-                if queue not in self.active_fanout_queues}
+        """List of queues being consumed from (excluding fanout queues)."""
+        return list(dict.fromkeys(
+            queue for queue in self._active_queues
+            if queue not in self.active_fanout_queues
+        ))
 
 
 class Transport(virtual.Transport):


### PR DESCRIPTION
Change active_queues from a set to an order-preserving list so that priority scheduling cycles respect the intended queue order.

Fixes https://github.com/celery/kombu/issues/801