### PR TITLE
Fix/2463 add gevent concurrent error to connection error

### DIFF
--- a/kombu/common.py
+++ b/kombu/common.py
@@ -288,7 +288,7 @@ def _ensure_errback(exc, interval):
 @contextmanager
 def _ignore_errors(conn):
     errors = conn.connection_errors + conn.channel_errors
-    if ConcurrentObjectUseError:
+    if ConcurrentObjectUseError is not None:
         errors += (ConcurrentObjectUseError,)
 
     try:

--- a/kombu/common.py
+++ b/kombu/common.py
@@ -16,6 +16,7 @@ from amqp import ChannelError, RecoverableConnectionError
 from .entity import Exchange, Queue
 from .log import get_logger
 from .serialization import registry as serializers
+from .utils.compat import ConcurrentObjectUseError
 from .utils.uuid import uuid
 
 __all__ = ('Broadcast', 'maybe_declare', 'uuid',
@@ -286,9 +287,13 @@ def _ensure_errback(exc, interval):
 
 @contextmanager
 def _ignore_errors(conn):
+    errors = conn.connection_errors + conn.channel_errors
+    if ConcurrentObjectUseError:
+        errors += (ConcurrentObjectUseError,)
+
     try:
         yield
-    except conn.connection_errors + conn.channel_errors:
+    except errors:
         pass
 
 

--- a/kombu/utils/compat.py
+++ b/kombu/utils/compat.py
@@ -21,9 +21,12 @@ except ImportError:  # pragma: no cover
     except ImportError:
         register_after_fork = None
 
-try:
-    from gevent.exceptions import ConcurrentObjectUseError
-except ImportError:
+if 'gevent' in sys.modules:
+    try:
+        from gevent.exceptions import ConcurrentObjectUseError
+    except ImportError:
+        ConcurrentObjectUseError = None
+else:
     ConcurrentObjectUseError = None
 
 

--- a/kombu/utils/compat.py
+++ b/kombu/utils/compat.py
@@ -21,6 +21,11 @@ except ImportError:  # pragma: no cover
     except ImportError:
         register_after_fork = None
 
+try:
+    from gevent.exceptions import ConcurrentObjectUseError
+except ImportError:
+    ConcurrentObjectUseError = None
+
 
 _environment = None
 

--- a/t/unit/test_common.py
+++ b/t/unit/test_common.py
@@ -55,6 +55,45 @@ def test_ignore_errors():
             raise KeyError()
 
 
+def test_ignore_errors_catches_concurrent_object_use_error_when_gevent_available():
+    """ignore_errors() must suppress ConcurrentObjectUseError when gevent is installed."""
+
+    class _ConcurrentObjectUseError(Exception):
+        """Stand-in for gevent.exceptions.ConcurrentObjectUseError."""
+
+    connection = Mock()
+    connection.channel_errors = ()
+    connection.connection_errors = ()
+
+    with patch.object(common, 'ConcurrentObjectUseError', _ConcurrentObjectUseError):
+        # context-manager form
+        with ignore_errors(connection):
+            raise _ConcurrentObjectUseError()
+
+        # function-call form
+        def raising():
+            raise _ConcurrentObjectUseError()
+
+        ignore_errors(connection, raising)
+
+
+def test_ignore_errors_reraises_when_gevent_not_available():
+    """ignore_errors() must not silently eat ConcurrentObjectUseError when
+    ConcurrentObjectUseError is None (gevent not installed)."""
+
+    class _ConcurrentObjectUseError(Exception):
+        pass
+
+    connection = Mock()
+    connection.channel_errors = ()
+    connection.connection_errors = ()
+
+    with patch.object(common, 'ConcurrentObjectUseError', None):
+        with pytest.raises(_ConcurrentObjectUseError):
+            with ignore_errors(connection):
+                raise _ConcurrentObjectUseError()
+
+
 class test_declaration_cached:
 
     def test_when_cached(self):

--- a/t/unit/utils/test_compat.py
+++ b/t/unit/utils/test_compat.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 import socket
 import sys
 import types
@@ -83,3 +84,45 @@ class test_detect_environment:
         finally:
             sys.modules.pop('gevent', None)
         compat._detect_environment()
+
+
+class test_ConcurrentObjectUseError_import:
+
+    @pytest.fixture(autouse=True)
+    def _restore_compat(self):
+        """Reload compat after each test to undo reload side-effects."""
+        yield
+        importlib.reload(compat)
+
+    def _reload(self):
+        return importlib.reload(compat)
+
+    def test_gevent_in_sys_modules_imports_class(self):
+        mock_exc = type('ConcurrentObjectUseError', (AssertionError,), {})
+        mock_exc_mod = types.ModuleType('gevent.exceptions')
+        mock_exc_mod.ConcurrentObjectUseError = mock_exc
+
+        with patch.dict(sys.modules, {
+            'gevent': types.ModuleType('gevent'),
+            'gevent.exceptions': mock_exc_mod,
+        }):
+            reloaded = self._reload()
+
+        assert reloaded.ConcurrentObjectUseError is mock_exc
+
+    def test_gevent_not_in_sys_modules_gives_none(self):
+        saved = {k: sys.modules.pop(k) for k in list(sys.modules) if 'gevent' in k}
+        try:
+            reloaded = self._reload()
+            assert reloaded.ConcurrentObjectUseError is None
+        finally:
+            sys.modules.update(saved)
+
+    def test_gevent_in_sys_modules_but_class_missing_gives_none(self):
+        with patch.dict(sys.modules, {
+            'gevent': types.ModuleType('gevent'),
+            'gevent.exceptions': types.ModuleType('gevent.exceptions'),
+        }):
+            reloaded = self._reload()
+
+        assert reloaded.ConcurrentObjectUseError is None


### PR DESCRIPTION
## Problem

When using Celery with the **gevent pool** and an AMQPS (TLS) broker (e.g. Amazon MQ / RabbitMQ),
a race condition occurs during connection shutdown:

1. Greenlet A is blocking on an SSL socket read.
2. Greenlet B calls `connection.close()`, which triggers an SSL `CloseOk` read on the same socket.
3. gevent detects two greenlets accessing the same socket concurrently and raises `ConcurrentObjectUseError`.

`ignore_errors()` only suppresses exceptions found in `Transport.connection_errors` and
`Transport.channel_errors`. `ConcurrentObjectUseError` is not in either tuple, so it propagates
all the way up and Celery treats it as an **unrecoverable error**, crashing the worker.

Reproduction: https://github.com/JaeHyuckSa/kombu-gevent-issue  
Issue: #2463

---

## Solution

**`kombu/utils/compat.py`**  
Optionally import `ConcurrentObjectUseError` from gevent in the established compat layer — the
single module that owns all optional runtime-environment dependencies (`register_after_fork`,
`detect_environment`, etc.). Falls back to `None` when gevent is not installed, keeping the fix
zero-cost for non-gevent users.

```python
try:
    from gevent.exceptions import ConcurrentObjectUseError
except ImportError:
    ConcurrentObjectUseError = None
```

**`kombu/common.py`**  
Import `ConcurrentObjectUseError` from `compat` and conditionally add it to the exception tuple
inside `_ignore_errors()`. Both the context-manager form and the function-call form of
`ignore_errors()` go through `_ignore_errors`, so both are covered.

```python
errors = conn.connection_errors + conn.channel_errors
if ConcurrentObjectUseError:
    errors += (ConcurrentObjectUseError,)
```

---

## Notes

- No behavioural change for non-gevent deployments.
- `ConcurrentObjectUseError` is included whenever gevent is installed, regardless of whether the
  transport is actively using it. If gevent is not monkey-patched, this error can never be raised,
  so the extra entry in the tuple is harmless.
