### PR TITLE
Fix/2463 gevent concurrent error

### DIFF
--- a/kombu/common.py
+++ b/kombu/common.py
@@ -16,6 +16,7 @@ from amqp import ChannelError, RecoverableConnectionError
 from .entity import Exchange, Queue
 from .log import get_logger
 from .serialization import registry as serializers
+from .utils.compat import get_gevent_concurrent_error
 from .utils.uuid import uuid
 
 __all__ = ('Broadcast', 'maybe_declare', 'uuid',
@@ -288,7 +289,9 @@ def _ensure_errback(exc, interval):
 def _ignore_errors(conn):
     try:
         yield
-    except conn.connection_errors + conn.channel_errors:
+    except conn.connection_errors + conn.channel_errors + (
+        (conc_err,) if (conc_err := get_gevent_concurrent_error()) is not None else ()
+    ):
         pass
 
 

--- a/kombu/utils/compat.py
+++ b/kombu/utils/compat.py
@@ -22,6 +22,22 @@ except ImportError:  # pragma: no cover
         register_after_fork = None
 
 
+def get_gevent_concurrent_error():
+    """Lazily return gevent's ConcurrentObjectUseError, or None.
+
+    Evaluated at call time (not import time) so that it correctly handles
+    the common startup ordering where kombu is imported before gevent's
+    monkey-patching takes place.
+    """
+    if 'gevent' in sys.modules:
+        try:
+            from gevent.exceptions import ConcurrentObjectUseError
+            return ConcurrentObjectUseError
+        except ImportError:
+            pass
+    return None
+
+
 _environment = None
 
 

--- a/t/unit/test_common.py
+++ b/t/unit/test_common.py
@@ -55,6 +55,53 @@ def test_ignore_errors():
             raise KeyError()
 
 
+def test_ignore_errors_catches_concurrent_object_use_error_when_gevent_available():
+    """ignore_errors() must suppress ConcurrentObjectUseError when gevent is installed."""
+
+    class _ConcurrentObjectUseError(Exception):
+        """Stand-in for gevent.exceptions.ConcurrentObjectUseError."""
+
+    connection = Mock()
+    connection.channel_errors = ()
+    connection.connection_errors = ()
+
+    with patch('kombu.common.get_gevent_concurrent_error', return_value=_ConcurrentObjectUseError):
+        # context-manager form
+        with ignore_errors(connection):
+            raise _ConcurrentObjectUseError()
+
+        # function-call form
+        def raising():
+            raise _ConcurrentObjectUseError()
+
+        ignore_errors(connection, raising)
+
+
+def test_ignore_errors_reraises_when_gevent_not_available():
+
+    class _ConcurrentObjectUseError(Exception):
+        pass
+
+    connection = Mock()
+    connection.channel_errors = ()
+    connection.connection_errors = ()
+
+    with patch('kombu.common.get_gevent_concurrent_error', return_value=None):
+        with pytest.raises(_ConcurrentObjectUseError):
+            with ignore_errors(connection):
+                raise _ConcurrentObjectUseError()
+
+
+def test_ignore_errors_lazy_evaluation_does_not_crash_with_mock_connection():
+
+    connection = Mock()  # connection_errors and channel_errors are both Mock
+
+    with patch('kombu.common.get_gevent_concurrent_error', return_value=None):
+        # Must not raise TypeError during normal (no-exception) execution
+        with ignore_errors(connection):
+            pass  # no exception raised → except clause never evaluated
+
+
 class test_declaration_cached:
 
     def test_when_cached(self):

--- a/t/unit/test_common.py
+++ b/t/unit/test_common.py
@@ -102,6 +102,46 @@ def test_ignore_errors_lazy_evaluation_does_not_crash_with_mock_connection():
             pass  # no exception raised → except clause never evaluated
 
 
+def test_ignore_errors_celery_shutdown_step_pattern():
+    """Regression test: simulates the exact Celery ConsumerStep.shutdown() pattern
+    that broke CI in PR #2473.
+
+    Celery's test setup passes a plain Mock() as the connection, so
+    connection.connection_errors and connection.channel_errors are both
+    Mock instances — not tuples.  Before the lazy-evaluation fix, the line
+
+        errors = conn.connection_errors + conn.channel_errors
+
+    executed eagerly (outside the try block), causing:
+        TypeError: unsupported operand type(s) for +: 'Mock' and 'Mock'
+
+    With the fix, the tuple composition only happens when an exception is
+    actually raised, so the mock attributes are never added together during
+    a normal (no-exception) shutdown and the test passes cleanly.
+    """
+    # Mirrors Celery: connection is a bare Mock, errors attrs are Mock too
+    connection = Mock()
+    assert isinstance(connection.connection_errors, Mock)
+    assert isinstance(connection.channel_errors, Mock)
+
+    # Mirrors Celery: consumer with a mock channel
+    consumer = Mock()
+
+    # Mirrors Celery ConsumerStep.shutdown():
+    #   for consumer in self._consumers:
+    #       with ignore_errors(connection):
+    #           consumer.channel.close()
+    with ignore_errors(connection):
+        consumer.channel.close()
+
+    consumer.channel.close.assert_called_once_with()
+
+    # Also verify the function-call form works the same way
+    consumer2 = Mock()
+    ignore_errors(connection, consumer2.channel.close)
+    consumer2.channel.close.assert_called_once_with()
+
+
 class test_declaration_cached:
 
     def test_when_cached(self):

--- a/t/unit/utils/test_compat.py
+++ b/t/unit/utils/test_compat.py
@@ -83,3 +83,77 @@ class test_detect_environment:
         finally:
             sys.modules.pop('gevent', None)
         compat._detect_environment()
+
+
+class test_get_gevent_concurrent_error:
+    """Tests for get_gevent_concurrent_error() lazy function.
+
+    The function must be evaluated at call time, not at import time, so
+    that it correctly handles the common startup ordering where kombu is
+    imported before gevent.monkey.patch_all() is called.
+    """
+
+    def test_returns_class_when_gevent_loaded_and_class_exists(self):
+        """Returns ConcurrentObjectUseError when gevent is in sys.modules."""
+        mock_exc = type('ConcurrentObjectUseError', (AssertionError,), {})
+        mock_exc_mod = types.ModuleType('gevent.exceptions')
+        mock_exc_mod.ConcurrentObjectUseError = mock_exc
+
+        with patch.dict(sys.modules, {
+            'gevent': types.ModuleType('gevent'),
+            'gevent.exceptions': mock_exc_mod,
+        }):
+            result = compat.get_gevent_concurrent_error()
+
+        assert result is mock_exc
+
+    def test_returns_none_when_gevent_not_in_sys_modules(self):
+        """Returns None when gevent has not been imported yet.
+
+        This covers the common startup ordering: kombu imported first,
+        gevent.monkey.patch_all() called later.
+        """
+        saved = {k: sys.modules.pop(k) for k in list(sys.modules) if 'gevent' in k}
+        try:
+            result = compat.get_gevent_concurrent_error()
+        finally:
+            sys.modules.update(saved)
+
+        assert result is None
+
+    def test_returns_none_when_gevent_loaded_but_class_missing(self):
+        """Returns None when gevent is present but the class is unavailable."""
+        with patch.dict(sys.modules, {
+            'gevent': types.ModuleType('gevent'),
+            'gevent.exceptions': types.ModuleType('gevent.exceptions'),
+        }):
+            result = compat.get_gevent_concurrent_error()
+
+        assert result is None
+
+    def test_runtime_evaluation_reflects_later_gevent_import(self):
+        """Calling the function after gevent is imported returns the class.
+
+        If kombu.utils.compat was imported before gevent, a module-level
+        variable would be stuck as None.  The lazy function always reflects
+        the current state of sys.modules at call time.
+        """
+        mock_exc = type('ConcurrentObjectUseError', (AssertionError,), {})
+        mock_exc_mod = types.ModuleType('gevent.exceptions')
+        mock_exc_mod.ConcurrentObjectUseError = mock_exc
+
+        # Simulate: kombu imported first → gevent not yet in sys.modules
+        saved = {k: sys.modules.pop(k) for k in list(sys.modules) if 'gevent' in k}
+        try:
+            assert compat.get_gevent_concurrent_error() is None  # before gevent
+
+            # Simulate: gevent.monkey.patch_all() called later
+            sys.modules.update({
+                'gevent': types.ModuleType('gevent'),
+                'gevent.exceptions': mock_exc_mod,
+            })
+            assert compat.get_gevent_concurrent_error() is mock_exc  # after gevent
+        finally:
+            for k in ('gevent', 'gevent.exceptions'):
+                sys.modules.pop(k, None)
+            sys.modules.update(saved)


### PR DESCRIPTION
## Problem

When using Celery with the **gevent pool** and an **AMQPS (TLS) broker**
(e.g. Amazon MQ / RabbitMQ), a race condition occurs during connection shutdown:

1. **Greenlet A** is blocking on an SSL socket read (waiting for the next AMQP frame).
2. **Greenlet B** calls `connection.close()`, which triggers an SSL `CloseOk` read on the
   **same socket**.
3. gevent detects two greenlets accessing the same socket IO-watcher concurrently and raises
   `ConcurrentObjectUseError` from `gevent.exceptions`.
4. `ignore_errors()` only suppresses exceptions listed in
   `Transport.connection_errors` and `Transport.channel_errors`.
   `ConcurrentObjectUseError` is not in either tuple, so it propagates up and Celery
   treats it as an unrecoverable error, **crashing the worker**.

Reproduction repo: https://github.com/JaeHyuckSa/kombu-gevent-issue  
Issue: #2463

---

## Why the straightforward fix breaks Celery's test suite

Two simpler approaches were tried and discarded:

### Approach 1 — module-level import + eager tuple outside `try`

```python
# kombu/utils/compat.py
try:
    from gevent.exceptions import ConcurrentObjectUseError
except ImportError:
    ConcurrentObjectUseError = None

# kombu/common.py
@contextmanager
def _ignore_errors(conn):
    errors = conn.connection_errors + conn.channel_errors   # ← EAGER
    if ConcurrentObjectUseError:
        errors += (ConcurrentObjectUseError,)
    try:
        yield
    except errors:
        pass
```

**Why it broke Celery CI:**

Celery's `ConsumerStep.shutdown()` calls `ignore_errors(connection, consumer.channel.close)`.
In Celery's test suite the connection is a plain `Mock()`, so
`connection.connection_errors` and `connection.channel_errors` are both `Mock` instances —
not tuples. The line

```python
errors = conn.connection_errors + conn.channel_errors
```

executes **every time** `_ignore_errors` is entered (even when no exception is ever raised),
producing:

```
TypeError: unsupported operand type(s) for +: 'Mock' and 'Mock'
```

This caused a cascade of Celery CI failures across its entire test suite.

### Approach 2 — module-level guard `if 'gevent' in sys.modules:`

```python
# evaluated once, at kombu import time
if 'gevent' in sys.modules:
    from gevent.exceptions import ConcurrentObjectUseError
else:
    ConcurrentObjectUseError = None
```

**Why it never actually worked in production:**

Real applications import kombu **before** calling `gevent.monkey.patch_all()`.
The guard evaluates `False` at import time and permanently sets
`ConcurrentObjectUseError = None`, so the fix silently does nothing for every
standard deployment.

---

## Solution

### `kombu/utils/compat.py` — lazy function

```python
def get_gevent_concurrent_error():
    """Lazily return gevent's ConcurrentObjectUseError, or None.

    Evaluated at call time (not import time) so that it correctly handles
    the common startup ordering where kombu is imported before gevent's
    monkey-patching takes place.
    """
    if 'gevent' in sys.modules:
        try:
            from gevent.exceptions import ConcurrentObjectUseError
            return ConcurrentObjectUseError
        except ImportError:
            pass
    return None
```

Placed in `kombu/utils/compat.py` — the established module that owns all
optional runtime-environment dependencies (`register_after_fork`,
`detect_environment`, etc.).

### `kombu/common.py` — fully lazy `except` clause

```python
@contextmanager
def _ignore_errors(conn):
    try:
        yield
    except conn.connection_errors + conn.channel_errors + (
        (conc_err,) if (conc_err := get_gevent_concurrent_error()) is not None else ()
    ):
        pass
```

The **entire** tuple expression — including `conn.connection_errors + conn.channel_errors` —
now lives inside the `except` clause.

Python only evaluates `except` expressions when an exception is actually raised.
During a normal (no-exception) shutdown, the mock attributes are never added together,
so `Mock + Mock` is never attempted and the `TypeError` never occurs.

---

## Key properties of the fix

| Property | Detail |
|---|---|
| Zero cost for non-gevent users | `get_gevent_concurrent_error()` returns `None` immediately when gevent is not in `sys.modules` |
| Correct import-order handling | Evaluated at call time, not at kombu import time; works even when kombu is imported before `monkey.patch_all()` |
| No Celery CI breakage | Tuple composition only happens on exception path; plain `Mock()` connections are never touched during normal shutdown |
| Covers both API forms | Both `with ignore_errors(conn):` and `ignore_errors(conn, fun)` go through `_ignore_errors` |

---

## Files changed

| File | Change |
|---|---|
| `kombu/utils/compat.py` | Added `get_gevent_concurrent_error()` lazy function |
| `kombu/common.py` | Imported `get_gevent_concurrent_error`; moved entire `except` tuple inside `except` clause |
| `t/unit/test_common.py` | 4 new tests for `_ignore_errors` / `ignore_errors` |
| `t/unit/utils/test_compat.py` | 4 new tests for `get_gevent_concurrent_error()` |

---
