### PR TITLE
Fix RabbitMQ 4.x crash: global QoS not supported on classic queues

### DIFF
--- a/kombu/transport/librabbitmq.py
+++ b/kombu/transport/librabbitmq.py
@@ -175,7 +175,14 @@ class Transport(base.Transport):
             warnings.warn(UserWarning(W_VERSION))
         else:
             if props.get('product') == 'RabbitMQ':
-                return version_string_as_tuple(props['version']) < (3, 3)
+                version_str = props.get('version')
+                if not version_str:
+                    return True
+                version = version_string_as_tuple(version_str)
+                # RabbitMQ < 3.3: per-channel QoS (return True)
+                # RabbitMQ 3.3–3.x: global QoS semantics (return False)
+                # RabbitMQ 4.0+: global QoS removed on classic queues (return True)
+                return version < (3, 3) or version >= (4, 0)
         return True
 
     @property

--- a/kombu/transport/pyamqp.py
+++ b/kombu/transport/pyamqp.py
@@ -224,7 +224,14 @@ class Transport(base.Transport):
     def qos_semantics_matches_spec(self, connection):
         props = connection.server_properties
         if props.get('product') == 'RabbitMQ':
-            return version_string_as_tuple(props['version']) < (3, 3)
+            version_str = props.get('version')
+            if not version_str:
+                return True
+            version = version_string_as_tuple(version_str)
+            # RabbitMQ < 3.3: per-channel QoS (return True)
+            # RabbitMQ 3.3–3.x: global QoS semantics (return False)
+            # RabbitMQ 4.0+: global QoS removed on classic queues (return True)
+            return version < (3, 3) or version >= (4, 0)
         return True
 
     @property

--- a/t/unit/transport/test_librabbitmq.py
+++ b/t/unit/transport/test_librabbitmq.py
@@ -148,3 +148,42 @@ class test_Transport:
         self.T.close_connection(conn)
         assert self.client.drain_events is None
         conn.close.assert_called_with()
+
+    def test_qos_semantics_matches_spec(self):
+        conn = Mock(name='connection')
+
+        # Non-RabbitMQ broker: always True
+        conn.server_properties = {'product': 'ActiveMQ', 'version': '5.0.0'}
+        assert self.T.qos_semantics_matches_spec(conn) is True
+
+        # RabbitMQ < 3.3: per-channel QoS (True)
+        conn.server_properties = {'product': 'RabbitMQ', 'version': '3.2.4'}
+        assert self.T.qos_semantics_matches_spec(conn) is True
+
+        # RabbitMQ 3.3: global QoS semantics introduced (False)
+        conn.server_properties = {'product': 'RabbitMQ', 'version': '3.3.0'}
+        assert self.T.qos_semantics_matches_spec(conn) is False
+
+        # RabbitMQ 3.13: still global QoS (False)
+        conn.server_properties = {'product': 'RabbitMQ', 'version': '3.13.0'}
+        assert self.T.qos_semantics_matches_spec(conn) is False
+
+        # RabbitMQ 4.0: global QoS removed on classic queues (True)
+        conn.server_properties = {'product': 'RabbitMQ', 'version': '4.0.0'}
+        assert self.T.qos_semantics_matches_spec(conn) is True
+
+        # RabbitMQ 4.x future version: still True
+        conn.server_properties = {'product': 'RabbitMQ', 'version': '4.2.1'}
+        assert self.T.qos_semantics_matches_spec(conn) is True
+
+        # AttributeError (no server_properties): returns True with warning
+        conn_bad = Mock(name='conn_bad', spec=[])
+        type(conn_bad).server_properties = property(
+            lambda self: (_ for _ in ()).throw(AttributeError)
+        )
+        with pytest.warns(UserWarning, match='librabbitmq version too old'):
+            assert self.T.qos_semantics_matches_spec(conn_bad) is True
+
+        # RabbitMQ with missing 'version' key: returns True (safe default)
+        conn.server_properties = {'product': 'RabbitMQ'}
+        assert self.T.qos_semantics_matches_spec(conn) is True

--- a/t/unit/transport/test_pyamqp.py
+++ b/t/unit/transport/test_pyamqp.py
@@ -230,3 +230,35 @@ class test_pyamqp:
             t = pyamqp.Transport(Mock())
             t.get_manager(1, kw=2)
             get_manager.assert_called_with(t.client, 1, kw=2)
+
+    def test_qos_semantics_matches_spec(self):
+        t = pyamqp.Transport(Mock())
+        conn = Mock()
+
+        # Non-RabbitMQ broker: always True
+        conn.server_properties = {'product': 'ActiveMQ', 'version': '5.0.0'}
+        assert t.qos_semantics_matches_spec(conn) is True
+
+        # RabbitMQ < 3.3: per-channel QoS (True)
+        conn.server_properties = {'product': 'RabbitMQ', 'version': '3.2.4'}
+        assert t.qos_semantics_matches_spec(conn) is True
+
+        # RabbitMQ 3.3: global QoS semantics introduced (False)
+        conn.server_properties = {'product': 'RabbitMQ', 'version': '3.3.0'}
+        assert t.qos_semantics_matches_spec(conn) is False
+
+        # RabbitMQ 3.13: still global QoS (False)
+        conn.server_properties = {'product': 'RabbitMQ', 'version': '3.13.0'}
+        assert t.qos_semantics_matches_spec(conn) is False
+
+        # RabbitMQ 4.0: global QoS removed on classic queues (True)
+        conn.server_properties = {'product': 'RabbitMQ', 'version': '4.0.0'}
+        assert t.qos_semantics_matches_spec(conn) is True
+
+        # RabbitMQ 4.x future version: still True
+        conn.server_properties = {'product': 'RabbitMQ', 'version': '4.2.1'}
+        assert t.qos_semantics_matches_spec(conn) is True
+
+        # RabbitMQ with missing 'version' key: returns True (safe default)
+        conn.server_properties = {'product': 'RabbitMQ'}
+        assert t.qos_semantics_matches_spec(conn) is True


### PR DESCRIPTION
RabbitMQ 4.0 removed support for global QoS prefetch (`basic.qos` with `global=true`) on classic queues. When Kombu connected to a RabbitMQ 4.x broker, `qos_semantics_matches_spec` returned `False` (because the version was not < 3.3), causing Celery to set `global=True` in its QoS call, which RabbitMQ 4.x immediately rejected with:

  540 NOT_IMPLEMENTED - queue does not support global qos

This crashed workers on startup before they could consume any tasks.

Fix the version boundary check in both `pyamqp` and `librabbitmq` transports to return `True` (per-channel QoS) for RabbitMQ >= 4.0:

  Before: version < (3, 3)
  After:  version < (3, 3) or version >= (4, 0)

This restores the correct behavior:
  - RabbitMQ < 3.3:   True  (spec-compliant per-channel QoS)
  - RabbitMQ 3.3–3.x: False (global QoS semantics)
  - RabbitMQ 4.0+:    True  (global QoS removed, per-channel only)

RabbitMQ deprecation announcement (2021):
  https://www.rabbitmq.com/blog/2021/08/21/4.0-deprecation-announcements

RabbitMQ 4.x classic queues docs (global QoS removal):
  https://www.rabbitmq.com/docs/classic-queues

Closes: #2469