### PR TITLE
ChannelPromise: ensure the AttributeError does not appear in the traceback when the contract raises an exception

### DIFF
--- a/kombu/utils/functional.py
+++ b/kombu/utils/functional.py
@@ -31,8 +31,9 @@ class ChannelPromise:
         try:
             return self.__value__
         except AttributeError:
-            value = self.__value__ = self.__contract__()
-            return value
+            pass
+        value = self.__value__ = self.__contract__()
+        return value
 
     def __repr__(self):
         try:

--- a/t/unit/utils/test_functional.py
+++ b/t/unit/utils/test_functional.py
@@ -20,6 +20,19 @@ class test_ChannelPromise:
         assert 'promise' in repr(ChannelPromise(obj))
         obj.assert_not_called()
 
+    def test_failing_contract(self):
+        def failing():
+            raise RuntimeError("failure for test")
+
+        p = ChannelPromise(failing)
+
+        with pytest.raises(RuntimeError, match="failure for test") as excinfo:
+            p()
+
+        # ensure the exception is not chained with internal ChannelPromise errors
+        assert excinfo.value.__context__ is None
+        assert excinfo.value.__cause__ is None
+
 
 class test_shufflecycle:
 


### PR DESCRIPTION
Closes https://github.com/celery/kombu/issues/2485

Discussion on different solutions in https://github.com/celery/kombu/issues/2485