### PR TITLE
Fix: SQS `polling_interval` transport option ignored in async event loop #2439

### DIFF
--- a/kombu/transport/SQS/__init__.py
+++ b/kombu/transport/SQS/__init__.py
@@ -36,7 +36,7 @@ is scheduled immediately; after an empty poll the transport waits
 
 ``wait_time_seconds`` and ``polling_interval`` are applied at different
 layers and their delays compose additively.  For an empty poll the total
-time before the next ``ReceiveMessage`` call is issued is:
+time before the next ``ReceiveMessage`` call is issued is::
 
     effective interval = wait_time_seconds + polling_interval
 

--- a/kombu/transport/SQS/__init__.py
+++ b/kombu/transport/SQS/__init__.py
@@ -12,9 +12,57 @@ Long Polling
 ------------
 https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html
 
-Long polling is enabled by setting the `wait_time_seconds` transport
-option to a number > 1.  Amazon supports up to 20 seconds.  This is
-enabled with 10 seconds by default.
+Long polling is enabled by setting the ``wait_time_seconds`` transport
+option to a value between 1 and 20.  Amazon supports up to 20 seconds.
+The default is 10 seconds.
+
+When ``wait_time_seconds`` is greater than 0, each ``ReceiveMessage``
+API call to AWS will block on the *server side* for up to that many
+seconds, returning early only when a message arrives.  This reduces
+empty responses and lowers SQS request costs compared to short polling
+(``wait_time_seconds=0``).
+
+Polling Interval
+----------------
+
+The ``polling_interval`` transport option (default: 1 second) controls
+the *client-side* delay added between consecutive polls when a poll
+returns no messages.  After a successful (non-empty) poll the next poll
+is scheduled immediately; after an empty poll the transport waits
+``polling_interval`` seconds before trying again.
+
+**Important — additive timing when both options are set:**
+
+``wait_time_seconds`` and ``polling_interval`` are applied at different
+layers and their delays compose additively.  For an empty poll the total
+time before the next ``ReceiveMessage`` call is issued is:
+
+    effective interval = wait_time_seconds + polling_interval
+
+For example, with the defaults (``wait_time_seconds=10``,
+``polling_interval=1``) an empty queue is polled at most once every
+~11 seconds: the AWS call blocks for up to 10 s, then the client waits
+an additional 1 s before rescheduling.
+
+To make ``polling_interval`` the *sole* timing control (e.g. for short
+polling), set ``wait_time_seconds=0``:
+
+.. code-block:: python
+
+    app.conf.broker_transport_options = {
+        'wait_time_seconds': 0,   # disable server-side long polling
+        'polling_interval': 5,    # client waits 5 s after each empty poll
+    }
+
+To rely entirely on long polling and remove the extra client-side delay,
+set ``polling_interval=0``:
+
+.. code-block:: python
+
+    app.conf.broker_transport_options = {
+        'wait_time_seconds': 10,  # server holds connection up to 10 s
+        'polling_interval': 0,    # no additional client-side wait
+    }
 
 Batch API Actions
 -----------------
@@ -32,7 +80,8 @@ from SQS when you have short-running tasks (or a large number of workers).
 When a Celery worker has multiple queues to monitor, it will pull down
 up to 'prefetch_count' messages from queueA and work on them all before
 moving on to queueB.  If queueB is empty, it will wait up until
-'polling_interval' expires before moving back and checking on queueA.
+'polling_interval' expires (plus any server-side long-polling delay from
+'wait_time_seconds') before moving back and checking on queueA.
 
 Message Attributes
 -----------------

--- a/kombu/transport/SQS/__init__.py
+++ b/kombu/transport/SQS/__init__.py
@@ -341,7 +341,9 @@ class Channel(virtual.Channel):
         if no_ack:
             self._noack_queues.add(queue)
         if self.hub:
-            self._loop1(queue)
+            # Start the polling loop immediately on first consume without
+            # incurring any polling_interval delay at startup.
+            self.hub.call_soon(self._schedule_queue, queue)
         return super().basic_consume(queue, no_ack, callback, consumer_tag, *args, **kwargs)
 
     def basic_cancel(self, consumer_tag):
@@ -656,8 +658,21 @@ class Channel(virtual.Channel):
             return self._messages_to_python(messages, queue)[0]
         raise Empty()
 
-    def _loop1(self, queue, _=None):
-        self.hub.call_soon(self._schedule_queue, queue)
+    def _loop1(self, queue, messages_fetched=None):
+        if messages_fetched:
+            # Messages were found in the last poll; schedule next poll immediately.
+            self.hub.call_soon(self._schedule_queue, queue)
+        else:
+            # No messages found (unsuccessful poll); respect polling_interval
+            # before the next attempt to avoid hammering SQS unnecessarily.
+            # Note: self.connection is the Transport instance (virtual transport
+            # establish_connection() returns self), so polling_interval is
+            # accessed directly on self.connection.
+            polling_interval = self.connection.polling_interval
+            if polling_interval:
+                self.hub.call_later(polling_interval, self._schedule_queue, queue)
+                return
+            self.hub.call_soon(self._schedule_queue, queue)
 
     def _schedule_queue(self, queue):
         if queue in self._active_queues:

--- a/kombu/transport/SQS/__init__.py
+++ b/kombu/transport/SQS/__init__.py
@@ -701,6 +701,8 @@ class Channel(virtual.Channel):
             for msg in messages['Messages']:
                 msg_parsed = self._message_to_python(msg, qname, queue)
                 callbacks[qname](msg_parsed)
+            return len(messages['Messages'])
+        return 0
 
     def _get_from_sqs(self, queue_name, queue_url,
                       connection, count=1, callback=None):

--- a/kombu/transport/SQS/__init__.py
+++ b/kombu/transport/SQS/__init__.py
@@ -13,8 +13,9 @@ Long Polling
 https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html
 
 Long polling is enabled by setting the ``wait_time_seconds`` transport
-option to a value between 1 and 20.  Amazon supports up to 20 seconds.
-The default is 10 seconds.
+option to a value between 1 and 20 (valid range: 0–20, where 0 disables
+long polling).  Amazon supports up to 20 seconds.  The default is 10
+seconds.
 
 When ``wait_time_seconds`` is greater than 0, each ``ReceiveMessage``
 API call to AWS will block on the *server side* for up to that many

--- a/t/unit/transport/SQS/test_SQS.py
+++ b/t/unit/transport/SQS/test_SQS.py
@@ -810,6 +810,106 @@ class test_Channel:
             'query': {'MessageSystemAttributeName.1': 'ApproximateReceiveCount'},
         }
 
+    # ------------------------------------------------------------------
+    # Tests for polling_interval fix (issue #2439)
+    # ------------------------------------------------------------------
+
+    def test_on_messages_ready_returns_message_count(self):
+        """_on_messages_ready returns the number of messages dispatched."""
+        self.channel.connection._callbacks = {
+            self.queue_name: Mock(name='callback')
+        }
+        messages = {
+            'Messages': [
+                {'Body': '{}', 'ReceiptHandle': 'rh1'},
+                {'Body': '{}', 'ReceiptHandle': 'rh2'},
+            ]
+        }
+        self.channel._message_to_python = Mock(return_value={})
+        result = self.channel._on_messages_ready(
+            self.queue_name, self.queue_name, messages
+        )
+        assert result == 2
+
+    def test_on_messages_ready_returns_zero_when_empty(self):
+        """_on_messages_ready returns 0 when SQS response has no messages."""
+        result = self.channel._on_messages_ready(
+            self.queue_name, self.queue_name, {}
+        )
+        assert result == 0
+
+        result = self.channel._on_messages_ready(
+            self.queue_name, self.queue_name, {'Messages': []}
+        )
+        assert result == 0
+
+    def test_loop1_calls_call_soon_when_messages_found(self):
+        """_loop1 schedules next poll immediately when messages were fetched."""
+        hub = Mock(name='hub')
+        self.channel.hub = hub
+
+        self.channel._loop1(self.queue_name, messages_fetched=3)
+
+        hub.call_soon.assert_called_once_with(
+            self.channel._schedule_queue, self.queue_name
+        )
+        hub.call_later.assert_not_called()
+
+    def test_loop1_calls_call_later_when_empty_poll_with_polling_interval(self):
+        """_loop1 uses call_later(polling_interval) when no messages were found."""
+        hub = Mock(name='hub')
+        self.channel.hub = hub
+        # self.channel.connection IS the Transport (virtual transport returns
+        # itself from establish_connection), so set polling_interval directly.
+        self.channel.connection.polling_interval = 5
+
+        self.channel._loop1(self.queue_name, messages_fetched=0)
+
+        hub.call_later.assert_called_once_with(
+            5, self.channel._schedule_queue, self.queue_name
+        )
+        hub.call_soon.assert_not_called()
+
+    def test_loop1_calls_call_soon_when_empty_poll_and_no_polling_interval(self):
+        """_loop1 falls back to call_soon when polling_interval is 0/None."""
+        hub = Mock(name='hub')
+        self.channel.hub = hub
+        self.channel.connection.polling_interval = 0
+
+        self.channel._loop1(self.queue_name, messages_fetched=0)
+
+        hub.call_soon.assert_called_once_with(
+            self.channel._schedule_queue, self.queue_name
+        )
+        hub.call_later.assert_not_called()
+
+    def test_loop1_default_arg_treated_as_empty_poll(self):
+        """_loop1 with no messages_fetched argument applies polling_interval."""
+        hub = Mock(name='hub')
+        self.channel.hub = hub
+        self.channel.connection.polling_interval = 2
+
+        # Called with no second argument (default None → falsy)
+        self.channel._loop1(self.queue_name)
+
+        hub.call_later.assert_called_once_with(
+            2, self.channel._schedule_queue, self.queue_name
+        )
+
+    def test_basic_consume_schedules_directly_via_call_soon(self):
+        """basic_consume calls hub.call_soon(_schedule_queue) directly, not via _loop1."""
+        hub_mock = Mock(name='hub')
+        self.channel.hub = hub_mock
+
+        self.channel.basic_consume(
+            'new-queue', no_ack=False,
+            callback=Mock(), consumer_tag='tag-test',
+        )
+
+        hub_mock.call_soon.assert_called_once_with(
+            self.channel._schedule_queue, 'new-queue'
+        )
+
     @patch('kombu.transport.SQS.AsyncSQSConnection')
     def test_asynsqs_with_predefined_queue_creates_queue_existing_client(self, mock_async_sqs):
         # Arrange


### PR DESCRIPTION
## Summary

Fixes #2439 — the `polling_interval` broker transport option was completely ignored for SQS. Regardless of whether any messages were received, the poller would immediately reschedule the next `ReceiveMessage` call via `hub.call_soon()`, causing SQS to be polled as fast as the network allows (limited only by `wait_time_seconds` long-polling).

## Root Cause

The SQS transport has its own async event-loop path that bypasses the `polling_interval` sleep used by `virtual.Transport.drain_events()`. The call chain was:

```
basic_consume
  └─ _loop1(queue)
       └─ hub.call_soon(_schedule_queue)        # schedules immediately
            └─ _get_bulk_async(callback=promise(_loop1, (queue,)))
                 └─ SQS ReceiveMessage
                      └─ _on_messages_ready()   # no return value
                           └─ _loop1(queue)     # always call_soon → infinite tight loop
```

Two concrete bugs:

1. **`_loop1` always called `hub.call_soon()`** — meaning the next poll was always scheduled *immediately*, regardless of whether the previous poll returned any messages.
2. **`_on_messages_ready` had no return value** — so the callback (`_loop1`) could never know whether messages were found, making it impossible to decide whether to wait.

## Behaviour After Fix

| Scenario | Before | After |
|---|---|---|
| Empty poll | Immediately polls again | Waits `polling_interval` seconds (default: 1s) |
| Successful poll | Immediately polls again | Immediately polls again ✓ |
| `polling_interval=0` or `None` | Immediately polls again | Immediately polls again ✓ |
| First `basic_consume` call | Immediately polls | Immediately polls ✓ |
| Custom `polling_interval=5` | Ignored | Waits 5 s between empty polls ✓ |


## Related

- Closes #2439
- Celery docs: https://docs.celeryq.dev/en/main/getting-started/backends-and-brokers/sqs.html#polling-interval
- `hub.call_later` API: `kombu/asynchronous/hub.py` — delegates to `self.timer.call_after(delay, callback, args)`
