### PR TITLE
fix(redis): do not remove on_poll_start from on_tick on disconnect

### DIFF
--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -1447,14 +1447,15 @@ class Transport(virtual.Transport):
         def _on_disconnect(connection):
             if connection._sock:
                 loop.remove(connection._sock)
-
-            # must have started polling or this will break reconnection
-            if cycle.fds:
-                # stop polling in the event loop
-                try:
-                    loop.on_tick.remove(on_poll_start)
-                except KeyError:
-                    pass
+            # Note: we intentionally do NOT remove on_poll_start from
+            # loop.on_tick here.  on_poll_start is idempotent — when there
+            # are no active file descriptors it simply does nothing.
+            # Removing it caused a race condition where a late-firing
+            # _on_disconnect from a stale channel would remove the
+            # on_poll_start callback that a newly-reconnected channel had
+            # just registered, leaving the worker alive but unable to
+            # consume any tasks ("catatonic worker" after broker restart).
+            # See: https://github.com/celery/celery/issues/8030
         cycle._on_connection_disconnect = _on_disconnect
 
         def on_poll_start():

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -1473,6 +1473,26 @@ class Transport(virtual.Transport):
                     except KeyError:
                         # fd was never tracked or already pruned — safe to ignore.
                         pass
+            else:
+                # In async Redis mode, Connection.disconnect() may have already
+                # cleared connection._sock (set to None) before invoking this
+                # callback. In that case we can no longer derive the fd from the
+                # socket itself, so we conservatively scan cycle._fd_to_chan for
+                # channels that are backed by this connection and prune them.
+                stale_fds = []
+                for fd, (chan, _type) in list(cycle._fd_to_chan.items()):
+                    client = getattr(chan, "client", None)
+                    subclient = getattr(chan, "subclient", None)
+                    client_conn = getattr(client, "connection", None)
+                    subclient_conn = getattr(subclient, "connection", None)
+                    if client_conn is connection or subclient_conn is connection:
+                        stale_fds.append(fd)
+                for fd in stale_fds:
+                    try:
+                        del cycle._fd_to_chan[fd]
+                    except KeyError:
+                        # fd was never tracked or already pruned — safe to ignore.
+                        pass
             # Note: we intentionally do NOT remove on_poll_start from
             # loop.on_tick here.  on_poll_start is idempotent — when there
             # are no active file descriptors it simply does nothing.

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -1447,6 +1447,27 @@ class Transport(virtual.Transport):
         def _on_disconnect(connection):
             if connection._sock:
                 loop.remove(connection._sock)
+                # Also prune this connection's file descriptor from the
+                # poller's internal fd map so that on_poll_start does not
+                # re-register stale/disconnected sockets on the next tick.
+                fd = None
+                sock = connection._sock
+                try:
+                    if hasattr(sock, "fileno"):
+                        fd = sock.fileno()
+                    else:
+                        fd = sock
+                except OSError:
+                    # Socket may already be closed; in that case there is
+                    # nothing further for us to clean up here.
+                    fd = None
+                if fd is not None and hasattr(cycle, "_fd_to_chan"):
+                    fd_to_chan = cycle._fd_to_chan
+                    try:
+                        del fd_to_chan[fd]
+                    except KeyError:
+                        # If the fd is not tracked, we have nothing to prune.
+                        pass
             # Note: we intentionally do NOT remove on_poll_start from
             # loop.on_tick here.  on_poll_start is idempotent — when there
             # are no active file descriptors it simply does nothing.

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -1447,26 +1447,31 @@ class Transport(virtual.Transport):
         def _on_disconnect(connection):
             if connection._sock:
                 loop.remove(connection._sock)
-                # Also prune this connection's file descriptor from the
-                # poller's internal fd map so that on_poll_start does not
-                # re-register stale/disconnected sockets on the next tick.
-                fd = None
+                # Prune the disconnected file descriptor from cycle._fd_to_chan
+                # so that the next on_poll_start tick does not re-register a
+                # stale/disconnected socket.  fileno() returns -1 on a socket
+                # that has been closed (but not yet garbage-collected), so we
+                # only prune when we get a valid (>= 0) file descriptor.
                 sock = connection._sock
+                fd = None
                 try:
                     if hasattr(sock, "fileno"):
-                        fd = sock.fileno()
+                        raw_fd = sock.fileno()
+                        # fileno() returns -1 for a closed-but-not-GC'd socket;
+                        # in that case there is no valid fd to prune.
+                        if raw_fd >= 0:
+                            fd = raw_fd
                     else:
+                        # Plain integer file descriptor (no fileno() method).
                         fd = sock
                 except OSError:
-                    # Socket may already be closed; in that case there is
-                    # nothing further for us to clean up here.
-                    fd = None
-                if fd is not None and hasattr(cycle, "_fd_to_chan"):
-                    fd_to_chan = cycle._fd_to_chan
+                    # Socket already closed at OS level; nothing to prune.
+                    pass
+                if fd is not None:
                     try:
-                        del fd_to_chan[fd]
+                        del cycle._fd_to_chan[fd]
                     except KeyError:
-                        # If the fd is not tracked, we have nothing to prune.
+                        # fd was never tracked or already pruned — safe to ignore.
                         pass
             # Note: we intentionally do NOT remove on_poll_start from
             # loop.on_tick here.  on_poll_start is idempotent — when there

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -1215,6 +1215,7 @@ class test_Channel:
         self.connection._sock = None
         transport.cycle = Mock(name='cycle')
         transport.cycle.fds = fds
+        transport.cycle._fd_to_chan = {}
         conn = Mock(name='conn')
         conn.client = Mock(name='client', transport_options={})
         loop = Mock(name='loop')
@@ -1368,6 +1369,82 @@ class test_Channel:
         loop.remove.assert_called_once_with(mock_sock)
         # _fd_to_chan must be left intact — we had no valid fd to prune.
         assert 42 in transport.cycle._fd_to_chan
+        assert len(loop.on_tick) == 1
+
+    def test_register_with_event_loop__on_disconnect__sock_none_prunes(self):
+        """Ensure _on_disconnect prunes stale fds when _sock is None.
+
+        In async Redis mode, Connection.disconnect() clears _sock to None
+        before invoking the disconnect callback.  _on_disconnect must still
+        prune cycle._fd_to_chan by scanning for channels backed by the
+        disconnected connection.
+
+        _fd_to_chan stores tuples of (channel, type_string), matching the
+        real data structure used by MultiChannelPoller._register.
+        """
+        transport = self.connection.transport
+        # _sock is None — simulates async Redis disconnect path
+        self.connection._sock = None
+        # Create a channel mock whose client.connection points to self.connection
+        stale_chan = Mock(name='stale_chan')
+        stale_chan.client.connection = self.connection
+        stale_chan.subclient.connection = None
+        # A channel that belongs to a different connection — must NOT be pruned
+        other_conn = Mock(name='other_conn')
+        alive_chan = Mock(name='alive_chan')
+        alive_chan.client.connection = other_conn
+        alive_chan.subclient.connection = None
+        transport.cycle = Mock(name='cycle', spec=['fds', '_fd_to_chan',
+                                                   'on_poll_init',
+                                                   'on_poll_start',
+                                                   'maybe_restore_messages',
+                                                   'maybe_check_subclient_health',
+                                                   '_on_connection_disconnect'])
+        transport.cycle.fds = {}
+        # _fd_to_chan values are (channel, type) tuples in production
+        transport.cycle._fd_to_chan = {
+            10: (stale_chan, 'BRPOP'),
+            20: (alive_chan, 'LISTEN'),
+        }
+        conn = Mock(name='conn')
+        conn.client = Mock(name='client', transport_options={})
+        loop = Mock(name='loop')
+        loop.on_tick = set()
+        redis.Transport.register_with_event_loop(transport, conn, loop)
+        transport.cycle._on_connection_disconnect(self.connection)
+        # loop.remove must NOT be called — there is no socket to remove
+        loop.remove.assert_not_called()
+        # Stale fd must be pruned, alive fd must remain
+        assert 10 not in transport.cycle._fd_to_chan
+        assert 20 in transport.cycle._fd_to_chan
+        # on_poll_start must still be registered
+        assert len(loop.on_tick) == 1
+
+    def test_register_with_event_loop__on_disconnect__sock_none_subclient(self):
+        """Ensure _on_disconnect also matches via subclient.connection.
+
+        _fd_to_chan stores tuples of (channel, type_string).
+        """
+        transport = self.connection.transport
+        self.connection._sock = None
+        stale_chan = Mock(name='stale_chan')
+        stale_chan.client.connection = None
+        stale_chan.subclient.connection = self.connection
+        transport.cycle = Mock(name='cycle', spec=['fds', '_fd_to_chan',
+                                                   'on_poll_init',
+                                                   'on_poll_start',
+                                                   'maybe_restore_messages',
+                                                   'maybe_check_subclient_health',
+                                                   '_on_connection_disconnect'])
+        transport.cycle.fds = {}
+        transport.cycle._fd_to_chan = {30: (stale_chan, 'BRPOP')}
+        conn = Mock(name='conn')
+        conn.client = Mock(name='client', transport_options={})
+        loop = Mock(name='loop')
+        loop.on_tick = set()
+        redis.Transport.register_with_event_loop(transport, conn, loop)
+        transport.cycle._on_connection_disconnect(self.connection)
+        assert 30 not in transport.cycle._fd_to_chan
         assert len(loop.on_tick) == 1
 
     def test_configurable_health_check(self):

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -1339,6 +1339,37 @@ class test_Channel:
         loop.remove.assert_called_once_with(mock_sock)
         assert len(loop.on_tick) == 1
 
+    def test_register_with_event_loop__on_disconnect__fileno_negative(self):
+        """Ensure _on_disconnect skips pruning when fileno() returns -1.
+
+        A socket that has been closed (but not yet GC'd) returns -1 from
+        fileno().  In that case the real fd is gone and _fd_to_chan must
+        NOT be touched (there is no valid key to remove).
+        """
+        transport = self.connection.transport
+        mock_sock = Mock(name='sock')
+        mock_sock.fileno.return_value = -1
+        self.connection._sock = mock_sock
+        transport.cycle = Mock(name='cycle', spec=['fds', '_fd_to_chan',
+                                                   'on_poll_init',
+                                                   'on_poll_start',
+                                                   'maybe_restore_messages',
+                                                   'maybe_check_subclient_health',
+                                                   '_on_connection_disconnect'])
+        transport.cycle.fds = {}
+        # Suppose fd 42 (the original fd before close) is still in the map.
+        transport.cycle._fd_to_chan = {42: Mock(name='chan')}
+        conn = Mock(name='conn')
+        conn.client = Mock(name='client', transport_options={})
+        loop = Mock(name='loop')
+        loop.on_tick = set()
+        redis.Transport.register_with_event_loop(transport, conn, loop)
+        transport.cycle._on_connection_disconnect(self.connection)
+        loop.remove.assert_called_once_with(mock_sock)
+        # _fd_to_chan must be left intact — we had no valid fd to prune.
+        assert 42 in transport.cycle._fd_to_chan
+        assert len(loop.on_tick) == 1
+
     def test_configurable_health_check(self):
         transport = self.connection.transport
         transport.cycle = Mock(name='cycle')

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -1203,7 +1203,14 @@ class test_Channel:
 
     @pytest.mark.parametrize('fds', [{12: 'LISTEN', 13: 'BRPOP'}, {}])
     def test_register_with_event_loop__on_disconnect__loop_cleanup(self, fds):
-        """Ensure event loop polling stops on disconnect (if started)."""
+        """Ensure on_poll_start stays in on_tick after disconnect.
+
+        on_poll_start is idempotent (no-op when there are no fds), so it
+        must NOT be removed on disconnect.  Removing it caused a race
+        condition where a late-firing _on_disconnect from a stale channel
+        would remove the callback just registered by a new channel,
+        leaving the worker unable to consume tasks after reconnection.
+        """
         transport = self.connection.transport
         self.connection._sock = None
         transport.cycle = Mock(name='cycle')
@@ -1215,11 +1222,8 @@ class test_Channel:
         redis.Transport.register_with_event_loop(transport, conn, loop)
         assert len(loop.on_tick) == 1
         transport.cycle._on_connection_disconnect(self.connection)
-        if fds:
-            assert len(loop.on_tick) == 0
-        else:
-            # on_tick shouldn't be cleared when polling hasn't started
-            assert len(loop.on_tick) == 1
+        # on_poll_start must remain registered regardless of fds state
+        assert len(loop.on_tick) == 1
 
     def test_configurable_health_check(self):
         transport = self.connection.transport

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -1225,6 +1225,120 @@ class test_Channel:
         # on_poll_start must remain registered regardless of fds state
         assert len(loop.on_tick) == 1
 
+    def test_register_with_event_loop__on_disconnect__removes_sock(self):
+        """Ensure _on_disconnect removes the socket from the event loop.
+
+        When connection._sock is set, _on_disconnect must call loop.remove()
+        on it and prune the fd from cycle._fd_to_chan when present.
+        """
+        transport = self.connection.transport
+        mock_sock = Mock(name='sock')
+        mock_sock.fileno.return_value = 42
+        self.connection._sock = mock_sock
+        transport.cycle = Mock(name='cycle', spec=['fds', '_fd_to_chan',
+                                                   'on_poll_init',
+                                                   'on_poll_start',
+                                                   'maybe_restore_messages',
+                                                   'maybe_check_subclient_health',
+                                                   '_on_connection_disconnect'])
+        transport.cycle.fds = {}
+        transport.cycle._fd_to_chan = {42: Mock(name='chan')}
+        conn = Mock(name='conn')
+        conn.client = Mock(name='client', transport_options={})
+        loop = Mock(name='loop')
+        loop.on_tick = set()
+        redis.Transport.register_with_event_loop(transport, conn, loop)
+        transport.cycle._on_connection_disconnect(self.connection)
+        loop.remove.assert_called_once_with(mock_sock)
+        # fd must be pruned from _fd_to_chan
+        assert 42 not in transport.cycle._fd_to_chan
+        # on_poll_start must still be registered after disconnect
+        assert len(loop.on_tick) == 1
+
+    def test_register_with_event_loop__on_disconnect__sock_no_fileno(self):
+        """Ensure _on_disconnect handles sockets without a fileno() method.
+
+        When connection._sock has no fileno() (e.g. a raw fd integer),
+        the fd itself is used as the key to prune from cycle._fd_to_chan.
+        """
+        transport = self.connection.transport
+        # Use a plain integer as the "sock" (no fileno attribute)
+        self.connection._sock = 99
+        transport.cycle = Mock(name='cycle', spec=['fds', '_fd_to_chan',
+                                                   'on_poll_init',
+                                                   'on_poll_start',
+                                                   'maybe_restore_messages',
+                                                   'maybe_check_subclient_health',
+                                                   '_on_connection_disconnect'])
+        transport.cycle.fds = {}
+        transport.cycle._fd_to_chan = {99: Mock(name='chan')}
+        conn = Mock(name='conn')
+        conn.client = Mock(name='client', transport_options={})
+        loop = Mock(name='loop')
+        loop.on_tick = set()
+        redis.Transport.register_with_event_loop(transport, conn, loop)
+        transport.cycle._on_connection_disconnect(self.connection)
+        loop.remove.assert_called_once_with(99)
+        assert 99 not in transport.cycle._fd_to_chan
+        assert len(loop.on_tick) == 1
+
+    def test_register_with_event_loop__on_disconnect__fileno_oserror(self):
+        """Ensure _on_disconnect handles OSError from fileno() gracefully.
+
+        When the socket is already closed, fileno() raises OSError.
+        _on_disconnect should swallow it and skip _fd_to_chan pruning.
+        """
+        transport = self.connection.transport
+        mock_sock = Mock(name='sock')
+        mock_sock.fileno.side_effect = OSError('Bad file descriptor')
+        self.connection._sock = mock_sock
+        transport.cycle = Mock(name='cycle', spec=['fds', '_fd_to_chan',
+                                                   'on_poll_init',
+                                                   'on_poll_start',
+                                                   'maybe_restore_messages',
+                                                   'maybe_check_subclient_health',
+                                                   '_on_connection_disconnect'])
+        transport.cycle.fds = {}
+        transport.cycle._fd_to_chan = {}
+        conn = Mock(name='conn')
+        conn.client = Mock(name='client', transport_options={})
+        loop = Mock(name='loop')
+        loop.on_tick = set()
+        redis.Transport.register_with_event_loop(transport, conn, loop)
+        # Must not raise even though fileno() raises OSError
+        transport.cycle._on_connection_disconnect(self.connection)
+        loop.remove.assert_called_once_with(mock_sock)
+        assert len(loop.on_tick) == 1
+
+    def test_register_with_event_loop__on_disconnect__fd_not_in_map(self):
+        """Ensure _on_disconnect handles missing fd in _fd_to_chan gracefully.
+
+        If the fd is not tracked (already removed), the KeyError must be
+        swallowed silently.
+        """
+        transport = self.connection.transport
+        mock_sock = Mock(name='sock')
+        mock_sock.fileno.return_value = 55
+        self.connection._sock = mock_sock
+        transport.cycle = Mock(name='cycle', spec=['fds', '_fd_to_chan',
+                                                   'on_poll_init',
+                                                   'on_poll_start',
+                                                   'maybe_restore_messages',
+                                                   'maybe_check_subclient_health',
+                                                   '_on_connection_disconnect'])
+        transport.cycle.fds = {}
+        # fd 55 is NOT in _fd_to_chan — KeyError must be silently ignored
+        transport.cycle._fd_to_chan = {}
+        conn = Mock(name='conn')
+        conn.client = Mock(name='client', transport_options={})
+        loop = Mock(name='loop')
+        loop.on_tick = set()
+        redis.Transport.register_with_event_loop(transport, conn, loop)
+        # Must not raise
+        transport.cycle._on_connection_disconnect(self.connection)
+        loop.remove.assert_called_once_with(mock_sock)
+        assert len(loop.on_tick) == 1
+
     def test_configurable_health_check(self):
         transport = self.connection.transport
         transport.cycle = Mock(name='cycle')


### PR DESCRIPTION
## Summary

Fix race condition in Redis transport reconnection that causes "catatonic worker" — a worker that is alive (responds to ping) but silently stops consuming tasks after a broker restart.

## Root cause

`_on_disconnect` in `register_with_event_loop` removes the `on_poll_start` callback from `loop.on_tick` when a Redis connection drops. During reconnection, a new channel re-registers its own `on_poll_start`. But if `_on_disconnect` from the **stale** channel fires **after** the new registration, it removes the new callback, leaving the event loop without any poll trigger. The worker stays alive but `_register_BRPOP` is never called — tasks pile up in Redis and are never consumed.

## Fix

Remove the `loop.on_tick.remove(on_poll_start)` call from `_on_disconnect`. `on_poll_start` is idempotent — when there are no active file descriptors, `cycle.fds` is empty and it simply does nothing. Removing it from `on_tick` was a premature optimization that created a window for the race condition.

## Companion PR

- **Celery**: celery/celery#10204 — adds `hub.reset()` to `synloop` (gevent/eventlet path), which was missing the cleanup that `asynloop` already had.

## Related issues

- celery/celery#8030 — original report (closed but not fully fixed)
- celery/celery#9191 — gevent-specific variant (open)
- celery/celery#9631 — Redis + HAProxy variant (open)
- celery/celery#9095 — Discussion with reports through Nov 2025 on Celery 5.5.3
- Partial fix: #2007 (addressed GC of partially-initialized channels, but not this reconnection race)

## Test plan

- Updated existing `test_register_with_event_loop__on_disconnect__loop_cleanup` to verify `on_poll_start` stays in `on_tick` after disconnect
- All 135 Redis transport tests pass