### PR TITLE
fix: gcpubsub transport crash when using Pub/Sub emulator

### DIFF
--- a/kombu/transport/gcpubsub.py
+++ b/kombu/transport/gcpubsub.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 
 import dataclasses
 import datetime
+import os
 import string
 import threading
 from concurrent.futures import (FIRST_COMPLETED, Future, ThreadPoolExecutor,
@@ -506,6 +507,10 @@ class Channel(virtual.Channel):
         This is a *rough* estimation, as Pub/Sub doesn't provide
         an exact API.
         """
+        if os.getenv("PUBSUB_EMULATOR_HOST"):
+            # Pub/Sub emulator does not support monitoring API.
+            return -1
+
         queue = self.entity_name(queue)
         if queue not in self._queue_cache:
             return 0

--- a/kombu/transport/gcpubsub.py
+++ b/kombu/transport/gcpubsub.py
@@ -507,13 +507,13 @@ class Channel(virtual.Channel):
         This is a *rough* estimation, as Pub/Sub doesn't provide
         an exact API.
         """
-        if os.getenv("PUBSUB_EMULATOR_HOST"):
-            # Pub/Sub emulator does not support monitoring API.
-            return -1
-
         queue = self.entity_name(queue)
         if queue not in self._queue_cache:
             return 0
+
+        if os.getenv("PUBSUB_EMULATOR_HOST"):
+            # Pub/Sub emulator does not support monitoring API.
+            return -1
         qdesc = self._queue_cache[queue]
         result = query.Query(
             self.monitor,

--- a/t/unit/transport/test_gcpubsub.py
+++ b/t/unit/transport/test_gcpubsub.py
@@ -487,15 +487,23 @@ class test_Channel:
         assert size == -1
 
     @patch.dict(os.environ, {"PUBSUB_EMULATOR_HOST": "localhost:8085"})
-    def test_size_with_emulator(self, channel):
+    @patch('kombu.transport.gcpubsub.query.Query')
+    def test_size_with_emulator(self, mock_query, channel):
         queue = "test_queue"
-        channel.monitor = MagicMock()
+        subscription_id = "test_subscription"
+        qdesc = QueueDescriptor(
+            name=queue,
+            topic_path="projects/project-id/topics/test_topic",
+            subscription_id=subscription_id,
+            subscription_path="projects/project-id/subscriptions/test_subscription",  # E501
+        )
+        channel._queue_cache[channel.entity_name(queue)] = qdesc
 
         size = channel._size(queue)
 
         assert size == -1
-        # Verify the monitoring API was never accessed
-        channel.monitor.assert_not_called()
+        # Verify the monitoring query API was never accessed
+        mock_query.assert_not_called()
 
     def test_basic_ack(self, channel):
         delivery_tag = "test_delivery_tag"

--- a/t/unit/transport/test_gcpubsub.py
+++ b/t/unit/transport/test_gcpubsub.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from concurrent.futures import Future
 from datetime import datetime
 from queue import Empty
@@ -448,9 +449,12 @@ class test_Channel:
         )
         assert result == [exchange]
 
+    @patch.dict(os.environ, {}, clear=False)
     @patch('kombu.transport.gcpubsub.monitoring_v3')
     @patch('kombu.transport.gcpubsub.query.Query')
     def test_size(self, mock_query, mock_monitor, channel):
+        # Ensure emulator env var is not set so we test the real path
+        os.environ.pop('PUBSUB_EMULATOR_HOST', None)
         queue = "test_queue"
         subscription_id = "test_subscription"
         qdesc = QueueDescriptor(
@@ -481,6 +485,17 @@ class test_Channel:
         mock_query_result.select_resources.return_value = [mock_item]
         size = channel._size(queue)
         assert size == -1
+
+    @patch.dict(os.environ, {"PUBSUB_EMULATOR_HOST": "localhost:8085"})
+    def test_size_with_emulator(self, channel):
+        queue = "test_queue"
+        channel.monitor = MagicMock()
+
+        size = channel._size(queue)
+
+        assert size == -1
+        # Verify the monitoring API was never accessed
+        channel.monitor.assert_not_called()
 
     def test_basic_ack(self, channel):
         delivery_tag = "test_delivery_tag"


### PR DESCRIPTION
## Problem

The `_size()` method in the gcpubsub transport crashes with `DefaultCredentialsError` when using the Pub/Sub emulator. The `self.monitor` cached property instantiates `monitoring_v3.MetricServiceClient()`, which calls `google.auth.default()` and this fails in emulator mode where no credentials exist nor are needed.

The emulator does not support the Cloud Monitoring API.

Fixes #2427

## Solution

Added a check for the `PUBSUB_EMULATOR_HOST` environment variable at the start of `_size()`. When the emulator is detected, we return `-1` immediately, bypassing the monitoring API call. This is consistent with the existing `-1` return when `PermissionDenied` is raised.

## Changes

- `kombu/transport/gcpubsub.py`: Skip monitoring API call in `_size()` when `PUBSUB_EMULATOR_HOST` is set
- `t/unit/transport/test_gcpubsub.py`: Added `test_size_with_emulator`, hardened `test_size` against env leakage