### PR TITLE
fix: preserve health_check_interval in Redis sentinel connection params

### DIFF
--- a/kombu/utils/functional.py
+++ b/kombu/utils/functional.py
@@ -352,7 +352,8 @@ def accepts_argument(func, argument_name):
     argument_spec = inspect.getfullargspec(func)
     return (
         argument_name in argument_spec.args or
-        argument_name in argument_spec.kwonlyargs
+        argument_name in argument_spec.kwonlyargs or
+        argument_spec.varkw is not None  # **kwargs accepts any keyword
     )
 
 


### PR DESCRIPTION
## Summary
- Preserve `health_check_interval` in Redis sentinel connection parameters
- The parameter was being filtered out by `accepts_argument` check

## Root Cause
The `accepts_argument` check for sentinel connections incorrectly removes `health_check_interval` from connection parameters. `SentinelManagedConnection` uses `**kwargs` to accept connection params, so `accepts_argument` returned False. Since redis-py >=4.5.2, sentinel connections support this parameter.

## Fix
Updated `accepts_argument` in `kombu/utils/functional.py` to return True when the function has `**kwargs` (varkw), since such functions accept any keyword argument.

## Testing
- Verified `health_check_interval` is preserved in sentinel connection params
- `SentinelManagedConnection.__init__(self, **kwargs)` now correctly identified as accepting the parameter

Fixes #2362

Made with [Cursor](https://cursor.com)