### PR TITLE
fix(redis): prevent timer callbacks from crashing event loop on connection error

### DIFF
--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -572,9 +572,18 @@ class MultiChannelPoller:
         for channel in self._channels:
             if channel.active_queues:
                 # only need to do this once, as they are not local to channel.
-                return channel.qos.restore_visible(
-                    num=channel.unacked_restore_limit,
-                )
+                try:
+                    return channel.qos.restore_visible(
+                        num=channel.unacked_restore_limit,
+                    )
+                except channel.connection_errors:
+                    # Connection is broken; skip this cycle and retry next tick.
+                    # The main polling loop handles reconnection independently.
+                    logger.debug(
+                        'maybe_restore_messages: connection error, '
+                        'will retry on next cycle', exc_info=True
+                    )
+                    return
 
     def maybe_check_subclient_health(self):
         for channel in self._channels:
@@ -582,7 +591,14 @@ class MultiChannelPoller:
             client = channel.__dict__.get('subclient')
             if client is not None \
                     and callable(getattr(client, 'check_health', None)):
-                client.check_health()
+                try:
+                    client.check_health()
+                except channel.connection_errors:
+                    logger.debug(
+                        'maybe_check_subclient_health: connection error, '
+                        'will retry on next cycle', exc_info=True
+                    )
+                    return
 
     def on_readable(self, fileno):
         chan, type = self._fd_to_chan[fileno]

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -1461,12 +1461,24 @@ class Transport(virtual.Transport):
             cycle_poll_start()
             [add_reader(fd, on_readable, fd) for fd in cycle.fds]
         loop.on_tick.add(on_poll_start)
-        loop.call_repeatedly(10, cycle.maybe_restore_messages)
+
+        # Cancel stale timer entries from a previous connection before
+        # registering new ones. Without this, each reconnect accumulates
+        # an extra entry in hub.timer._queue; they all fire against the
+        # same cycle and can crash the event loop during reconnect.
+        for attr in ('_restore_messages_tref', '_subclient_health_tref'):
+            old_tref = getattr(cycle, attr, None)
+            if old_tref is not None:
+                old_tref.cancel()
+
+        cycle._restore_messages_tref = loop.call_repeatedly(
+            10, cycle.maybe_restore_messages
+        )
         health_check_interval = connection.client.transport_options.get(
             'health_check_interval',
             DEFAULT_HEALTH_CHECK_INTERVAL
         )
-        loop.call_repeatedly(
+        cycle._subclient_health_tref = loop.call_repeatedly(
             health_check_interval,
             cycle.maybe_check_subclient_health
         )

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -1712,6 +1712,100 @@ class test_MultiChannelPoller:
             num=chan1.unacked_restore_limit,
         )
 
+    def test_maybe_restore_messages_calls_restore_visible(self):
+        """Happy path: restore_visible is called for a channel with active queues."""
+        p = self.Poller()
+        channel = Mock(name='channel')
+        channel.active_queues = ['a_queue']
+        p._channels = [channel]
+
+        p.maybe_restore_messages()
+
+        channel.qos.restore_visible.assert_called_once_with(
+            num=channel.unacked_restore_limit,
+        )
+
+    def test_maybe_restore_messages_skips_channel_without_active_queues(self):
+        """Channels with no active queues must be ignored."""
+        p = self.Poller()
+        channel = Mock(name='channel')
+        channel.active_queues = []
+        p._channels = [channel]
+
+        p.maybe_restore_messages()
+
+        channel.qos.restore_visible.assert_not_called()
+
+    def test_maybe_restore_messages_swallows_connection_error(self):
+        """Connection errors from timer callbacks must not propagate.
+
+        maybe_restore_messages is scheduled via call_repeatedly and runs
+        inside fire_timers. If a ConnectionError escapes, it matches
+        hub.propagate_errors and tears down the entire event loop.
+        The fix catches channel.connection_errors and returns early.
+        """
+        p = self.Poller()
+
+        class ConnError(Exception):
+            pass
+
+        channel = Mock(name='channel')
+        channel.active_queues = ['a_queue']
+        channel.connection_errors = (ConnError,)
+        channel.qos.restore_visible.side_effect = ConnError('connection lost')
+        p._channels = [channel]
+
+        # Must not raise
+        p.maybe_restore_messages()
+
+        channel.qos.restore_visible.assert_called_once()
+
+    def test_maybe_check_subclient_health_calls_check_health(self):
+        """Happy path: check_health is called when subclient is cached."""
+        p = self.Poller()
+        channel = Mock(name='channel')
+        client = Mock(name='subclient')
+        channel.__dict__['subclient'] = client
+        p._channels = [channel]
+
+        p.maybe_check_subclient_health()
+
+        client.check_health.assert_called_once()
+
+    def test_maybe_check_subclient_health_skips_when_no_subclient(self):
+        """Channels with no cached subclient must be silently skipped."""
+        p = self.Poller()
+        channel = Mock(name='channel')
+        # Ensure 'subclient' is not in __dict__ (not yet accessed/cached)
+        channel.__dict__.pop('subclient', None)
+        p._channels = [channel]
+
+        p.maybe_check_subclient_health()  # must not raise
+
+    def test_maybe_check_subclient_health_swallows_connection_error(self):
+        """Connection errors from timer callbacks must not propagate.
+
+        Same reasoning as test_maybe_restore_messages_swallows_connection_error:
+        the fix catches channel.connection_errors and returns early instead of
+        letting the exception bubble up through fire_timers.
+        """
+        p = self.Poller()
+
+        class ConnError(Exception):
+            pass
+
+        channel = Mock(name='channel')
+        channel.connection_errors = (ConnError,)
+        client = Mock(name='subclient')
+        client.check_health.side_effect = ConnError('connection lost')
+        channel.__dict__['subclient'] = client
+        p._channels = [channel]
+
+        # Must not raise
+        p.maybe_check_subclient_health()
+
+        client.check_health.assert_called_once()
+
     def test_handle_event(self):
         p = self.Poller()
         chan = Mock(name='chan')

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -1246,6 +1246,51 @@ class test_Channel:
             call(13, transport.on_readable, 13),
         ])
 
+    def test_register_with_event_loop_stores_trefs_on_cycle(self):
+        """call_repeatedly return values (trefs) must be stored on cycle.
+
+        Without storing the trefs, stale timer entries accumulate in
+        hub.timer._queue across reconnects (each reconnect adds a new entry
+        without removing the old one).
+        """
+        transport = self.connection.transport
+        transport.cycle = Mock(name='cycle')
+        transport.cycle.fds = {}
+        conn = Mock(name='conn')
+        conn.client = Mock(name='client', transport_options={})
+        loop = Mock(name='loop')
+        tref1, tref2 = Mock(name='tref_restore'), Mock(name='tref_health')
+        loop.call_repeatedly.side_effect = [tref1, tref2]
+
+        redis.Transport.register_with_event_loop(transport, conn, loop)
+
+        assert transport.cycle._restore_messages_tref is tref1
+        assert transport.cycle._subclient_health_tref is tref2
+
+    def test_register_with_event_loop_cancels_stale_trefs_on_reconnect(self):
+        """Stale timer entries from a previous connection must be cancelled.
+
+        Each call to register_with_event_loop (i.e. each reconnect) must
+        cancel the previous trefs before registering new ones, so that
+        hub.timer._queue never accumulates duplicate entries.
+        """
+        transport = self.connection.transport
+        transport.cycle = Mock(name='cycle')
+        transport.cycle.fds = {}
+        conn = Mock(name='conn')
+        conn.client = Mock(name='client', transport_options={})
+        loop = Mock(name='loop')
+
+        old_restore_tref = Mock(name='old_restore_tref')
+        old_health_tref = Mock(name='old_health_tref')
+        transport.cycle._restore_messages_tref = old_restore_tref
+        transport.cycle._subclient_health_tref = old_health_tref
+
+        redis.Transport.register_with_event_loop(transport, conn, loop)
+
+        old_restore_tref.cancel.assert_called_once()
+        old_health_tref.cancel.assert_called_once()
+
     def test_transport_on_readable(self):
         transport = self.connection.transport
         cycle = transport.cycle = Mock(name='cyle')


### PR DESCRIPTION
## fix(redis): prevent timer callbacks from crashing event loop on connection error

Closes / related: celery/celery#10205, celery/celery#8030

---

### Problem

When a Redis connection drops while a Celery worker is running, two separate bugs in `kombu/transport/redis.py` conspire to crash and repeatedly restart the event loop:

**Root cause A – timer callbacks propagate `ConnectionError` to the event loop**

`MultiChannelPoller.maybe_restore_messages` and `maybe_check_subclient_health` are scheduled as repeating timer callbacks
via `call_repeatedly`. They are executed inside `Hub.fire_timers`, which has this exception-dispatch logic:

```python
try:
    entry()
except propagate:
    raise          # ← re-raises if the error type is in propagate_errors
except Exception:
    logger.error(...)   # ← everything else is swallowed
```

`hub.propagate_errors` is set to `connection.connection_errors` by `asynloop` (in `celery/worker/loops.py`).  `redis.exceptions.ConnectionError` is part of `connection_errors`, so an exception thrown by either timer callback escapes `fire_timers`, propagates out of the `create_loop` generator, and tears down the entire event loop — triggering a full blueprint restart.

The timer callbacks are **not** the right place to detect a broken connection; the main polling loop handles reconnection independently. They should just skip the current tick on error.

**Root cause B – stale timer entries accumulate across reconnects**

`register_with_event_loop` was calling `loop.call_repeatedly(…)` and
discarding the returned `tref` (timer reference):

```python
loop.call_repeatedly(10, cycle.maybe_restore_messages)          # tref lost
loop.call_repeatedly(health_check_interval,
                     cycle.maybe_check_subclient_health)         # tref lost
```

On every reconnect `register_with_event_loop` is called again. Without cancelling the previous trefs, `hub.timer._queue` accumulates one extra entry per reconnect. After *N* reconnects there are *N* copies of each callback firing every tick, all of them hitting the same (broken) cycle and all potentially crashing the event loop again.

---

### Fix

**Change 1 – catch `channel.connection_errors` in timer callbacks**

`maybe_restore_messages` and `maybe_check_subclient_health` now wrap their inner work in `try/except channel.connection_errors`. On error they log a `DEBUG` message and return early, letting the next scheduled tick retry naturally.

```python
def maybe_restore_messages(self):
    for channel in self._channels:
        if channel.active_queues:
            try:
                return channel.qos.restore_visible(
                    num=channel.unacked_restore_limit,
                )
            except channel.connection_errors:
                logger.debug(
                    'maybe_restore_messages: connection error, '
                    'will retry on next cycle', exc_info=True
                )
                return
```

**Change 2 – store and cancel trefs between reconnects**

The trefs returned by `call_repeatedly` are now stored on `cycle`. At the top of `register_with_event_loop`, any pre-existing trefs are cancelled before new ones are registered:

```python
for attr in ('_restore_messages_tref', '_subclient_health_tref'):
    old_tref = getattr(cycle, attr, None)
    if old_tref is not None:
        old_tref.cancel()

cycle._restore_messages_tref = loop.call_repeatedly(
    10, cycle.maybe_restore_messages
)
cycle._subclient_health_tref = loop.call_repeatedly(
    health_check_interval, cycle.maybe_check_subclient_health
)
```

---

### Relationship between the two changes

|                        | Change 1                                              | Change 2                                           |
|------------------------|-------------------------------------------------------|----------------------------------------------------|
| What it fixes          | Timer callback no longer crashes the event loop       | Timer queue no longer accumulates stale entries    |
| Without the other      | No crash, but queue still grows across reconnects     | Queue stays clean, but first disconnect still crashes |
| Together               | Complete fix for the kombu-side of celery/celery#10205 |                                                   |

Change 1 is the **immediate safety net**; Change 2 is the **structural cure**. Both are required for a complete fix.

---


### Companion work (future PR in celery/celery)

As a defense-in-depth measure, `asynloop` in `celery/worker/loops.py` should call `hub.timer.clear()` during `blueprint.restart()` to drain any entries that were not cancelled before the loop was torn down. That change belongs in a separate celery-side PR and is not required for this fix to be effective.
