### PR TITLE
Pass through Redis credential_provider from connection_kwargs during client creation in redis transport

### DIFF
--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -1336,8 +1336,18 @@ class Channel(virtual.Channel):
 
     def _create_client(self, asynchronous=False):
         if asynchronous:
-            return self.Client(connection_pool=self.async_pool)
-        return self.Client(connection_pool=self.pool)
+            return self.Client(
+                connection_pool=self.async_pool,
+                credential_provider=self.async_pool.connection_kwargs.get(
+                    'credential_provider',
+                ),
+            )
+        return self.Client(
+            connection_pool=self.pool,
+            credential_provider=self.pool.connection_kwargs.get(
+                'credential_provider',
+            ),
+        )
 
     def _get_pool(self, asynchronous=False):
         params = self._connparams(asynchronous=asynchronous)

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -1336,18 +1336,20 @@ class Channel(virtual.Channel):
 
     def _create_client(self, asynchronous=False):
         if asynchronous:
-            return self.Client(
-                connection_pool=self.async_pool,
-                credential_provider=self.async_pool.connection_kwargs.get(
-                    'credential_provider',
-                ),
-            )
-        return self.Client(
-            connection_pool=self.pool,
-            credential_provider=self.pool.connection_kwargs.get(
+            client_kwargs = {'connection_pool': self.async_pool}
+            credential_provider = self.async_pool.connection_kwargs.get(
                 'credential_provider',
-            ),
+            )
+            if credential_provider is not None:
+                client_kwargs['credential_provider'] = credential_provider
+            return self.Client(**client_kwargs)
+        client_kwargs = {'connection_pool': self.pool}
+        credential_provider = self.pool.connection_kwargs.get(
+            'credential_provider',
         )
+        if credential_provider is not None:
+            client_kwargs['credential_provider'] = credential_provider
+        return self.Client(**client_kwargs)
 
     def _get_pool(self, asynchronous=False):
         params = self._connparams(asynchronous=asynchronous)

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -1105,8 +1105,8 @@ class test_Channel:
         provider = object()
         client_factory = Mock(name='Client')
         self.channel.Client = client_factory
-        self.channel.pool = Mock(connection_kwargs={'credential_provider': provider})
-        self.channel.async_pool = Mock(connection_kwargs={'credential_provider': provider})
+        self.channel._pool = Mock(connection_kwargs={'credential_provider': provider})
+        self.channel._async_pool = Mock(connection_kwargs={'credential_provider': provider})
 
         self.channel._create_client()
         client_factory.assert_called_with(

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -1101,6 +1101,26 @@ class test_Channel:
         with pytest.raises(ValueError):
             self.channel._connparams()
 
+    def test_create_client_passes_credential_provider_from_pool(self):
+        provider = object()
+        client_factory = Mock(name='Client')
+        self.channel.Client = client_factory
+        self.channel.pool = Mock(connection_kwargs={'credential_provider': provider})
+        self.channel.async_pool = Mock(connection_kwargs={'credential_provider': provider})
+
+        self.channel._create_client()
+        client_factory.assert_called_with(
+            connection_pool=self.channel.pool,
+            credential_provider=provider,
+        )
+
+        client_factory.reset_mock()
+        self.channel._create_client(asynchronous=True)
+        client_factory.assert_called_with(
+            connection_pool=self.channel.async_pool,
+            credential_provider=provider,
+        )
+
     def test_connparams_password_for_unix_socket(self):
         self.channel.connection.client.hostname = \
             'socket://:foo@/var/run/redis.sock'


### PR DESCRIPTION
Redis transport passes credential_provider to ConnectionPool but not to redis.Redis(...), which prevents `StreamingCredentialProvider` re-auth registration for long-lived connections.

This is especially relevant for IAM auth to ElastiCache which has a hard 12 hour connection duration and requires an explicit re-auth before that time.