### PR TITLE
fix: RabbitMQ 4.3.0 compatibility

### DIFF
--- a/docs/reference/kombu.pidbox.rst
+++ b/docs/reference/kombu.pidbox.rst
@@ -73,7 +73,7 @@
     Mailbox Options
     ~~~~~~~~~~~~~~~
 
-    .. versionadded:: 5.7.0
+    .. versionadded:: 5.6.0
 
     The `Mailbox` supports several configuration options that affect
     the behavior of its queues.

--- a/docs/reference/kombu.pidbox.rst
+++ b/docs/reference/kombu.pidbox.rst
@@ -73,16 +73,20 @@
     Mailbox Options
     ~~~~~~~~~~~~~~~
 
-    .. versionadded:: 5.6.0
+    .. versionadded:: 5.7.0
 
     The `Mailbox` supports several configuration options that affect
-    the behavior of its exchanges and queues.
+    the behavior of its queues.
 
-    - ``durable``: If True, declares durable exchanges that survive broker restarts.
-    - ``exclusive``: If True, declares exclusive exchanges (usable by only one connection).
+    - ``queue_durable``: If True, declares durable queues that survive broker restarts.
+      Defaults to False.
+    - ``queue_exclusive``: If True, declares exclusive queues (usable by only
+      one connection, auto-deleted on disconnect). Defaults to True.
 
-    These provide finer control over broker-side behavior and are useful
-    in production environments where queue durability matters.\
+    .. versionchanged:: 5.7.0
+       ``queue_exclusive`` now defaults to ``True`` for RabbitMQ 4.3.0
+       compatibility. RabbitMQ 4.3.0 rejects transient non-exclusive queues
+       by default.
 
     Node
     ----

--- a/kombu/pidbox.py
+++ b/kombu/pidbox.py
@@ -80,10 +80,10 @@ class Node:
                 accept=self.mailbox.accept if accept is None else accept,
                 **options
             )
-        except channel_errors:
+        except channel_errors as exc:
             raise InconsistencyError(
                 W_PIDBOX_IN_USE.format(node=self)
-            )
+            ) from exc
 
     def handler(self, fun):
         self.handlers[fun.__name__] = fun

--- a/kombu/pidbox.py
+++ b/kombu/pidbox.py
@@ -72,11 +72,18 @@ class Node:
                 warnings.warn(W_PIDBOX_IN_USE.format(node=self))
         queue.on_declared = verify_exclusive
 
-        return Consumer(
-            channel or self.channel, [queue], no_ack=no_ack,
-            accept=self.mailbox.accept if accept is None else accept,
-            **options
-        )
+        conn = self.mailbox.connection
+        channel_errors = conn.channel_errors if conn else ()
+        try:
+            return Consumer(
+                channel or self.channel, [queue], no_ack=no_ack,
+                accept=self.mailbox.accept if accept is None else accept,
+                **options
+            )
+        except channel_errors:
+            raise InconsistencyError(
+                W_PIDBOX_IN_USE.format(node=self)
+            )
 
     def handler(self, fun):
         self.handlers[fun.__name__] = fun
@@ -181,7 +188,7 @@ class Mailbox:
                  type='direct', connection=None, clock=None,
                  accept=None, serializer=None, producer_pool=None,
                  queue_ttl=None, queue_expires=None,
-                 queue_durable=False, queue_exclusive=False,
+                 queue_durable=False, queue_exclusive=True,
                  reply_queue_ttl=None, reply_queue_expires=10.0):
         self.namespace = namespace
         self.connection = connection

--- a/kombu/pidbox.py
+++ b/kombu/pidbox.py
@@ -81,9 +81,11 @@ class Node:
                 **options
             )
         except channel_errors as exc:
-            raise InconsistencyError(
-                W_PIDBOX_IN_USE.format(node=self)
-            ) from exc
+            if getattr(exc, 'code', 0) == 405:
+                raise InconsistencyError(
+                    W_PIDBOX_IN_USE.format(node=self)
+                ) from exc
+            raise
 
     def handler(self, fun):
         self.handlers[fun.__name__] = fun

--- a/kombu/simple.py
+++ b/kombu/simple.py
@@ -157,7 +157,8 @@ class SimpleBuffer(SimpleQueue):
 
     no_ack = True
     queue_opts = {'durable': False,
-                  'auto_delete': True}
+                  'auto_delete': True,
+                  'exclusive': True}
     exchange_opts = {'durable': False,
                      'delivery_mode': 'transient',
                      'auto_delete': True}

--- a/t/unit/test_pidbox.py
+++ b/t/unit/test_pidbox.py
@@ -168,8 +168,17 @@ class test_Mailbox:
         assert not consumer2.no_ack
 
     def test_Node_consumer_channel_error_raises_inconsistency(self):
+        base_channel_error = self.connection.channel_errors[0]
+
+        class ResourceLockedChannelError(base_channel_error):
+            def __str__(self):
+                return (
+                    "RESOURCE_LOCKED - cannot obtain exclusive access to "
+                    "locked queue 'pidbox': already using this queue"
+                )
+
         with patch('kombu.pidbox.Consumer') as MockConsumer:
-            MockConsumer.side_effect = self.connection.channel_errors[0]()
+            MockConsumer.side_effect = ResourceLockedChannelError()
             with pytest.raises(InconsistencyError, match='already using'):
                 self.node.Consumer()
 

--- a/t/unit/test_pidbox.py
+++ b/t/unit/test_pidbox.py
@@ -167,10 +167,12 @@ class test_Mailbox:
         assert consumer2.channel is chan2
         assert not consumer2.no_ack
 
-    def test_Node_consumer_channel_error_raises_inconsistency(self):
+    def test_Node_consumer_resource_locked_raises_inconsistency(self):
         base_channel_error = self.connection.channel_errors[0]
 
         class ResourceLockedChannelError(base_channel_error):
+            code = 405
+
             def __str__(self):
                 return (
                     "RESOURCE_LOCKED - cannot obtain exclusive access to "
@@ -180,6 +182,17 @@ class test_Mailbox:
         with patch('kombu.pidbox.Consumer') as MockConsumer:
             MockConsumer.side_effect = ResourceLockedChannelError()
             with pytest.raises(InconsistencyError, match='already using'):
+                self.node.Consumer()
+
+    def test_Node_consumer_other_channel_error_propagates(self):
+        base_channel_error = self.connection.channel_errors[0]
+
+        class AccessRefusedError(base_channel_error):
+            code = 403
+
+        with patch('kombu.pidbox.Consumer') as MockConsumer:
+            MockConsumer.side_effect = AccessRefusedError()
+            with pytest.raises(AccessRefusedError):
                 self.node.Consumer()
 
     def test_Node_consumer_multiple_listeners(self):

--- a/t/unit/test_pidbox.py
+++ b/t/unit/test_pidbox.py
@@ -167,6 +167,12 @@ class test_Mailbox:
         assert consumer2.channel is chan2
         assert not consumer2.no_ack
 
+    def test_Node_consumer_channel_error_raises_inconsistency(self):
+        with patch('kombu.pidbox.Consumer') as MockConsumer:
+            MockConsumer.side_effect = self.connection.channel_errors[0]()
+            with pytest.raises(InconsistencyError, match='already using'):
+                self.node.Consumer()
+
     def test_Node_consumer_multiple_listeners(self):
         warnings.resetwarnings()
         consumer = self.node.Consumer()
@@ -341,6 +347,14 @@ class test_Mailbox:
         m = consumer.queues[0].get()
         if m:
             return m.payload
+
+    def test_mailbox_defaults_to_exclusive(self):
+        mbox = pidbox.Mailbox('flagbox_default')(self.connection)
+
+        for q in (mbox.get_queue('worker1'), mbox.get_reply_queue()):
+            assert q.exclusive is True
+            assert q.durable is False
+            assert q.auto_delete is True
 
     def test_mailbox_queue_exclusive(self):
         mbox = pidbox.Mailbox(

--- a/t/unit/test_simple.py
+++ b/t/unit/test_simple.py
@@ -194,10 +194,13 @@ class test_SimpleBuffer(SimpleBase):
         assert q.queue.exchange.auto_delete
 
     def test_queue_opts(self):
-        q = self.Queue('test_queue_opts', queue_opts={'auto_delete': False})
+        q = self.Queue('test_queue_opts',
+                       queue_opts={'auto_delete': False, 'exclusive': False})
         assert not q.queue.durable
         assert not q.queue.auto_delete
+        assert not q.queue.exclusive
 
         q = self.Queue('test_queue_opts')
         assert not q.queue.durable
         assert q.queue.auto_delete
+        assert q.queue.exclusive


### PR DESCRIPTION
## Summary

RabbitMQ 4.3.0 disables transient non-exclusive queues by default. Kombu's pidbox queues and `SimpleBuffer` queues are declared with `durable=False, exclusive=False`, which RabbitMQ 4.3.0 rejects with `(541) INTERNAL_ERROR`.

### RabbitMQ References

- [**Release Notes (Broadcom TechDocs)**](https://techdocs.broadcom.com/us/en/vmware-tanzu/data-solutions/open-source-rabbitmq/4-3/opn-src-rabbitmq/site-release-notes.html): *"Deprecated Features are Now Disabled by Default — This includes non-durable (transient) non-exclusive queues: attempts to declare a queue with that property combination are rejected by default. Use durable queues, transient exclusive queues, or durable queues with a queue TTL instead."*
- [**Deprecated Features List**](https://www.rabbitmq.com/release-information/deprecated-features-list): `transient_nonexcl_queues` — *"Covers queues that are both non-durable and non-exclusive, this combination should be avoided. Use durable queues or non-durable exclusive queues."*
- [**Deprecation Announcement (August 2021)**](https://www.rabbitmq.com/blog/2021/08/21/4.0-deprecation-announcements): Original deprecation notice for RabbitMQ 4.0+

### Fix

**`kombu/pidbox.py`** — Change `Mailbox` default from `queue_exclusive=False` to `queue_exclusive=True`. Pidbox queues are per-connection, transient control channels — only the declaring connection consumes from them. Messages are published as transient (the exchange sets `delivery_mode='transient'` in `_get_exchange()`), so a durable queue surviving a restart would just leave an empty queue that never auto-deletes, accumulating zombie queues in containerized deployments. `exclusive=True` matches the intended lifecycle and is RabbitMQ's recommended alternative for the deprecated pattern.

Additionally, `Node.Consumer` now catches channel errors (e.g., `RESOURCE_LOCKED`) and raises `InconsistencyError` with the `W_PIDBOX_IN_USE` guidance message. With exclusive queues, the existing `verify_exclusive` / `on_declared` soft-check can't fire (the broker rejects the declare before the callback runs), so this hardens the duplicate-node detection into a proper error.

**`kombu/simple.py`** — Add `'exclusive': True` to `SimpleBuffer.queue_opts`. `SimpleBuffer` is documented as "Simple API for ephemeral queues" with `durable=False, auto_delete=True` — `exclusive=True` matches this ephemeral semantics exactly.

### Before → After

| | Before | After |
|---|---|---|
| `Mailbox.queue_exclusive` default | `False` | `True` |
| `SimpleBuffer.queue_opts` | `{'durable': False, 'auto_delete': True}` | `{'durable': False, 'auto_delete': True, 'exclusive': True}` |
| Duplicate node detection | `W_PIDBOX_IN_USE` warning via `on_declared` callback | `InconsistencyError` with `W_PIDBOX_IN_USE` message |

### Why `exclusive=True` (not `durable=True`)

- Pidbox messages are transient (exchange `delivery_mode='transient'`) — a durable queue surviving a restart just leaves an empty queue
- `durable=True` disables `auto_delete` (`auto_delete = not self.queue_durable`), causing permanent zombie queues in k8s/ECS where each pod gets a unique nodename
- The pidbox lifecycle is a natural fit for [exclusive queues](https://www.rabbitmq.com/docs/queues#exclusive-queues): one connection declares it, only that connection consumes, the queue dies with its consumer
- `exclusive=True` implies `auto_delete=True` per AMQP spec (enforced in `entity.py:594-596`)
- The `ValueError` guard at `pidbox.py:202-206` prevents the invalid `durable=True + exclusive=True` combination

---

Companion PR: celery/celery#10290 | Closes #2237