### PR TITLE
prefixed native delayed delivery

### DIFF
--- a/examples/delayed_infra.py
+++ b/examples/delayed_infra.py
@@ -19,5 +19,5 @@ with Connection('amqp://guest:guest@localhost:5672//') as connection:
         producer.publish(
             "delayed msg",
             routing_key=routing_key,
-            exchange=level_name(27)
+            exchange=level_name(27, "my_prefix")
         )

--- a/examples/delayed_infra.py
+++ b/examples/delayed_infra.py
@@ -6,14 +6,14 @@ from kombu.transport.native_delayed_delivery import (
     declare_native_delayed_delivery_exchanges_and_queues, level_name)
 
 with Connection('amqp://guest:guest@localhost:5672//') as connection:
-    declare_native_delayed_delivery_exchanges_and_queues(connection, 'quorum')
+    declare_native_delayed_delivery_exchanges_and_queues(connection, 'quorum', "my_prefix")
     channel = connection.channel()
 
     destination_exchange = Exchange('destination_exchange', type='topic')
     queue = Queue("destination", exchange=destination_exchange, routing_key='destination_route')
     queue.declare(channel=connection.channel())
 
-    bind_queue_to_native_delayed_delivery_exchange(connection, queue)
+    bind_queue_to_native_delayed_delivery_exchange(connection, queue, "my_prefix")
     with connection.Producer(channel=channel) as producer:
         routing_key = calculate_routing_key(30, 'destination_route')
         producer.publish(

--- a/kombu/transport/native_delayed_delivery.py
+++ b/kombu/transport/native_delayed_delivery.py
@@ -33,7 +33,15 @@ def _celery_delayed_delivery_exchange(prefix: str | None = None) -> str:
 def declare_native_delayed_delivery_exchanges_and_queues(
     connection: Connection, queue_type: str, prefix: str | None = ""
 ) -> None:
-    """Declares all native delayed delivery exchanges and queues."""
+    """Declare all native delayed delivery exchanges and queues.
+
+    The generated delayed exchange/queue names use ``prefix`` when it is a
+    non-empty string. In that case, level names are created as
+    ``"{prefix}_celery_delayed_{level}"`` and the delivery exchange is named
+    ``"{prefix}_celery_delayed_delivery"``. If ``prefix`` is ``None`` or an
+    empty string, no prefix is applied and the default names
+    ``"celery_delayed_{level}"`` and ``"celery_delayed_delivery"`` are used.
+    """
     if queue_type != "classic" and queue_type != "quorum":
         raise ValueError("queue_type must be either classic or quorum")
 

--- a/kombu/transport/native_delayed_delivery.py
+++ b/kombu/transport/native_delayed_delivery.py
@@ -24,7 +24,7 @@ def level_name(level: int, prefix: str | None = "") -> str:
     return f"celery_delayed_{level}"
 
 
-def celery_delayed_delivery_exchange(prefix: str | None = None) -> str:
+def _celery_delayed_delivery_exchange(prefix: str | None = None) -> str:
     if prefix:
         return f"{prefix}_{CELERY_DELAYED_DELIVERY_EXCHANGE}"
     return CELERY_DELAYED_DELIVERY_EXCHANGE
@@ -53,7 +53,7 @@ def declare_native_delayed_delivery_exchanges_and_queues(
             "x-queue-type": queue_type,
             "x-overflow": "reject-publish",
             "x-message-ttl": pow(2, level) * 1000,
-            "x-dead-letter-exchange": next_level if level > 0 else celery_delayed_delivery_exchange(prefix),
+            "x-dead-letter-exchange": next_level if level > 0 else _celery_delayed_delivery_exchange(prefix),
         }
 
         if queue_type == 'quorum':
@@ -81,7 +81,7 @@ def declare_native_delayed_delivery_exchanges_and_queues(
         routing_key = "*." + routing_key
 
     delivery_exchange: Exchange = Exchange(
-        celery_delayed_delivery_exchange(prefix), type="topic").bind(channel)
+        _celery_delayed_delivery_exchange(prefix), type="topic").bind(channel)
     delivery_exchange.declare()
     delivery_exchange.bind_to(level_name(0, prefix), routing_key)
 
@@ -134,7 +134,7 @@ def bind_queue_to_native_delayed_delivery_exchange(
 
         routing_key = binding_entry.routing_key if binding_entry.routing_key.startswith(
             '#') else f"#.{binding_entry.routing_key}"
-        exchange.bind_to(celery_delayed_delivery_exchange(prefix), routing_key=routing_key)
+        exchange.bind_to(_celery_delayed_delivery_exchange(prefix), routing_key=routing_key)
         queue.bind_to(exchange.name, routing_key=routing_key)
 
 

--- a/kombu/transport/native_delayed_delivery.py
+++ b/kombu/transport/native_delayed_delivery.py
@@ -14,7 +14,7 @@ MAX_LEVEL = MAX_NUMBER_OF_BITS_TO_USE - 1
 CELERY_DELAYED_DELIVERY_EXCHANGE = "celery_delayed_delivery"
 
 
-def level_name(level: int, prefix: str | None = "") -> str:
+def level_name(level: int, prefix: str | None = None) -> str:
     """Generates the delayed queue/exchange name based on the level."""
     if level < 0:
         raise ValueError("level must be a non-negative number")
@@ -31,7 +31,7 @@ def _celery_delayed_delivery_exchange(prefix: str | None = None) -> str:
 
 
 def declare_native_delayed_delivery_exchanges_and_queues(
-    connection: Connection, queue_type: str, prefix: str | None = ""
+    connection: Connection, queue_type: str, prefix: str | None = None
 ) -> None:
     """Declare all native delayed delivery exchanges and queues.
 
@@ -95,7 +95,7 @@ def declare_native_delayed_delivery_exchanges_and_queues(
 
 
 def bind_queue_to_native_delayed_delivery_exchange(
-    connection: Connection, queue: Queue, prefix: str | None = ""
+    connection: Connection, queue: Queue, prefix: str | None = None
 ) -> None:
     """Bind a queue to the native delayed delivery exchange.
 

--- a/kombu/transport/native_delayed_delivery.py
+++ b/kombu/transport/native_delayed_delivery.py
@@ -14,15 +14,25 @@ MAX_LEVEL = MAX_NUMBER_OF_BITS_TO_USE - 1
 CELERY_DELAYED_DELIVERY_EXCHANGE = "celery_delayed_delivery"
 
 
-def level_name(level: int) -> str:
+def level_name(level: int, prefix: str | None = "") -> str:
     """Generates the delayed queue/exchange name based on the level."""
     if level < 0:
         raise ValueError("level must be a non-negative number")
 
+    if prefix:
+        return f"{prefix}_celery_delayed_{level}"
     return f"celery_delayed_{level}"
 
 
-def declare_native_delayed_delivery_exchanges_and_queues(connection: Connection, queue_type: str) -> None:
+def celery_delayed_delivery_exchange(prefix: str | None = None) -> str:
+    if prefix:
+        return f"{prefix}_{CELERY_DELAYED_DELIVERY_EXCHANGE}"
+    return CELERY_DELAYED_DELIVERY_EXCHANGE
+
+
+def declare_native_delayed_delivery_exchanges_and_queues(
+    connection: Connection, queue_type: str, prefix: str | None = ""
+) -> None:
     """Declares all native delayed delivery exchanges and queues."""
     if queue_type != "classic" and queue_type != "quorum":
         raise ValueError("queue_type must be either classic or quorum")
@@ -32,8 +42,8 @@ def declare_native_delayed_delivery_exchanges_and_queues(connection: Connection,
     routing_key: str = "1.#"
 
     for level in range(27, -1, - 1):
-        current_level = level_name(level)
-        next_level = level_name(level - 1) if level > 0 else None
+        current_level = level_name(level, prefix)
+        next_level = level_name(level - 1, prefix) if level > 0 else None
 
         delayed_exchange: Exchange = Exchange(
             current_level, type="topic").bind(channel)
@@ -43,7 +53,7 @@ def declare_native_delayed_delivery_exchanges_and_queues(connection: Connection,
             "x-queue-type": queue_type,
             "x-overflow": "reject-publish",
             "x-message-ttl": pow(2, level) * 1000,
-            "x-dead-letter-exchange": next_level if level > 0 else CELERY_DELAYED_DELIVERY_EXCHANGE,
+            "x-dead-letter-exchange": next_level if level > 0 else celery_delayed_delivery_exchange(prefix),
         }
 
         if queue_type == 'quorum':
@@ -60,8 +70,8 @@ def declare_native_delayed_delivery_exchanges_and_queues(connection: Connection,
 
     routing_key = "0.#"
     for level in range(27, 0, - 1):
-        current_level = level_name(level)
-        next_level = level_name(level - 1) if level > 0 else None
+        current_level = level_name(level, prefix)
+        next_level = level_name(level - 1, prefix) if level > 0 else None
 
         next_level_exchange: Exchange = Exchange(
             next_level, type="topic").bind(channel)
@@ -71,12 +81,14 @@ def declare_native_delayed_delivery_exchanges_and_queues(connection: Connection,
         routing_key = "*." + routing_key
 
     delivery_exchange: Exchange = Exchange(
-        CELERY_DELAYED_DELIVERY_EXCHANGE, type="topic").bind(channel)
+        celery_delayed_delivery_exchange(prefix), type="topic").bind(channel)
     delivery_exchange.declare()
-    delivery_exchange.bind_to(level_name(0), routing_key)
+    delivery_exchange.bind_to(level_name(0, prefix), routing_key)
 
 
-def bind_queue_to_native_delayed_delivery_exchange(connection: Connection, queue: Queue) -> None:
+def bind_queue_to_native_delayed_delivery_exchange(
+    connection: Connection, queue: Queue, prefix: str | None = ""
+) -> None:
     """Bind a queue to the native delayed delivery exchange.
 
     When a message arrives at the delivery exchange, it must be forwarded to
@@ -89,6 +101,8 @@ def bind_queue_to_native_delayed_delivery_exchange(connection: Connection, queue
     :type connection: Connection
     :param queue: The queue to be bound to the native delayed delivery exchange.
     :type queue: Queue
+    :param prefix: Prefix name of the delayed delivery exchanges and queues
+    :type prefix: str
 
     Warning:
     -------
@@ -119,7 +133,7 @@ def bind_queue_to_native_delayed_delivery_exchange(connection: Connection, queue
 
         routing_key = binding_entry.routing_key if binding_entry.routing_key.startswith(
             '#') else f"#.{binding_entry.routing_key}"
-        exchange.bind_to(CELERY_DELAYED_DELIVERY_EXCHANGE, routing_key=routing_key)
+        exchange.bind_to(celery_delayed_delivery_exchange(prefix), routing_key=routing_key)
         queue.bind_to(exchange.name, routing_key=routing_key)
 
 

--- a/kombu/transport/native_delayed_delivery.py
+++ b/kombu/transport/native_delayed_delivery.py
@@ -101,8 +101,9 @@ def bind_queue_to_native_delayed_delivery_exchange(
     :type connection: Connection
     :param queue: The queue to be bound to the native delayed delivery exchange.
     :type queue: Queue
-    :param prefix: Prefix name of the delayed delivery exchanges and queues
-    :type prefix: str
+    :param prefix: Optional prefix for delayed delivery exchange and queue names;
+        ``None`` or ``""`` means no prefix is applied.
+    :type prefix: str | None
 
     Warning:
     -------

--- a/t/unit/transport/test_native_delayed_delivery.py
+++ b/t/unit/transport/test_native_delayed_delivery.py
@@ -22,6 +22,15 @@ class test_native_delayed_delivery_level_name:
     def test_level_name_with_level_1(self):
         assert level_name(1) == 'celery_delayed_1'
 
+    def test_level_name_with_prefix(self):
+        assert level_name(0, 'my_prefix') == 'my_prefix_celery_delayed_0'
+
+    def test_level_name_with_empty_prefix(self):
+        assert level_name(0, '') == 'celery_delayed_0'
+
+    def test_level_name_with_none_prefix(self):
+        assert level_name(0, None) == 'celery_delayed_0'
+
 
 class test_declare_native_delayed_delivery_exchanges_and_queues:
     def test_invalid_queue_type(self):
@@ -33,6 +42,10 @@ class test_declare_native_delayed_delivery_exchanges_and_queues:
 
     def test_quorum_queue_type(self):
         declare_native_delayed_delivery_exchanges_and_queues(Mock(), 'quorum')
+
+    def test_with_prefix(self):
+        declare_native_delayed_delivery_exchanges_and_queues(
+            Mock(), 'quorum', 'my_prefix')
 
 
 class test_bind_queue_to_native_delayed_delivery_exchange:
@@ -108,6 +121,23 @@ class test_bind_queue_to_native_delayed_delivery_exchange:
         bind_queue_to_native_delayed_delivery_exchange(Mock(), queue_mock)
         queue_mock.bind().exchange.bind().bind_to.assert_called_once_with(
             CELERY_DELAYED_DELIVERY_EXCHANGE,
+            routing_key="#.foo"
+        )
+        queue_mock.bind().bind_to.assert_called_once_with(
+            'foo',
+            routing_key="#.foo"
+        )
+
+    def test_bind_to_topic_exchange_with_prefix(self):
+        queue_mock = Mock()
+        queue_mock.bind().exchange.bind().type = 'topic'
+        queue_mock.bind().exchange.bind().name = 'foo'
+        queue_mock.bind().routing_key = 'foo'
+
+        bind_queue_to_native_delayed_delivery_exchange(
+            Mock(), queue_mock, 'my_prefix')
+        queue_mock.bind().exchange.bind().bind_to.assert_called_once_with(
+            'my_prefix_' + CELERY_DELAYED_DELIVERY_EXCHANGE,
             routing_key="#.foo"
         )
         queue_mock.bind().bind_to.assert_called_once_with(


### PR DESCRIPTION
Add an optional `prefix` parameter to the native delayed delivery API so the
generated exchanges and queues can be namespaced (e.g. `my_prefix_celery_delayed_0`
instead of `celery_delayed_0`). Default behavior is unchanged when no prefix
is passed.

Relates to celery/celery#10269.