### PR TITLE
Azure Service Bus: add AutoLockRenewer support via use_lock_renewal transport option

### DIFF
--- a/kombu/transport/azureservicebus.py
+++ b/kombu/transport/azureservicebus.py
@@ -54,6 +54,14 @@ Transport Options
 * ``retry_backoff_factor`` - Azure SDK exponential backoff factor.
   Default ``0.8``
 * ``retry_backoff_max`` - Azure SDK retry total time. Default ``120``
+* ``use_lock_renewal`` - Enable Azure SDK ``AutoLockRenewer`` to keep
+  message locks alive while a worker is processing. Only effective when
+  receive mode is ``PEEK_LOCK`` (the default). Default ``False``.
+* ``max_lock_renewal_duration`` - Time in seconds that locks registered
+  to the renewer should be maintained for. Default ``3600`` (1 hour).
+
+.. versionadded:: 5.7.0
+    ``use_lock_renewal`` and ``max_lock_renewal_duration`` transport options.
 """
 
 from __future__ import annotations
@@ -65,9 +73,9 @@ from typing import Any
 import azure.core.exceptions
 import azure.servicebus.exceptions
 import isodate
-from azure.servicebus import (ServiceBusClient, ServiceBusMessage,
-                              ServiceBusReceiveMode, ServiceBusReceiver,
-                              ServiceBusSender)
+from azure.servicebus import (AutoLockRenewer, ServiceBusClient,
+                              ServiceBusMessage, ServiceBusReceiveMode,
+                              ServiceBusReceiver, ServiceBusSender)
 from azure.servicebus.management import ServiceBusAdministrationClient
 
 try:
@@ -124,6 +132,8 @@ class Channel(virtual.Channel):
     default_retry_backoff_factor: float = 0.8
     # Max time to backoff (is the default from service bus repo)
     default_retry_backoff_max: int = 120
+    default_use_lock_renewal: bool = False
+    default_max_lock_renewal_duration: float = 3600  # in seconds (1 hour)
     domain_format: str = 'kombu%(vhost)s'
 
     def __init__(self, *args, **kwargs):
@@ -204,9 +214,19 @@ class Channel(virtual.Channel):
         cache_key = queue_cache_key or queue
         queue_obj = self._queue_cache.get(cache_key, None)
         if queue_obj is None or queue_obj.receiver is None:
+            auto_lock_renewer = None
+            if (self.use_lock_renewal
+                    and recv_mode == ServiceBusReceiveMode.PEEK_LOCK):
+                if self.connection._renewer is None:
+                    self.connection._renewer = AutoLockRenewer(
+                        max_lock_renewal_duration=(
+                            self.max_lock_renewal_duration)
+                    )
+                auto_lock_renewer = self.connection._renewer
             receiver = self.queue_service.get_queue_receiver(
                 queue_name=queue, receive_mode=recv_mode,
-                keep_alive=self.uamqp_keep_alive_interval)
+                keep_alive=self.uamqp_keep_alive_interval,
+                auto_lock_renewer=auto_lock_renewer)
             queue_obj = self._add_queue_to_cache(cache_key, receiver=receiver)
         return queue_obj
 
@@ -441,6 +461,17 @@ class Channel(virtual.Channel):
         return self.transport_options.get(
             'retry_backoff_max', self.default_retry_backoff_max)
 
+    @cached_property
+    def use_lock_renewal(self) -> bool:
+        return self.transport_options.get(
+            'use_lock_renewal', self.default_use_lock_renewal)
+
+    @cached_property
+    def max_lock_renewal_duration(self) -> float:
+        return self.transport_options.get(
+            'max_lock_renewal_duration',
+            self.default_max_lock_renewal_duration)
+
 
 class Transport(virtual.Transport):
     """Azure Service Bus transport."""
@@ -455,11 +486,19 @@ class Transport(virtual.Transport):
         super().__init__(client, **kwargs)
         self._queue_cache: dict[str, SendReceive] = {}
         self._noack_queues: set[str] = set()
+        self._renewer: AutoLockRenewer | None = None
 
     def close_connection(self, connection) -> None:
         try:
             super().close_connection(connection)
         finally:
+            if self._renewer is not None:
+                try:
+                    self._renewer.close()
+                except Exception:
+                    logger.exception(
+                        "Failed to close AutoLockRenewer; continuing")
+                self._renewer = None
             for queue_obj in self._queue_cache.values():
                 try:
                     queue_obj.close()

--- a/kombu/transport/azureservicebus.py
+++ b/kombu/transport/azureservicebus.py
@@ -172,17 +172,16 @@ class Channel(virtual.Channel):
         self._connection_string = ';'.join(
             [key + '=' + value for key, value in conn_dict.items()])
 
-    def basic_consume(self, queue, no_ack, *args, **kwargs):
+    def basic_consume(self, queue, no_ack, callback, consumer_tag,
+                      *args, **kwargs):
         if no_ack:
-            self._noack_queues.add(queue)
+            self.connection._noack_consumer_tags.add(consumer_tag)
         return super().basic_consume(
-            queue, no_ack, *args, **kwargs
+            queue, no_ack, callback, consumer_tag, *args, **kwargs
         )
 
     def basic_cancel(self, consumer_tag):
-        if consumer_tag in self._consumers:
-            queue = self._tag_to_queue[consumer_tag]
-            self._noack_queues.discard(queue)
+        self.connection._noack_consumer_tags.discard(consumer_tag)
         return super().basic_cancel(consumer_tag)
 
     def _add_queue_to_cache(
@@ -211,7 +210,7 @@ class Channel(virtual.Channel):
             self, queue: str,
             recv_mode: ServiceBusReceiveMode = ServiceBusReceiveMode.PEEK_LOCK,
             queue_cache_key: str | None = None) -> SendReceive:
-        cache_key = queue_cache_key or queue
+        cache_key = queue_cache_key or f"{queue}::{recv_mode.name}"
         queue_obj = self._queue_cache.get(cache_key, None)
         if queue_obj is None or queue_obj.receiver is None:
             auto_lock_renewer = None
@@ -422,7 +421,10 @@ class Channel(virtual.Channel):
 
     @property
     def _noack_queues(self) -> set[str]:
-        return self.connection._noack_queues
+        tag_to_queue = self._tag_to_queue
+        return {tag_to_queue[t]
+                for t in self.connection._noack_consumer_tags
+                if t in tag_to_queue}
 
     @cached_property
     def queue_name_prefix(self) -> str:
@@ -485,7 +487,7 @@ class Transport(virtual.Transport):
     def __init__(self, client, **kwargs):
         super().__init__(client, **kwargs)
         self._queue_cache: dict[str, SendReceive] = {}
-        self._noack_queues: set[str] = set()
+        self._noack_consumer_tags: set[str] = set()
         self._renewer: AutoLockRenewer | None = None
 
     def close_connection(self, connection) -> None:
@@ -506,7 +508,7 @@ class Transport(virtual.Transport):
                     logger.exception(
                         "Failed to close cached SendReceive; continuing")
             self._queue_cache.clear()
-            self._noack_queues.clear()
+            self._noack_consumer_tags.clear()
 
     @staticmethod
     def parse_uri(uri: str) -> tuple[str, str | DefaultAzureCredential |

--- a/kombu/transport/azureservicebus.py
+++ b/kombu/transport/azureservicebus.py
@@ -262,11 +262,21 @@ class Channel(virtual.Channel):
     def _delete(self, queue: str, *args, **kwargs) -> None:
         """Delete queue by name."""
         queue = self.entity_name(self.queue_name_prefix + queue)
-
         self.queue_mgmt_service.delete_queue(queue)
-        send_receive_obj = self._queue_cache.pop(queue, None)
-        if send_receive_obj:
-            send_receive_obj.close()
+        keys = [
+            k for k in self._queue_cache
+            if k == queue or k.startswith(f"{queue}::")
+        ]
+        for k in keys:
+            obj = self._queue_cache.pop(k, None)
+            if obj is None:
+                continue
+            try:
+                obj.close()
+            except Exception:
+                logger.exception(
+                    "Failed to close cached SendReceive for %r; continuing",
+                    k)
 
     def _put(self, queue: str, message, **kwargs) -> None:
         """Put message onto queue."""
@@ -348,29 +358,26 @@ class Channel(virtual.Channel):
 
     def _purge(self, queue) -> int:
         """Delete all current messages in a queue."""
-        # Azure doesn't provide a purge api yet
+        # Azure has no broker-side purge API. Drain via an ephemeral
+        # RECEIVE_AND_DELETE receiver scoped to this call so we do not
+        # leak the receiver into _queue_cache.
         n = 0
         max_purge_count = 10
         queue = self.entity_name(self.queue_name_prefix + queue)
 
-        # By default all the receivers will be in PEEK_LOCK receive mode
-        queue_obj = self._queue_cache.get(queue, None)
-        if queue not in self._noack_queues or \
-           queue_obj is None or queue_obj.receiver is None:
-            queue_obj = self._get_asb_receiver(
-                queue,
-                ServiceBusReceiveMode.RECEIVE_AND_DELETE, 'purge_' + queue
-            )
-
-        while True:
-            messages = queue_obj.receiver.receive_messages(
-                max_message_count=max_purge_count,
-                max_wait_time=0.2
-            )
-            n += len(messages)
-
-            if len(messages) < max_purge_count:
-                break
+        with self.queue_service.get_queue_receiver(
+            queue_name=queue,
+            receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
+            keep_alive=self.uamqp_keep_alive_interval,
+        ) as receiver:
+            while True:
+                messages = receiver.receive_messages(
+                    max_message_count=max_purge_count,
+                    max_wait_time=0.2,
+                )
+                n += len(messages)
+                if len(messages) < max_purge_count:
+                    break
 
         return n
 

--- a/t/unit/transport/test_azureservicebus.py
+++ b/t/unit/transport/test_azureservicebus.py
@@ -627,3 +627,158 @@ def test_returning_da():
 def test_returning_mi():
     conn = Connection(URL_CREDS_MI, transport=azureservicebus.Transport)
     assert conn.as_uri(True) == URL_CREDS_MI_FQ
+
+
+def test_lock_renewal_default_config():
+    """use_lock_renewal defaults to False; duration defaults to 3600s."""
+    conn = Connection(URL_CREDS_SAS, transport=azureservicebus.Transport)
+    channel = conn.channel()
+
+    assert channel.use_lock_renewal is False
+    assert channel.max_lock_renewal_duration == \
+        azureservicebus.Channel.default_max_lock_renewal_duration
+
+
+def test_lock_renewal_config_initialization():
+    """Transport options override the renewal defaults."""
+    options = {
+        'use_lock_renewal': True,
+        'max_lock_renewal_duration': 1234,
+    }
+    conn = Connection(URL_CREDS_SAS, transport=azureservicebus.Transport,
+                      transport_options=options)
+    channel = conn.channel()
+
+    assert channel.use_lock_renewal is True
+    assert channel.max_lock_renewal_duration == 1234
+
+
+@patch('kombu.transport.azureservicebus.AutoLockRenewer')
+def test_get_asb_receiver_default_does_not_create_renewer(
+    mock_renewer_cls, mock_queue,
+):
+    """Renewer is not instantiated when use_lock_renewal is unset."""
+    channel = mock_queue.channel
+    channel.queue_service.get_queue_receiver = MagicMock()
+
+    channel._get_asb_receiver(
+        'some_queue', recv_mode=ServiceBusReceiveMode.PEEK_LOCK)
+
+    mock_renewer_cls.assert_not_called()
+    assert channel.queue_service.get_queue_receiver.call_args.kwargs[
+        'auto_lock_renewer'] is None
+    assert channel.connection._renewer is None
+
+
+@patch('kombu.transport.azureservicebus.AutoLockRenewer')
+def test_get_asb_receiver_creates_and_reuses_renewer(
+    mock_renewer_cls, mock_queue,
+):
+    """Renewer is created on first PEEK_LOCK call, reused, and gated."""
+    conn = Connection(
+        URL_CREDS_SAS,
+        transport=azureservicebus.Transport,
+        transport_options={'use_lock_renewal': True},
+    )
+    channel = conn.channel()
+    channel.queue_service.get_queue_receiver = MagicMock()
+
+    # Renewer is created on first PEEK_LOCK call.
+    channel._get_asb_receiver(
+        'first_queue', recv_mode=ServiceBusReceiveMode.PEEK_LOCK)
+    mock_renewer_cls.assert_called_once_with(
+        max_lock_renewal_duration=channel.max_lock_renewal_duration)
+    assert channel.queue_service.get_queue_receiver.call_args.kwargs[
+        'auto_lock_renewer'] is mock_renewer_cls.return_value
+    assert channel.connection._renewer is mock_renewer_cls.return_value
+
+    # Subsequent PEEK_LOCK calls reuse the same renewer.
+    channel._get_asb_receiver(
+        'second_queue', recv_mode=ServiceBusReceiveMode.PEEK_LOCK)
+    assert mock_renewer_cls.call_count == 1
+
+    # RECEIVE_AND_DELETE never gets a renewer attached.
+    channel._get_asb_receiver(
+        'third_queue', recv_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE)
+    assert channel.queue_service.get_queue_receiver.call_args.kwargs[
+        'auto_lock_renewer'] is None
+
+
+@patch('kombu.transport.azureservicebus.AutoLockRenewer')
+def test_separate_connections_get_separate_renewers(
+    mock_renewer_cls, mock_asb, mock_asb_management,
+):
+    """Regression: renewer is per-Connection, not process-wide."""
+    options = {'use_lock_renewal': True}
+    conn_a = Connection(
+        URL_CREDS_SAS, transport=azureservicebus.Transport,
+        transport_options=options,
+    )
+    conn_b = Connection(
+        URL_CREDS_SAS, transport=azureservicebus.Transport,
+        transport_options=options,
+    )
+    chan_a = conn_a.channel()
+    chan_b = conn_b.channel()
+    chan_a.queue_service.get_queue_receiver = MagicMock()
+    chan_b.queue_service.get_queue_receiver = MagicMock()
+
+    mock_renewer_cls.side_effect = [MagicMock(), MagicMock()]
+
+    chan_a._get_asb_receiver(
+        'q', recv_mode=ServiceBusReceiveMode.PEEK_LOCK)
+    chan_b._get_asb_receiver(
+        'q', recv_mode=ServiceBusReceiveMode.PEEK_LOCK)
+
+    assert chan_a.connection._renewer is not None
+    assert chan_b.connection._renewer is not None
+    assert chan_a.connection._renewer is not chan_b.connection._renewer
+    assert mock_renewer_cls.call_count == 2
+
+
+def test_close_connection_without_renewer_is_safe(mock_queue: MockQueue):
+    """Connection release with no renewer ever created is a no-op."""
+    transport = mock_queue.conn.transport
+    assert transport._renewer is None
+
+    mock_queue.conn.release()
+
+    assert transport._renewer is None
+
+
+def test_close_connection_closes_renewer(mock_queue: MockQueue):
+    """Connection release closes the renewer exactly once."""
+    transport = mock_queue.conn.transport
+    renewer = MagicMock()
+    transport._renewer = renewer
+
+    mock_queue.conn.release()
+
+    renewer.close.assert_called_once()
+    assert transport._renewer is None
+
+
+def test_close_connection_continues_on_renewer_close_exception(
+    mock_queue: MockQueue, caplog,
+):
+    """A failing renewer.close() must not strand cache teardown."""
+    transport = mock_queue.conn.transport
+    renewer = MagicMock()
+    renewer.close.side_effect = RuntimeError("boom")
+    transport._renewer = renewer
+
+    sender = MagicMock()
+    mock_queue.channel._add_queue_to_cache('q1', sender=sender)
+
+    with caplog.at_level(
+        'ERROR', logger='kombu.transport.azureservicebus'
+    ):
+        mock_queue.conn.release()
+
+    renewer.close.assert_called_once()
+    assert transport._renewer is None
+    sender.close.assert_called_once()
+    assert transport._queue_cache == {}
+    assert any(
+        'AutoLockRenewer' in record.message for record in caplog.records
+    )

--- a/t/unit/transport/test_azureservicebus.py
+++ b/t/unit/transport/test_azureservicebus.py
@@ -476,26 +476,25 @@ def test_separate_connections_get_separate_queue_caches(
 def test_separate_connections_get_separate_noack_queues(
     mock_asb, mock_asb_management
 ):
-    """Regression: separate Connections must not share _noack_queues."""
+    """Regression: separate Connections must not share no_ack state."""
     conn_a = Connection(URL_CREDS_SAS, transport=azureservicebus.Transport)
     conn_b = Connection(URL_CREDS_SAS, transport=azureservicebus.Transport)
     chan_a = conn_a.channel()
     chan_b = conn_b.channel()
 
-    assert chan_a._noack_queues is not chan_b._noack_queues
-
-    chan_a._noack_queues.add('shared-name')
+    chan_a.basic_consume('shared-name', True, lambda m: None, 'tag-x')
     assert 'shared-name' in chan_a._noack_queues
     assert 'shared-name' not in chan_b._noack_queues
 
 
 def test_channels_on_same_connection_share_queue_cache(mock_queue: MockQueue):
-    """Channels on one Connection still share cache (Transport-scoped)."""
+    """Channels on one Connection share Transport-scoped state."""
     chan_a = mock_queue.channel
     chan_b = mock_queue.conn.channel()
 
     assert chan_a._queue_cache is chan_b._queue_cache
-    assert chan_a._noack_queues is chan_b._noack_queues
+    assert (chan_a.connection._noack_consumer_tags
+            is chan_b.connection._noack_consumer_tags)
 
 
 def test_channel_close_does_not_evict_queue_cache(mock_queue: MockQueue):
@@ -522,12 +521,12 @@ def test_close_connection_clears_queue_cache(mock_queue: MockQueue):
     receiver = MagicMock()
     mock_queue.channel._add_queue_to_cache(
         'q1', sender=sender, receiver=receiver)
-    mock_queue.channel._noack_queues.add('q1')
+    transport._noack_consumer_tags.add('tag-x')
 
     transport.close_connection(mock_queue.conn)
 
     assert transport._queue_cache == {}
-    assert transport._noack_queues == set()
+    assert transport._noack_consumer_tags == set()
     sender.close.assert_called_once()
     receiver.close.assert_called_once()
 
@@ -782,3 +781,46 @@ def test_close_connection_continues_on_renewer_close_exception(
     assert any(
         'AutoLockRenewer' in record.message for record in caplog.records
     )
+
+
+def test_basic_cancel_does_not_de_noack_when_another_no_ack_consumer_remains(
+    mock_queue: MockQueue,
+):
+    """Regression: cancelling an ack consumer must not remove the queue
+    from the no_ack view while a no_ack consumer is still subscribed."""
+    channel = mock_queue.channel
+    queue = mock_queue.queue_name
+
+    channel.basic_consume(queue, True, lambda m: None, 'tag_noack')
+    channel.basic_consume(queue, False, lambda m: None, 'tag_ack')
+    assert queue in channel._noack_queues
+
+    channel.basic_cancel('tag_ack')
+
+    assert queue in channel._noack_queues
+
+
+def test_get_asb_receiver_creates_separate_receiver_per_recv_mode(
+    mock_queue: MockQueue,
+):
+    """Regression: a receiver created in one recv_mode must not be reused
+    for callers requesting the other mode (silently skips renewal wiring
+    and applies the wrong receive semantics)."""
+    channel = mock_queue.channel
+    recv_a = MagicMock(name='peek_lock_receiver')
+    recv_b = MagicMock(name='receive_and_delete_receiver')
+    channel.queue_service.get_queue_receiver = MagicMock(
+        side_effect=[recv_a, recv_b])
+
+    queue_obj_a = channel._get_asb_receiver(
+        'q', recv_mode=ServiceBusReceiveMode.PEEK_LOCK)
+    queue_obj_b = channel._get_asb_receiver(
+        'q', recv_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE)
+
+    assert channel.queue_service.get_queue_receiver.call_count == 2
+    assert channel.queue_service.get_queue_receiver.call_args_list[0].kwargs[
+        'receive_mode'] == ServiceBusReceiveMode.PEEK_LOCK
+    assert channel.queue_service.get_queue_receiver.call_args_list[1].kwargs[
+        'receive_mode'] == ServiceBusReceiveMode.RECEIVE_AND_DELETE
+    assert queue_obj_a.receiver is recv_a
+    assert queue_obj_b.receiver is recv_b

--- a/t/unit/transport/test_azureservicebus.py
+++ b/t/unit/transport/test_azureservicebus.py
@@ -42,6 +42,13 @@ class ASBQueue:
             def close(self):
                 pass
 
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                self.close()
+                return False
+
             def receive_messages(_self, **kwargs2):
                 max_message_count = kwargs2.get('max_message_count', 1)
                 result = []
@@ -325,6 +332,55 @@ def test_delete_populated_queue(mock_queue: MockQueue):
 
     mock_queue.channel._delete(mock_queue.queue_name)
     assert mock_queue.queue_name not in mock_queue.channel._queue_cache
+
+
+def test_delete_closes_all_cached_entries_for_queue(mock_queue: MockQueue):
+    """Regression: _delete must close every cache entry for the queue,
+    including mode-keyed receiver entries created via _get_asb_receiver."""
+    channel = mock_queue.channel
+    queue = mock_queue.queue_name
+
+    sender = MagicMock(name='sender')
+    pl_recv = MagicMock(name='peek_lock_recv')
+    rad_recv = MagicMock(name='receive_and_delete_recv')
+    channel._add_queue_to_cache(queue, sender=sender)
+    channel._add_queue_to_cache(f'{queue}::PEEK_LOCK', receiver=pl_recv)
+    channel._add_queue_to_cache(
+        f'{queue}::RECEIVE_AND_DELETE', receiver=rad_recv)
+
+    channel._delete(queue)
+
+    transport = mock_queue.conn.transport
+    assert queue not in transport._queue_cache
+    assert f'{queue}::PEEK_LOCK' not in transport._queue_cache
+    assert f'{queue}::RECEIVE_AND_DELETE' not in transport._queue_cache
+    sender.close.assert_called_once()
+    pl_recv.close.assert_called_once()
+    rad_recv.close.assert_called_once()
+
+
+def test_purge_uses_ephemeral_receiver(mock_queue: MockQueue):
+    """Regression: _purge must drain via a one-shot receiver it closes
+    itself, not via a cached purge_<queue> entry."""
+    channel = mock_queue.channel
+    queue = mock_queue.queue_name
+
+    ephemeral_receiver = MagicMock(name='ephemeral_recv')
+    ephemeral_receiver.receive_messages = MagicMock(return_value=[])
+    ephemeral_receiver.__enter__ = MagicMock(return_value=ephemeral_receiver)
+    ephemeral_receiver.__exit__ = MagicMock(return_value=False)
+    channel.queue_service.get_queue_receiver = MagicMock(
+        return_value=ephemeral_receiver)
+
+    channel._purge(queue)
+
+    channel.queue_service.get_queue_receiver.assert_called_once()
+    call = channel.queue_service.get_queue_receiver.call_args
+    assert call.kwargs['receive_mode'] == \
+        ServiceBusReceiveMode.RECEIVE_AND_DELETE
+    ephemeral_receiver.__exit__.assert_called_once()
+    assert f'purge_{queue}' not in channel._queue_cache
+    assert f'{queue}::RECEIVE_AND_DELETE' not in channel._queue_cache
 
 
 def test_purge(mock_queue: MockQueue):


### PR DESCRIPTION
Opt-in `AutoLockRenewer` support on the `azureservicebus` transport, picking up the proposal in #1788 / #2446 by @tuschla.

This branch was rebased onto merged #2543 (`fix(azureservicebus): scope queue cache and noack set to Connection`). Now that per-Connection state lives on `Transport`, the renewer fits cleanly into the same model.

## Why

Service Bus messages received in `PEEK_LOCK` mode hold a broker-side lock for `peek_lock_seconds` (default 60s, max 300s). Handlers that exceed that bound get their message redelivered. The Azure SDK ships `AutoLockRenewer` for exactly this case, but kombu has never exposed it. Workers handling slow tasks against Service Bus are left choosing between unsafe long timeouts and code that retries forever.

## What changed

Two new transport options:

* `use_lock_renewal` (default `False`) wires an `AutoLockRenewer` into every `PEEK_LOCK` receiver created on the channel. Locks renew in the background while a worker is processing.
* `max_lock_renewal_duration` (default `3600` seconds) caps how long the renewer keeps any one message's lock alive.

Implementation choices:

* The renewer is owned by `Transport`, not `Channel`. This matches the per-Connection model established in #2543 and lines the renewer up with the cached `SendReceive` objects so the lifecycle stays consistent.
* Renewer is created lazily on the first `PEEK_LOCK` receiver call from any channel on the connection. Shared across receivers on the same `kombu.Connection`.
* `Transport.close_connection` closes the renewer in its `finally` block before iterating the cached `SendReceive` entries, so the background renewal thread stops touching receivers before they get torn down.
* `RECEIVE_AND_DELETE` receivers are deliberately not attached, since those messages have no lock to renew.

Default behaviour is unchanged. Existing `PEEK_LOCK` consumers stay on the original lock semantics until they opt in.

## Tests

Five new unit tests covering configuration and the receiver-wiring path:

* `test_lock_renewal_default_config`
* `test_lock_renewal_config_initialization`
* `test_get_asb_receiver_default_does_not_create_renewer`
* `test_get_asb_receiver_creates_and_reuses_renewer` (lazy create, reuse, `RECEIVE_AND_DELETE` gating)
* `test_separate_connections_get_separate_renewers` (per-Connection isolation, mirroring the #2543 cache-isolation regression coverage)

Three teardown tests for the new `Transport.close_connection` path:

* `test_close_connection_without_renewer_is_safe`
* `test_close_connection_closes_renewer`
* `test_close_connection_continues_on_renewer_close_exception` (per-entry exception isolation, same shape as #2543's cache-close test)

```
$ pytest t/unit/transport/test_azureservicebus.py
============================== 41 passed in 2.20s ==============================
```

Wider transport suite (skipping `test_gcpubsub.py` and `SQS/` which need optional dependencies the dev env doesn't have): 221 passed, 175 skipped, 0 failed.

## Integration

I re-ran the celery/celery#8878 deterministic reproducer from #2543 against the official Azure Service Bus emulator, once with the renewer off (default) and once with `use_lock_renewal=True` on both connections. Both pass: send succeeds and `conn_a.transport._renewer is not conn_b.transport._renewer` confirms per-Connection isolation under the renewer.

## Chaos

@tuschla flagged in this thread that earlier renewer work broke under gevent. I ran a 60-second concurrent producer / consumer / churn workload against the emulator twice: once with raw threading and once with `gevent.monkey.patch_all()` applied before any other import.

Threading run: 337 produced, 22 acked, 0 lock losses, 0 regression AttributeErrors, 0 SDK socket errors, 4 distinct renewers across 4 worker connections, threads return to baseline after `Connection.release()`.

Gevent run: 334 produced, 25 acked, 0 lock losses, 0 regression AttributeErrors, 0 SDK socket errors, 4 distinct renewers, threads back to baseline. `monkey.is_module_patched("threading") == True` confirmed gevent was in effect.

The Transport-scoped renewer holds up under both schedulers.

## Thanks

@tuschla for raising the gevent failure mode in this thread. The investigation that started from that comment is what surfaced the per-Connection state scoping bug that became #2543. This PR rests on top of that fix.

Related: #2543.
