### PR TITLE
fix(azureservicebus): scope queue cache and noack set to Connection

### DIFF
--- a/kombu/transport/azureservicebus.py
+++ b/kombu/transport/azureservicebus.py
@@ -7,12 +7,13 @@ queues and delete old queues as required.
 
 Notes when using with Celery if you are experiencing issues with programs not
 terminating properly. The Azure Service Bus SDK uses the Azure uAMQP library
-which in turn creates some threads. If the AzureServiceBus Channel is closed,
-said threads will be closed properly, but it seems there are times when Celery
-does not do this so these threads will be left running. As the uAMQP threads
-are not marked as Daemon threads, they will not be killed when the main thread
-exits. Setting the ``uamqp_keep_alive_interval`` transport option to 0 will
-prevent the keep_alive thread from starting
+which in turn creates some threads. If the AzureServiceBus Connection is
+closed (e.g. via ``Connection.release()``), said threads will be closed
+properly, but it seems there are times when Celery does not do this so these
+threads will be left running. As the uAMQP threads are not marked as Daemon
+threads, they will not be killed when the main thread exits. Setting the
+``uamqp_keep_alive_interval`` transport option to 0 will prevent the
+keep_alive thread from starting
 
 
 More information about Azure Service Bus:
@@ -76,11 +77,14 @@ except ImportError:
     DefaultAzureCredential = None
     ManagedIdentityCredential = None
 
+from kombu.log import get_logger
 from kombu.utils.encoding import bytes_to_str, safe_str
 from kombu.utils.json import dumps, loads
 from kombu.utils.objects import cached_property
 
 from . import virtual
+
+logger = get_logger(__name__)
 
 # dots are replaced by dash, all other punctuation replaced by underscore.
 PUNCTUATIONS_TO_REPLACE = set(string.punctuation) - {'_', '.', '-'}
@@ -121,8 +125,6 @@ class Channel(virtual.Channel):
     # Max time to backoff (is the default from service bus repo)
     default_retry_backoff_max: int = 120
     domain_format: str = 'kombu%(vhost)s'
-    _queue_cache: dict[str, SendReceive] = {}
-    _noack_queues: set[str] = set()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -302,7 +304,18 @@ class Channel(virtual.Channel):
                     delivery_info['azure_message'])
             except azure.servicebus.exceptions.MessageAlreadySettled:
                 super().basic_ack(delivery_tag)
+            except azure.servicebus.exceptions.MessageLockLostError:
+                logger.warning(
+                    "complete_message on queue %r failed with "
+                    "MessageLockLostError; the broker may have redelivered "
+                    "this message. Consider shorter handlers or enabling "
+                    "lock renewal.",
+                    queue,
+                )
+                super().basic_reject(delivery_tag)
             except Exception:
+                logger.exception(
+                    "complete_message on queue %r failed", queue)
                 super().basic_reject(delivery_tag)
             else:
                 super().basic_ack(delivery_tag)
@@ -343,15 +356,12 @@ class Channel(virtual.Channel):
         return n
 
     def close(self) -> None:
-        # receivers and senders spawn threads so clean them up
-        if not self.closed:
-            self.closed = True
-            for queue_obj in self._queue_cache.values():
-                queue_obj.close()
-            self._queue_cache.clear()
-
-            if self.connection is not None:
-                self.connection.close_channel(self)
+        # Cache and noack set live on Transport; see Transport.close_connection.
+        if self.closed:
+            return
+        self.closed = True
+        if self.connection is not None:
+            self.connection.close_channel(self)
 
     @cached_property
     def queue_service(self) -> ServiceBusClient:
@@ -389,6 +399,14 @@ class Channel(virtual.Channel):
     @property
     def transport_options(self):
         return self.connection.client.transport_options
+
+    @property
+    def _queue_cache(self) -> dict[str, SendReceive]:
+        return self.connection._queue_cache
+
+    @property
+    def _noack_queues(self) -> set[str]:
+        return self.connection._noack_queues
 
     @cached_property
     def queue_name_prefix(self) -> str:
@@ -436,6 +454,24 @@ class Transport(virtual.Transport):
     polling_interval = 1
     default_port = None
     can_parse_url = True
+
+    def __init__(self, client, **kwargs):
+        super().__init__(client, **kwargs)
+        self._queue_cache: dict[str, SendReceive] = {}
+        self._noack_queues: set[str] = set()
+
+    def close_connection(self, connection) -> None:
+        try:
+            super().close_connection(connection)
+        finally:
+            for queue_obj in self._queue_cache.values():
+                try:
+                    queue_obj.close()
+                except Exception:
+                    logger.exception(
+                        "Failed to close cached SendReceive; continuing")
+            self._queue_cache.clear()
+            self._noack_queues.clear()
 
     @staticmethod
     def parse_uri(uri: str) -> tuple[str, str | DefaultAzureCredential |

--- a/kombu/transport/azureservicebus.py
+++ b/kombu/transport/azureservicebus.py
@@ -357,11 +357,7 @@ class Channel(virtual.Channel):
 
     def close(self) -> None:
         # Cache and noack set live on Transport; see Transport.close_connection.
-        if self.closed:
-            return
-        self.closed = True
-        if self.connection is not None:
-            self.connection.close_channel(self)
+        super().close()
 
     @cached_property
     def queue_service(self) -> ServiceBusClient:

--- a/t/unit/transport/test_azureservicebus.py
+++ b/t/unit/transport/test_azureservicebus.py
@@ -457,6 +457,163 @@ def test_basic_ack_reject_message_when_raises_exception(
         assert super_basic_reject.call_count == 1
 
 
+def test_separate_connections_get_separate_queue_caches(
+    mock_asb, mock_asb_management
+):
+    """Regression: separate Connections must not share _queue_cache."""
+    conn_a = Connection(URL_CREDS_SAS, transport=azureservicebus.Transport)
+    conn_b = Connection(URL_CREDS_SAS, transport=azureservicebus.Transport)
+    chan_a = conn_a.channel()
+    chan_b = conn_b.channel()
+
+    assert chan_a._queue_cache is not chan_b._queue_cache
+
+    chan_a._add_queue_to_cache('shared-name', sender=MagicMock())
+    assert 'shared-name' in chan_a._queue_cache
+    assert 'shared-name' not in chan_b._queue_cache
+
+
+def test_separate_connections_get_separate_noack_queues(
+    mock_asb, mock_asb_management
+):
+    """Regression: separate Connections must not share _noack_queues."""
+    conn_a = Connection(URL_CREDS_SAS, transport=azureservicebus.Transport)
+    conn_b = Connection(URL_CREDS_SAS, transport=azureservicebus.Transport)
+    chan_a = conn_a.channel()
+    chan_b = conn_b.channel()
+
+    assert chan_a._noack_queues is not chan_b._noack_queues
+
+    chan_a._noack_queues.add('shared-name')
+    assert 'shared-name' in chan_a._noack_queues
+    assert 'shared-name' not in chan_b._noack_queues
+
+
+def test_channels_on_same_connection_share_queue_cache(mock_queue: MockQueue):
+    """Channels on one Connection still share cache (Transport-scoped)."""
+    chan_a = mock_queue.channel
+    chan_b = mock_queue.conn.channel()
+
+    assert chan_a._queue_cache is chan_b._queue_cache
+    assert chan_a._noack_queues is chan_b._noack_queues
+
+
+def test_channel_close_does_not_evict_queue_cache(mock_queue: MockQueue):
+    """Regression: Channel.close() must not evict siblings' cache entries."""
+    chan_a = mock_queue.channel
+    chan_b = mock_queue.conn.channel()
+
+    sender = MagicMock()
+    chan_a._add_queue_to_cache('q', sender=sender)
+    assert 'q' in chan_b._queue_cache
+
+    chan_a.close()
+
+    # Sibling still sees the cached entry; SDK object was not closed.
+    assert 'q' in chan_b._queue_cache
+    assert chan_b._queue_cache['q'].sender is sender
+    sender.close.assert_not_called()
+
+
+def test_close_connection_clears_queue_cache(mock_queue: MockQueue):
+    """Transport.close_connection() tears down the per-Connection cache."""
+    transport = mock_queue.conn.transport
+    sender = MagicMock()
+    receiver = MagicMock()
+    mock_queue.channel._add_queue_to_cache(
+        'q1', sender=sender, receiver=receiver)
+    mock_queue.channel._noack_queues.add('q1')
+
+    transport.close_connection(mock_queue.conn)
+
+    assert transport._queue_cache == {}
+    assert transport._noack_queues == set()
+    sender.close.assert_called_once()
+    receiver.close.assert_called_once()
+
+
+def test_close_connection_continues_on_per_entry_exception(
+    mock_queue: MockQueue
+):
+    """A failing SendReceive.close() must not strand sibling cleanup."""
+    transport = mock_queue.conn.transport
+
+    bad = MagicMock()
+    bad.close.side_effect = RuntimeError("boom")
+    good_sender = MagicMock()
+
+    mock_queue.channel._add_queue_to_cache('bad', sender=bad)
+    mock_queue.channel._add_queue_to_cache('good', sender=good_sender)
+
+    transport.close_connection(mock_queue.conn)
+
+    good_sender.close.assert_called_once()
+    assert transport._queue_cache == {}
+
+
+def test_basic_ack_lock_lost_logs_warning_and_rejects(
+    mock_queue: MockQueue, caplog
+):
+    """Regression: lock-lost ack failures must be logged, not silent."""
+    mock_queue.producer.publish("test message")
+    message = mock_queue.channel._get(mock_queue.queue_name)
+    mock_queue.channel.qos.get = MagicMock(
+        return_value=mock_queue.channel.Message(
+            message, mock_queue.channel
+        )
+    )
+    receiver_mock = MagicMock()
+    receiver_mock.complete_message = MagicMock(
+        side_effect=azure.servicebus.exceptions.MessageLockLostError())
+    queue_object_mock = MagicMock()
+    queue_object_mock.receiver = receiver_mock
+    mock_queue.channel._get_asb_receiver = MagicMock(
+        return_value=queue_object_mock)
+    with patch(
+        'kombu.transport.virtual.base.Channel.basic_reject'
+    ) as super_basic_reject, caplog.at_level(
+        'WARNING', logger='kombu.transport.azureservicebus'
+    ):
+        mock_queue.channel.basic_ack("test_delivery_tag")
+
+    assert super_basic_reject.call_count == 1
+    assert any(
+        'MessageLockLostError' in record.message
+        for record in caplog.records
+    )
+
+
+def test_basic_ack_unknown_exception_logs_and_rejects(
+    mock_queue: MockQueue, caplog
+):
+    """Regression: unknown ack failures must be logged with traceback."""
+    mock_queue.producer.publish("test message")
+    message = mock_queue.channel._get(mock_queue.queue_name)
+    mock_queue.channel.qos.get = MagicMock(
+        return_value=mock_queue.channel.Message(
+            message, mock_queue.channel
+        )
+    )
+    receiver_mock = MagicMock()
+    receiver_mock.complete_message = MagicMock(
+        side_effect=RuntimeError("transient broker error"))
+    queue_object_mock = MagicMock()
+    queue_object_mock.receiver = receiver_mock
+    mock_queue.channel._get_asb_receiver = MagicMock(
+        return_value=queue_object_mock)
+    with patch(
+        'kombu.transport.virtual.base.Channel.basic_reject'
+    ) as super_basic_reject, caplog.at_level(
+        'ERROR', logger='kombu.transport.azureservicebus'
+    ):
+        mock_queue.channel.basic_ack("test_delivery_tag")
+
+    assert super_basic_reject.call_count == 1
+    error_records = [r for r in caplog.records if r.levelname == 'ERROR']
+    assert error_records, "expected an ERROR-level log from logger.exception"
+    assert error_records[0].exc_info is not None
+
+
 def test_returning_sas():
     conn = Connection(URL_CREDS_SAS, transport=azureservicebus.Transport)
     assert conn.as_uri(True) == URL_CREDS_SAS_FQ


### PR DESCRIPTION
On Azure Service Bus, `Channel._queue_cache` and `Channel._noack_queues` are declared as class attributes, so every `Channel` instance in the Python process shares one dict and one set keyed by queue name. This is the common cause of four bugs on `main`.

This work was triggered by @tuschla flagging a gevent breakage in [their review comment on #2542](https://github.com/celery/kombu/pull/2542#issuecomment-4413246847). Reproducing that failure mode against the local Azure Service Bus emulator pointed at the cache-sharing problem rather than anything in #2542 itself, and once the cache is scoped per Connection the gevent failure mode goes away. Thanks @tuschla for catching this; without that comment these bugs would still be sitting on `main`.

## What's wrong on main

1. **Cross-Connection cache poisoning.** Two `kombu.Connection` objects to different Service Bus namespaces share one process-wide queue cache, so identically named queues on different namespaces collide. A `Sender` or `Receiver` from one namespace gets silently used by the other.
2. **`Channel.close()` evicts siblings.** `close()` iterates the (shared) cache and calls `.close()` on every entry, tearing down `Sender` and `Receiver` objects that other live `Channel` instances are still using. I think this is what's behind celery/celery#8878 (`AttributeError: 'NoneType' object has no attribute 'create_sender_link'` under high task volume); see the reproduction section below.
3. **Cross-Connection `_noack_queues` leak.** `no_ack=True` on a queue in one `Connection` silently flips behaviour for an identically named queue in every other `Connection` in the process.
4. **Silent ack failures.** `basic_ack`'s bare `except Exception: super().basic_reject()` swallows `MessageLockLostError` (and any other broker error) with no logging, so workers have no visibility into messages being redelivered because the broker rejected the ack.

## Fix

Move `_queue_cache` and `_noack_queues` to `Transport` instance attributes, matching the convention used elsewhere in `kombu/transport/` (e.g. `MultiChannelPoller` on the redis Transport, the per-Transport thread pool and futures map on the gcpubsub Transport). Each `kombu.Connection` now gets its own copy.

`Transport.close_connection` is overridden to tear down the cache and no-ack set, with a per-entry try/except so one failing `SendReceive.close()` does not strand the rest. Cleanup runs in a `finally` so it still happens if `super().close_connection()` raises. `Channel.close()` no longer touches the cache.

`Channel` keeps backward-compatible read-through `@property` shims for `_queue_cache` and `_noack_queues` that delegate to the `Transport`, so any external code holding a `Channel` reference and reading those attributes keeps working.

`basic_ack` now catches `MessageLockLostError` explicitly and logs a warning with actionable guidance; the bare `except Exception` is replaced with `logger.exception(...)`. User-facing behaviour is unchanged, both paths still downgrade to `basic_reject`.

The module docstring's threading note is updated from "If the AzureServiceBus Channel is closed" to "If the AzureServiceBus Connection is closed (e.g. via `Connection.release()`)" to reflect where the SDK lifecycle now lives.

## Test plan

Adds 8 regression tests in `t/unit/transport/test_azureservicebus.py`, covering each bug above plus the per-Transport teardown path:

* `test_separate_connections_get_separate_queue_caches` (bug 1)
* `test_separate_connections_get_separate_noack_queues` (bug 3)
* `test_channels_on_same_connection_share_queue_cache` (intended sharing preserved)
* `test_channel_close_does_not_evict_queue_cache` (bug 2)
* `test_close_connection_clears_queue_cache`
* `test_close_connection_continues_on_per_entry_exception`
* `test_basic_ack_lock_lost_logs_warning_and_rejects` (bug 4, `MessageLockLostError` path)
* `test_basic_ack_unknown_exception_logs_and_rejects` (bug 4, generic exception path)

```
$ pytest t/unit/transport/test_azureservicebus.py
============================== 33 passed in 1.65s ==============================
```

The wider transport suite (skipping `test_gcpubsub.py` and `SQS/` which need optional dependencies the dev env doesn't have) passes 213, fails 0.

## Reproduction against the emulator

I also ran a 4-step deterministic reproducer against the official Azure Service Bus emulator container. It opens two `kombu.Connection` objects pointed at the emulator, publishes via Channel A (which populates the cache), looks up the same queue via Channel B (which on `main` returns the same shared `SendReceive` object), closes Channel A, and then tries to use the reference Channel B held.

On `upstream/main`:

```
chan_a._queue_cache is chan_b._queue_cache: True
same object as chan_a's cache entry: True
chan_b cache keys post-close: []
held SendReceive .sender is now: None
RESULT: send FAILED with AttributeError:
    'NoneType' object has no attribute 'send_messages'
```

On this branch:

```
chan_a._queue_cache is chan_b._queue_cache: False
same object as chan_a's cache entry: False
chan_b cache keys post-close: ['test-renewal']
held SendReceive .sender is now: <ServiceBusSender object at 0x...>
RESULT: send succeeded
```

The deterministic reproduction surfaces the bug as `'NoneType' object has no attribute 'send_messages'` (the kombu-layer `SendReceive.sender` is nulled by `SendReceive.close()`). The original celery/celery#8878 report shows `'NoneType' object has no attribute 'create_sender_link'`, which is the SDK-internal version of the same race: `SendReceive.close()` first calls `self.sender.close()` (sets the SDK's `_handler` to None) and then `self.sender = None`. A sibling thread that reads `.sender` between those two lines gets a still-live `ServiceBusSender` whose internal `_handler` is None, which produces the deeper `create_sender_link` traceback on the next `send_messages`. The root cause is the same and both symptoms go away on this branch.

The repro script (`repro_celery_8878.py`) lives on a separate branch (`azureservicebus-celery-8878-repro`) so it doesn't ship with this PR. Verification against the original reporter's production setup would be welcome.

## Notes

Targeting the next 5.6.x patch release. No new transport options or public API surface, just bug fixes.

#2542 (Azure Service Bus AutoLockRenewer support) is independent of this PR. Once this lands, #2542 rebases on top and shrinks, since the per-Connection state model here is the natural home for the renewer's lifecycle.

Related: celery/celery#8878.
