### PR TITLE
Use logger instead of print when restoring unacked messages

### DIFF
--- a/kombu/transport/virtual/base.py
+++ b/kombu/transport/virtual/base.py
@@ -289,7 +289,7 @@ class QoS:
             return
         try:
             if state:
-                if stderr:
+                if stderr is not None:
                     print(RESTORING_FMT.format(len(self._delivered)), file=stderr)
                 else:
                     logger.info(RESTORING_FMT.format(len(self._delivered)))

--- a/kombu/transport/virtual/base.py
+++ b/kombu/transport/virtual/base.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import base64
 import socket
-import sys
 import warnings
 from array import array
 from collections import OrderedDict, defaultdict, namedtuple

--- a/kombu/transport/virtual/base.py
+++ b/kombu/transport/virtual/base.py
@@ -281,7 +281,6 @@ class QoS:
         """
         self._on_collect.cancel()
         self._flush()
-        stderr = sys.stderr if stderr is None else stderr
         state = self._delivered
 
         if not self.restore_at_shutdown or not self.channel.do_restore:
@@ -291,14 +290,19 @@ class QoS:
             return
         try:
             if state:
-                print(RESTORING_FMT.format(len(self._delivered)),
-                      file=stderr)
+                if stderr:
+                    print(RESTORING_FMT.format(len(self._delivered)), file=stderr)
+                else:
+                    logger.info(RESTORING_FMT.format(len(self._delivered)))
                 unrestored = self.restore_unacked()
 
                 if unrestored:
                     errors, messages = list(zip(*unrestored))
-                    print(RESTORE_PANIC_FMT.format(len(errors), errors),
-                          file=stderr)
+                    if stderr:
+                        print(RESTORE_PANIC_FMT.format(len(errors), errors), file=stderr)
+                    else:
+                        logger.error(RESTORE_PANIC_FMT.format(len(errors), errors))
+
                     emergency_dump_state(messages, stderr=stderr)
         finally:
             state.restored = True

--- a/t/unit/transport/virtual/test_base.py
+++ b/t/unit/transport/virtual/test_base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import logging
 import socket
 import sys
 import warnings
@@ -17,7 +18,6 @@ from kombu.transport import virtual
 from kombu.utils.uuid import uuid
 
 PRINT_FQDN = 'builtins.print'
-LOG_FQDN = 'logging.Logger._log'
 
 
 def client(**kwargs):
@@ -413,11 +413,10 @@ class test_Channel:
         assert not q._delivered
 
     @patch('kombu.transport.virtual.base.emergency_dump_state')
-    @patch(LOG_FQDN)
     @patch(PRINT_FQDN)
     @pytest.mark.parametrize("stderr_set", [True, False])
-    def test_restore_unacked_once_when_unrestored(self, print_, log_,
-                                                  emergency_dump_state, stderr_set):
+    def test_restore_unacked_once_when_unrestored(self, print_,
+                                                  emergency_dump_state, stderr_set, caplog):
         stderr = sys.stderr if stderr_set else None
         q = self.channel.qos
         q._flush = Mock()
@@ -435,12 +434,14 @@ class test_Channel:
         ru.return_value = [(exc, 1)]
 
         self.channel.do_restore = True
-        q.restore_unacked_once(stderr=stderr)
+        with caplog.at_level(logging.INFO, logger="kombu.transport.virtual.base"):
+            q.restore_unacked_once(stderr=stderr)
         if stderr_set:
             print_.assert_called()
-            log_.assert_not_called()
+            assert not caplog.messages
         else:
-            log_.assert_called()
+            assert caplog.messages[0].startswith("Restoring")
+            assert caplog.messages[0].endswith("unacknowledged message(s)")
             print_.assert_not_called()
 
         emergency_dump_state.assert_called()

--- a/t/unit/transport/virtual/test_base.py
+++ b/t/unit/transport/virtual/test_base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import socket
+import sys
 import warnings
 from array import array
 from time import monotonic
@@ -16,6 +17,7 @@ from kombu.transport import virtual
 from kombu.utils.uuid import uuid
 
 PRINT_FQDN = 'builtins.print'
+LOG_FQDN = 'logging.Logger._log'
 
 
 def client(**kwargs):
@@ -411,9 +413,12 @@ class test_Channel:
         assert not q._delivered
 
     @patch('kombu.transport.virtual.base.emergency_dump_state')
+    @patch(LOG_FQDN)
     @patch(PRINT_FQDN)
-    def test_restore_unacked_once_when_unrestored(self, print_,
-                                                  emergency_dump_state):
+    @pytest.mark.parametrize("stderr_set", [True, False])
+    def test_restore_unacked_once_when_unrestored(self, print_, log_,
+                                                  emergency_dump_state, stderr_set):
+        stderr = sys.stderr if stderr_set else None
         q = self.channel.qos
         q._flush = Mock()
 
@@ -430,8 +435,14 @@ class test_Channel:
         ru.return_value = [(exc, 1)]
 
         self.channel.do_restore = True
-        q.restore_unacked_once()
-        print_.assert_called()
+        q.restore_unacked_once(stderr=stderr)
+        if stderr_set:
+            print_.assert_called()
+            log_.assert_not_called()
+        else:
+            log_.assert_called()
+            print_.assert_not_called()
+
         emergency_dump_state.assert_called()
 
     def test_basic_recover(self):


### PR DESCRIPTION
Printing instead of using configured loggers can be pretty disruptive in a deployed environment.

This starts to use `logger` instead of `print` for messages emitted when restoring unacked messages.

This continues to print to the supplied file if that's passed as an argument, to avoid breaking anyone who may be overriding this and relying on current print behavior to print to  a specific file location.