### PR TITLE
Ignore errors when attempting to restore messages if the message was acked

### DIFF
--- a/kombu/transport/virtual/base.py
+++ b/kombu/transport/virtual/base.py
@@ -260,14 +260,18 @@ class QoS:
 
         while delivered:
             try:
-                _, message = pop_message()
+                key, message = pop_message()
             except KeyError:  # pragma: no cover
                 break
 
             try:
                 restore(message)
             except BaseException as exc:
-                errors.append((exc, message))
+                if key not in self._dirty:
+                    # Another thread may have acked the message after the earlier '_flush' call.
+                    # This may cause the restore attempt to fail (e.g. in SQS).
+                    # If restore fails, we only care about errors for messages that have not been 'acked'.
+                    errors.append((exc, message))
         delivered.clear()
         return errors
 

--- a/t/unit/transport/virtual/test_base.py
+++ b/t/unit/transport/virtual/test_base.py
@@ -416,7 +416,7 @@ class test_Channel:
         q._delivered = {1: 1}
 
         def mock_restore_raises_exceptions_due_to_acked_message(*args, **kwargs):
-            q._dirty = {1}  # acked dirty message
+            q.ack(1)  # simulate concurrent ack of the delivered message
             raise SystemExit(1)
 
         q.channel._restore = Mock()

--- a/t/unit/transport/virtual/test_base.py
+++ b/t/unit/transport/virtual/test_base.py
@@ -410,6 +410,22 @@ class test_Channel:
         assert errors[0][1] == 1
         assert not q._delivered
 
+    def test_restore_unacked_ignores_raised_exceptions_when_acked(self):
+        q = self.channel.qos
+        q._flush = Mock()
+        q._delivered = {1: 1}
+
+        def mock_restore_raises_exceptions_due_to_acked_message(*args, **kwargs):
+            q._dirty = {1}  # acked dirty message
+            raise SystemExit(1)
+
+        q.channel._restore = Mock()
+        q.channel._restore.side_effect = mock_restore_raises_exceptions_due_to_acked_message
+
+        errors = q.restore_unacked()
+        assert not errors
+        assert not q._delivered
+
     @patch('kombu.transport.virtual.base.emergency_dump_state')
     @patch(PRINT_FQDN)
     def test_restore_unacked_once_when_unrestored(self, print_,


### PR DESCRIPTION
I am seeing a lot of errors from SQS in my logs coming from here (through the `restore_unacked_once` path) with the message:

> Message does not exist or is not available for visibility timeout change.

My assumption is that while we are closing the channel, we call `restore_unacked_once`, but some task invocations are still completing while we are restoring unacked messages. This results in a race condition where messages may be acked after the '_flush' call earlier in this function, and the loop iteration where we attempt to restore that particular message.

If we encounter an exception when we attempt to restore a message but then find that the message has already been acked by another thread - then we should ignore the error.