### PR TITLE
Defer `_reset_cycle` call until after updating `_active_queue`

### DIFF
--- a/kombu/transport/virtual/base.py
+++ b/kombu/transport/virtual/base.py
@@ -647,12 +647,12 @@ class Channel(AbstractChannel, base.StdChannel):
         """Cancel consumer by consumer tag."""
         if consumer_tag in self._consumers:
             self._consumers.remove(consumer_tag)
-            self._reset_cycle()
             queue = self._tag_to_queue.pop(consumer_tag, None)
             try:
                 self._active_queues.remove(queue)
             except ValueError:
                 pass
+            self._reset_cycle()
             self.connection._callbacks.pop(queue, None)
 
     def basic_get(self, queue, no_ack=False, **kwargs):

--- a/t/unit/transport/virtual/test_base.py
+++ b/t/unit/transport/virtual/test_base.py
@@ -495,7 +495,7 @@ class test_Channel:
         self.channel.exchange_declare(exchange='unique_name')
         assert self.channel.get_exchanges()
 
-    def test_basic_cancel_not_in_active_queues(self):
+    def test_basic_cancel(self):
         c = self.channel
         c._consumers.add('x')
         c._tag_to_queue['x'] = 'foo'
@@ -504,10 +504,22 @@ class test_Channel:
         def mock_reset_cycle():
             # Ensure queue is removed prior to calling '_reset_cycle'
             assert 'foo' not in c._active_queues
-        c._reset_cycle = mock_reset_cycle
+
+        c._reset_cycle = Mock(side_effect=mock_reset_cycle)
 
         c.basic_cancel('x')
         assert c._active_queues == []
+        c._reset_cycle.assert_called_once_with()
+
+    def test_basic_cancel_not_in_active_queues(self):
+        c = self.channel
+        c._consumers.add('x')
+        c._tag_to_queue['x'] = 'foo'
+        c._active_queues = Mock()
+        c._active_queues.remove.side_effect = ValueError()
+
+        c.basic_cancel('x')
+        c._active_queues.remove.assert_called_with('foo')
 
     def test_basic_cancel_unknown_ctag(self):
         assert self.channel.basic_cancel('unknown-tag') is None

--- a/t/unit/transport/virtual/test_base.py
+++ b/t/unit/transport/virtual/test_base.py
@@ -499,11 +499,15 @@ class test_Channel:
         c = self.channel
         c._consumers.add('x')
         c._tag_to_queue['x'] = 'foo'
-        c._active_queues = Mock()
-        c._active_queues.remove.side_effect = ValueError()
+        c._active_queues = ['foo']
+
+        def mock_reset_cycle():
+            # Ensure queue is removed prior to calling '_reset_cycle'
+            assert 'foo' not in c._active_queues
+        c._reset_cycle = mock_reset_cycle
 
         c.basic_cancel('x')
-        c._active_queues.remove.assert_called_with('foo')
+        assert c._active_queues == []
 
     def test_basic_cancel_unknown_ctag(self):
         assert self.channel.basic_cancel('unknown-tag') is None


### PR DESCRIPTION
`_reset_cycle` when called updates `_cycle` with a new `FairCycle` based on the value of `active_queues`. 

This means we should call `_reset_cycle` after we remove the queue from `_active_queues` instead of before that.