### PR TITLE
Use logging instead of printing in emergency_dump_state

### DIFF
--- a/kombu/utils/div.py
+++ b/kombu/utils/div.py
@@ -24,7 +24,7 @@ def emergency_dump_state(state, open_file=open, dump=None, stderr=None):
         print(f'EMERGENCY DUMP STATE TO FILE -> {persist} <-',
               file=stderr)
     else:
-        logger.error('EMERGENCY DUMP STATE TO FILE', extra={"emergency_state_file": persist})
+        logger.error('EMERGENCY DUMP STATE TO FILE -> %s <-', persist, extra={"emergency_state_file": persist})
     fh = open_file(persist, 'w')
     try:
         try:

--- a/kombu/utils/div.py
+++ b/kombu/utils/div.py
@@ -2,34 +2,41 @@
 
 from __future__ import annotations
 
+import logging
 import os
-import sys
 
 from .encoding import default_encode
+
+logger = logging.getLogger(__name__)
 
 
 def emergency_dump_state(state, open_file=open, dump=None, stderr=None):
     """Dump message state to stdout or file."""
     from pprint import pformat
     from tempfile import mkstemp
-    stderr = sys.stderr if stderr is None else stderr
 
     if dump is None:
         import pickle
         dump = pickle.dump
     fd, persist = mkstemp()
     os.close(fd)
-    print(f'EMERGENCY DUMP STATE TO FILE -> {persist} <-',
-          file=stderr)
+    if stderr:
+        print(f'EMERGENCY DUMP STATE TO FILE -> {persist} <-',
+              file=stderr)
+    else:
+        logger.error('EMERGENCY DUMP STATE TO FILE', extra={"emergency_state_file": persist})
     fh = open_file(persist, 'w')
     try:
         try:
             dump(state, fh, protocol=0)
         except Exception as exc:
-            print(
-                f'Cannot pickle state: {exc!r}. Fallback to pformat.',
-                file=stderr,
-            )
+            if stderr:
+                print(
+                    f'Cannot pickle state: {exc!r}. Fallback to pformat.',
+                    file=stderr,
+                )
+            else:
+                logger.exception("Cannot pickle state. Falling back to pformat.")
             fh.write(default_encode(pformat(state)))
     finally:
         fh.flush()

--- a/t/unit/utils/test_div.py
+++ b/t/unit/utils/test_div.py
@@ -46,3 +46,26 @@ class test_emergency_dump_state:
         assert 'bar' in fh.getvalue()
         assert stderr.getvalue()
         assert not stdouts.stdout.getvalue()
+
+    def test_dump_logging(self, caplog):
+        fh = MyBytesIO()
+        emergency_dump_state(
+            {'foo': 'bar'}, open_file=lambda n, m: fh, stderr=None)
+        assert pickle.loads(fh.getvalue()) == {'foo': 'bar'}
+        assert "EMERGENCY DUMP STATE TO FILE" in caplog.text
+
+    def test_dump_logging_exception(self, caplog):
+        fh = MyStringIO()
+
+        def raise_something(*args, **kwargs):
+            raise KeyError('foo')
+
+        emergency_dump_state(
+            {'foo': 'bar'},
+            open_file=lambda n, m: fh,
+            dump=raise_something,
+            stderr=None,
+        )
+        assert 'foo' in fh.getvalue()
+        assert 'bar' in fh.getvalue()
+        assert "Cannot pickle state. Falling back to pformat." in caplog.text


### PR DESCRIPTION
Continuation of https://github.com/celery/kombu/pull/2551

Avoid printing directly to stderr, use logger instead. For anyone who may rely on printing directly to file by providing `stderr` this will continue to print to provided file if explicitly set / provided.