### PR TITLE
Make the Redis ack-emulation restore cadence configurable

### DIFF
--- a/docs/reference/kombu.transport.redis.rst
+++ b/docs/reference/kombu.transport.redis.rst
@@ -35,6 +35,119 @@
     .. versionadded:: 5.7.0
     Supports Queue TTL
 
+    Visibility timeout and unacked message restore
+    ----------------------------------------------
+    .. versionadded:: 5.7.0
+
+    When ack emulation is enabled (the default), a message that has been
+    delivered but not yet acknowledged is tracked in a single, *global* Redis
+    sorted set (``unacked_index``) scored by the time it was fetched.
+    Periodically each consuming worker runs
+    :meth:`QoS.restore_visible <kombu.transport.redis.QoS.restore_visible>`,
+    which scans that set for entries older than ``now - visibility_timeout``
+    and pushes them back onto their original queues so another worker can pick
+    them up.
+
+    Because the index is shared by every worker and queue on the same Redis
+    database (and ``global_keyprefix``), *any* consuming worker restores
+    abandoned messages for the whole fleet — including messages left behind by
+    workers that crashed.
+
+    Two transport options control how often the restore scan runs:
+
+    ``unacked_restore_interval`` (int, default ``10``)
+        Seconds between periodic restore sweeps on the asynchronous
+        (event-loop / prefork) path.  Lower this to recover abandoned messages
+        faster when using a low ``visibility_timeout``.
+
+    ``unacked_restore_throttle`` (int, default ``10``)
+        Only perform an actual Redis scan on every *N*-th ``restore_visible``
+        call.  This protects Redis from being hit too often, especially on the
+        synchronous poll path where a restore is *attempted* on every empty
+        poll.  Set to ``1`` to scan on every call.
+
+    The effective sweep period on the asynchronous path is roughly::
+
+        unacked_restore_interval * unacked_restore_throttle   (seconds)
+
+    For example, to actually scan every 5 seconds with a 30 second visibility
+    timeout:
+
+    .. code-block:: python
+
+        app.conf.broker_transport_options = {
+            "visibility_timeout": 30,
+            "unacked_restore_interval": 5,
+            "unacked_restore_throttle": 1,
+        }
+
+    .. note::
+
+        ``unacked_restore_interval`` only affects the asynchronous path
+        (a prefork worker driven by the event loop on Linux/macOS).  On the
+        synchronous path — used by ``eventlet``/``gevent`` pools, on Windows,
+        or by any plain ``connection.drain_events()`` loop — there is no
+        restore timer; a restore is attempted on every empty poll
+        (~``brpop_timeout``, 1 second) and only ``unacked_restore_throttle``
+        governs how often Redis is actually scanned.
+
+    .. warning::
+
+        ``restore_visible`` uses the *scanning* worker's own
+        ``visibility_timeout`` as the cutoff — the sorted set stores only the
+        fetch timestamp, not each message's timeout.  Configure the same
+        ``visibility_timeout`` on every worker that may run the sweep,
+        otherwise restore timing becomes inconsistent: too low re-queues
+        messages that are still being processed (duplicate execution), too
+        high delays recovery.
+
+    Dedicated "janitor" worker for green pools
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Under the ``eventlet`` and ``gevent`` pools every greenlet runs
+    cooperatively in a single OS thread.  A CPU-bound task that does not yield
+    blocks the hub, which also stalls the broker consumer loop — so restore
+    sweeps (and heartbeats) stop running until the task finishes.  Visibility
+    timeouts may then expire without anything re-queuing the affected messages.
+
+    Because the unacked index is global, you can side-step this by running a
+    small dedicated **prefork** worker whose only job is to drive restores.
+    Point it at the same Redis database and ``global_keyprefix`` as your real
+    workers, have it consume a throwaway queue (so ``active_queues`` is
+    non-empty and the restore loop fires), give it the *same*
+    ``visibility_timeout`` as the rest of the fleet, and tune its restore
+    cadence aggressively:
+
+    .. code-block:: python
+
+        # janitor_app.py
+        from celery import Celery
+
+        app = Celery("janitor", broker="redis://localhost:6379/0")
+        app.conf.broker_transport_options = {
+            "visibility_timeout": 3600,        # MUST match the real workers
+            "unacked_restore_interval": 5,
+            "unacked_restore_throttle": 1,
+        }
+
+    .. code-block:: console
+
+        $ celery -A janitor_app worker -P prefork -c 1 -Q janitor_dummy
+
+    The janitor never needs to consume the real queues: ``restore_visible``
+    re-routes each recovered message to its original queue using the bindings
+    stored in Redis.  Its hub is independent of the green-pool workers, so it
+    keeps reaping expired messages even while they are busy with CPU-bound
+    work — and it doubles as a safety net for messages stranded by crashed
+    workers.
+
+    .. note::
+
+        The janitor only *drives* the sweep; the per-message restore work is
+        unchanged, and all workers still contend for the same ``unacked_mutex``
+        so only one sweep runs at a time.  ``ack_emulation`` must stay enabled
+        for the unacked index to exist.
+
     Queue arguments
     ---------------
     The following queue argument is supported. Pass it per-queue via

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -37,6 +37,15 @@ Transport Options
 * ``unacked_mutex_expire``
 * ``visibility_timeout``
 * ``unacked_restore_limit``
+* ``unacked_restore_interval``: (int) Seconds between periodic
+  ``restore_visible`` sweeps in the async (event loop / prefork) path.
+  Defaults to ``10``. Lower this to recover abandoned messages faster when
+  using a low ``visibility_timeout``.
+* ``unacked_restore_throttle``: (int) Only run an actual Redis scan on every
+  Nth ``restore_visible`` call. Defaults to ``10``. The effective async sweep
+  period is roughly ``unacked_restore_interval * unacked_restore_throttle``
+  seconds, so set this to ``1`` to make ``unacked_restore_interval`` the sole
+  control.
 * ``fanout_prefix``
 * ``fanout_patterns``
 * ``global_keyprefix``: (str) The global key prefix to be prepended to all keys
@@ -420,7 +429,9 @@ class QoS(virtual.QoS):
 
     def restore_visible(self, start=0, num=10, interval=10):
         self._vrestore_count += 1
-        if (self._vrestore_count - 1) % interval:
+        # ``interval or 1`` avoids a ZeroDivisionError if the throttle is
+        # misconfigured to 0; 1 means "scan on every call".
+        if (self._vrestore_count - 1) % (interval or 1):
             return
         with self.channel.conn_or_acquire() as client:
             ceil = time() - self.visibility_timeout
@@ -566,6 +577,7 @@ class MultiChannelPoller:
         for channel in self._channels:
             return channel.qos.restore_visible(
                 num=channel.unacked_restore_limit,
+                interval=channel.unacked_restore_throttle,
             )
 
     def maybe_restore_messages(self):
@@ -575,6 +587,7 @@ class MultiChannelPoller:
                 try:
                     return channel.qos.restore_visible(
                         num=channel.unacked_restore_limit,
+                        interval=channel.unacked_restore_throttle,
                     )
                 except channel.connection_errors:
                     # Connection is broken; skip this cycle and retry next tick.
@@ -668,6 +681,16 @@ class Channel(virtual.Channel):
     unacked_mutex_key = 'unacked_mutex'
     unacked_mutex_expire = 300  # 5 minutes
     unacked_restore_limit = None
+    #: Seconds between periodic ``restore_visible`` sweeps in the async
+    #: (event loop / prefork) path.  Lower this to recover abandoned messages
+    #: faster when using a low ``visibility_timeout``.
+    unacked_restore_interval = 10
+    #: Only run an actual Redis scan on every Nth ``restore_visible`` call.
+    #: Protects the synchronous poll path (restore is attempted on every empty
+    #: poll) from hitting Redis too often.  Set to 1 to scan on every call.
+    #: Effective async sweep period is roughly
+    #: ``unacked_restore_interval * unacked_restore_throttle`` seconds.
+    unacked_restore_throttle = 10
     visibility_timeout = 3600   # 1 hour
     priority_steps = PRIORITY_STEPS
     socket_timeout = None
@@ -738,6 +761,8 @@ class Channel(virtual.Channel):
          'unacked_mutex_expire',
          'visibility_timeout',
          'unacked_restore_limit',
+         'unacked_restore_interval',
+         'unacked_restore_throttle',
          'fanout_prefix',
          'fanout_patterns',
          'global_keyprefix',
@@ -1533,8 +1558,11 @@ class Transport(virtual.Transport):
             if old_tref is not None:
                 old_tref.cancel()
 
+        restore_interval = connection.client.transport_options.get(
+            'unacked_restore_interval', Channel.unacked_restore_interval
+        )
         cycle._restore_messages_tref = loop.call_repeatedly(
-            10, cycle.maybe_restore_messages
+            restore_interval, cycle.maybe_restore_messages
         )
         health_check_interval = connection.client.transport_options.get(
             'health_check_interval',

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -1561,6 +1561,8 @@ class Transport(virtual.Transport):
         restore_interval = connection.client.transport_options.get(
             'unacked_restore_interval', Channel.unacked_restore_interval
         )
+        if restore_interval <= 0:
+            restore_interval = Channel.unacked_restore_interval
         cycle._restore_messages_tref = loop.call_repeatedly(
             restore_interval, cycle.maybe_restore_messages
         )

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -718,6 +718,47 @@ class test_Channel:
         client.setnx.side_effect = redis.MutexHeld()
         qos.restore_visible()
 
+    def test_qos_restore_visible_interval_throttles(self):
+        client = self.channel._create_client = Mock(name='client')
+        client = client()
+
+        def pipe(*args, **kwargs):
+            return Pipeline(client)
+        client.pipeline = pipe
+        client.zrevrangebyscore.return_value = []
+        qos = redis.QoS(self.channel)
+        qos.restore_by_tag = Mock(name='restore_by_tag')
+
+        # interval=3 -> only the 1st and 4th calls perform an actual scan.
+        qos._vrestore_count = 0
+        qos.restore_visible(interval=3)
+        client.zrevrangebyscore.assert_called_once()
+        client.zrevrangebyscore.reset_mock()
+
+        qos.restore_visible(interval=3)   # 2nd call -> skip
+        qos.restore_visible(interval=3)   # 3rd call -> skip
+        client.zrevrangebyscore.assert_not_called()
+
+        qos.restore_visible(interval=3)   # 4th call -> scan
+        client.zrevrangebyscore.assert_called_once()
+
+    def test_qos_restore_visible_zero_interval_no_zerodivision(self):
+        client = self.channel._create_client = Mock(name='client')
+        client = client()
+
+        def pipe(*args, **kwargs):
+            return Pipeline(client)
+        client.pipeline = pipe
+        client.zrevrangebyscore.return_value = []
+        qos = redis.QoS(self.channel)
+        qos.restore_by_tag = Mock(name='restore_by_tag')
+
+        # interval=0 must not raise ZeroDivisionError and scans on every call.
+        qos._vrestore_count = 0
+        qos.restore_visible(interval=0)
+        qos.restore_visible(interval=0)
+        assert client.zrevrangebyscore.call_count == 2
+
     def test_basic_consume_when_fanout_queue(self):
         self.channel.exchange_declare(exchange='txconfan', type='fanout')
         self.channel.queue_declare(queue='txconfanq')
@@ -2006,6 +2047,7 @@ class test_MultiChannelPoller:
         p.on_poll_init(poller)
         chan1.qos.restore_visible.assert_called_with(
             num=chan1.unacked_restore_limit,
+            interval=chan1.unacked_restore_throttle,
         )
 
     def test_maybe_restore_messages_calls_restore_visible(self):
@@ -2019,6 +2061,7 @@ class test_MultiChannelPoller:
 
         channel.qos.restore_visible.assert_called_once_with(
             num=channel.unacked_restore_limit,
+            interval=channel.unacked_restore_throttle,
         )
 
     def test_maybe_restore_messages_skips_channel_without_active_queues(self):

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -1267,6 +1267,45 @@ class test_Channel:
             call(13, transport.on_readable, 13),
         ])
 
+    def test_register_with_event_loop__restore_interval_from_options(self):
+        """A non-default ``unacked_restore_interval`` transport option is
+        forwarded as the delay of the periodic restore timer, instead of the
+        built-in default of 10 seconds."""
+        transport = self.connection.transport
+        transport.cycle = Mock(name='cycle')
+        transport.cycle.fds = {}
+        conn = Mock(name='conn')
+        conn.client = Mock(
+            name='client',
+            transport_options={'unacked_restore_interval': 5},
+        )
+        loop = Mock(name='loop')
+        redis.Transport.register_with_event_loop(transport, conn, loop)
+        loop.call_repeatedly.assert_has_calls([
+            call(5, transport.cycle.maybe_restore_messages),
+            call(25, transport.cycle.maybe_check_subclient_health),
+        ])
+
+    @pytest.mark.parametrize('restore_interval', [0, -5])
+    def test_register_with_event_loop__non_positive_interval_falls_back(
+            self, restore_interval):
+        """A non-positive ``unacked_restore_interval`` would stall the restore
+        timer, so it falls back to the default cadence of 10 seconds."""
+        transport = self.connection.transport
+        transport.cycle = Mock(name='cycle')
+        transport.cycle.fds = {}
+        conn = Mock(name='conn')
+        conn.client = Mock(
+            name='client',
+            transport_options={'unacked_restore_interval': restore_interval},
+        )
+        loop = Mock(name='loop')
+        redis.Transport.register_with_event_loop(transport, conn, loop)
+        loop.call_repeatedly.assert_has_calls([
+            call(10, transport.cycle.maybe_restore_messages),
+            call(25, transport.cycle.maybe_check_subclient_health),
+        ])
+
     @pytest.mark.parametrize('fds', [{12: 'LISTEN', 13: 'BRPOP'}, {}])
     def test_register_with_event_loop__on_disconnect__loop_cleanup(self, fds):
         """Ensure on_poll_start stays in on_tick after disconnect.


### PR DESCRIPTION
## Summary

The Redis transport re-queues delivered-but-unacked messages whose
`visibility_timeout` has expired via `QoS.restore_visible`. How *often* that
scan actually runs was previously governed by two hard-coded constants:

- the event-loop restore timer fired every **10s** (`call_repeatedly(10, ...)`), and
- `restore_visible` only performed a real Redis scan on every **10th** call
  (a hard-coded `interval=10` throttle).

The effective sweep period was therefore fixed at roughly **100 seconds**,
independent of the configured `visibility_timeout`. Users who set a low
`visibility_timeout` (e.g. 30s) still had to wait up to ~100s for abandoned
messages to be restored, making the setting appear random or ignored.

This PR exposes both constants as transport options so the restore cadence can
be tuned to match the configured `visibility_timeout`, while keeping the
previous values as defaults (fully backward compatible).

## Changes

- Add two transport options to the Redis `Channel`:
  - `unacked_restore_interval` (int, default `10`) — seconds between periodic
    restore sweeps on the asynchronous (event-loop / prefork) path.
  - `unacked_restore_throttle` (int, default `10`) — only perform an actual
    Redis scan on every *N*-th `restore_visible` call. Set to `1` to scan on
    every call.
- Wire `unacked_restore_interval` into `register_with_event_loop`
  (`call_repeatedly`) and `unacked_restore_throttle` into the
  `restore_visible(interval=...)` call sites (sync poll path and
  `maybe_restore_messages`).
- Harden `restore_visible` against a misconfigured throttle of `0`
  (`% (interval or 1)`), which previously would raise `ZeroDivisionError`.
- Document the options, the cadence formula, the **prefork vs green-pool**
  path difference (see below), the shared-`visibility_timeout` cutoff caveat,
  and a "janitor worker" pattern for green pools in the Redis transport
  reference.

## Restore behaviour differs by worker pool ⚠️

The two new options do **not** behave identically across pools, because the
Redis transport has two distinct code paths that trigger `restore_visible`:

### Asynchronous path — prefork (default on Linux/macOS)

The worker drives Redis via the kombu event loop / hub. Restores are scheduled
by a dedicated timer:

```python
loop.call_repeatedly(unacked_restore_interval, cycle.maybe_restore_messages)
```

Here **both** options apply. The effective sweep period is:

```
unacked_restore_interval * unacked_restore_throttle   (seconds)
```

So with the defaults (`10 * 10`) a real scan happens about every 100s — the
previous behaviour. To scan every 5s, set `unacked_restore_interval=5` and
`unacked_restore_throttle=1`:

```python
app.conf.broker_transport_options = {
    "visibility_timeout": 30,
    "unacked_restore_interval": 5,
    "unacked_restore_throttle": 1,
}
```

### Synchronous path — eventlet / gevent (and Windows, or plain `drain_events`)

Green-pool workers do **not** use the event-loop restore timer. They reach
`restore_visible` through `MultiChannelPoller.get()`, which attempts a restore
on **every empty poll** (~`brpop_timeout`, 1s by default). On this path:

- `unacked_restore_interval` is **ignored** (there is no `call_repeatedly`
  timer), and
- `unacked_restore_throttle` is the **only** control — a real Redis scan runs
  on every *N*-th empty poll (default 10 → roughly every ~10s while idle).

There is a further caveat specific to `gevent`/`eventlet`: all greenlets share
a single OS thread, so a **CPU-bound task that doesn't yield blocks the hub**,
which also stalls the consumer loop — restores (and heartbeats) pause until the
task finishes. For deployments that need reliable restores under green pools,
the docs now describe a dedicated **prefork "janitor" worker** (same Redis db /
`global_keyprefix`, same `visibility_timeout`, aggressive restore cadence) that
drives restores independently of the busy green-pool workers.

**Practical guidance**

- Prefork: tune `unacked_restore_interval` (× `unacked_restore_throttle`).
- eventlet/gevent: tune `unacked_restore_throttle` only; consider a janitor
  worker for CPU-bound workloads.

## Backward compatibility

Defaults reproduce the prior behaviour exactly (10s timer × 10 throttle ≈ 100s
sweep on the async path; ~10× `brpop_timeout` on the sync path). No change
unless the new options are set.

## Related issues

- Fixes celery/celery#6229 — *"Tasks longer than the visibility timeout are not
  being re-queued with acks_late and the Redis broker."* The root cause
  identified in that thread is exactly kombu's internal ~100s restore timer /
  hard-coded `interval=10` throttle; this PR makes that cadence configurable.
- Addresses several comments in celery/celery#9339 — *"Visibility timeout not
  functioning as expected."* In particular the finding that tweaking the
  `kombu.transport.redis.QoS` `interval` resolves the inconsistent redelivery
  delay, the request to expose it as configuration, and the gevent-specific
  observation that `restore_visible` stops being called while workers are busy
  (now documented, with the janitor-worker workaround).
  - https://github.com/celery/celery/issues/9339#issuecomment-2628317310 
  - https://github.com/celery/celery/issues/9339#issuecomment-3115324677

## Tests

- Updated `test_on_poll_init` and
  `test_maybe_restore_messages_calls_restore_visible` to assert the new
  `interval=` kwarg is forwarded.
- Added `test_qos_restore_visible_interval_throttles` — verifies the throttle
  gates scans (scans on the 1st and 4th call for `interval=3`).
- Added `test_qos_restore_visible_zero_interval_no_zerodivision` — verifies
  `interval=0` does not raise and scans on every call.

Drafted-by: Claude Code (Opus 4.8)
