### PR TITLE
Fix KeyError(<fileno>) crash in Redis transport on_readable/handle_event

### DIFF
--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -601,7 +601,10 @@ class MultiChannelPoller:
                     return
 
     def on_readable(self, fileno):
-        chan, type = self._fd_to_chan[fileno]
+        chan_type = self._fd_to_chan.get(fileno)
+        if chan_type is None:
+            return
+        chan, type = chan_type
         if chan.qos.can_consume():
             chan.handlers[type]()
 
@@ -609,7 +612,10 @@ class MultiChannelPoller:
         if event & READ:
             return self.on_readable(fileno), self
         elif event & ERR:
-            chan, type = self._fd_to_chan[fileno]
+            chan_type = self._fd_to_chan.get(fileno)
+            if chan_type is None:
+                return
+            chan, type = chan_type
             chan._poll_error(type)
 
     def get(self, callback, timeout=None):

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -603,18 +603,20 @@ class MultiChannelPoller:
     def on_readable(self, fileno):
         chan_type = self._fd_to_chan.get(fileno)
         if chan_type is None:
+            logger.debug('on_readable: fd %r not mapped, ignoring', fileno)
             return
         chan, type = chan_type
         if chan.qos.can_consume():
             chan.handlers[type]()
 
     def handle_event(self, fileno, event):
+        chan_type = self._fd_to_chan.get(fileno)
+        if chan_type is None:
+            logger.debug('handle_event: fd %r not mapped, ignoring', fileno)
+            return
         if event & READ:
             return self.on_readable(fileno), self
         elif event & ERR:
-            chan_type = self._fd_to_chan.get(fileno)
-            if chan_type is None:
-                return
             chan, type = chan_type
             chan._poll_error(type)
 

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -2129,8 +2129,8 @@ class test_MultiChannelPoller:
     def test_handle_event_ignores_unmapped_fd(self):
         p = self.Poller()
         assert 35 not in p._fd_to_chan
-        p.handle_event(35, redis.READ)
-        p.handle_event(35, redis.ERR)
+        assert p.handle_event(35, redis.READ) is None
+        assert p.handle_event(35, redis.ERR) is None
 
     def test_fds(self):
         p = self.Poller()

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -2121,6 +2121,17 @@ class test_MultiChannelPoller:
 
         p.handle_event(13, ~(redis.READ | redis.ERR))
 
+    def test_on_readable_ignores_unmapped_fd(self):
+        p = self.Poller()
+        assert 35 not in p._fd_to_chan
+        p.on_readable(35)
+
+    def test_handle_event_ignores_unmapped_fd(self):
+        p = self.Poller()
+        assert 35 not in p._fd_to_chan
+        p.handle_event(35, redis.READ)
+        p.handle_event(35, redis.ERR)
+
     def test_fds(self):
         p = self.Poller()
         p._fd_to_chan = {1: 2}


### PR DESCRIPTION
## Summary

`MultiChannelPoller.on_readable()` (and the `ERR` branch of `handle_event()`) look up the firing fd with a bare `self._fd_to_chan[fileno]`. Under connection churn the event loop can report a fd as readable *after* its channel has already been removed from `_fd_to_chan` (connection dropped + reconnected within the same poll cycle; the stale reader on the hub isn't removed in lockstep). The lookup then raises `KeyError(fileno)`.

That exception escapes the event loop and crashes the consumer:

```
Unrecoverable error: KeyError(35)
  File ".../celery/worker/loops.py", line 111, in asynloop
    next(loop)
  File ".../kombu/asynchronous/hub.py", line 377, in create_loop
    cb(*cbargs)
  File ".../kombu/transport/redis.py", line 1394, in on_readable
    self.cycle.on_readable(fileno)
  File ".../kombu/transport/redis.py", line 577, in on_readable
    chan, type = self._fd_to_chan[fileno]
                 ~~~~~~~~~~~~~~~~^^^^^^^^
KeyError: 35
```

`KeyError` is not in `connection.connection_errors`, so celery's loop error guard (`hub.propagate_errors`) does not recover from it — the worker dies.

## Reproduction (deterministic, against current `main`)

```python
from kombu.transport.redis import MultiChannelPoller

p = MultiChannelPoller()
# epoll reported fd 35 readable, but its channel was just torn down,
# so 35 is no longer in _fd_to_chan:
p.on_readable(35)   # -> KeyError: 35   (crashes the consumer in production)
```

## Fix

Guard both bare `_fd_to_chan[fileno]` lookups. When the fd is no longer mapped, log at debug and return: the event is for a channel that no longer exists, so there is nothing for this transport to read. Any in-flight message on the dropped connection was never acked and is redelivered by the broker, so no message is lost.

This matches the early-return-on-stale-state pattern already used elsewhere in this transport (e.g. `maybe_check_subclient_health`).

## Context

This is a long-standing, intermittently reported crash that has been closed before without a code fix (hard to reproduce reliably in the field):

- celery/kombu#379 — "Unrecoverable error: KeyError(21,)"
- celery/celery#2827 — "redis backend Unrecoverable error: KeyError(9,)"

The integer in the error is just the OS file descriptor, which is why it varies per occurrence and is unrelated to message payloads.

## Tests

Added `test_on_readable_ignores_unmapped_fd` and `test_handle_event_ignores_unmapped_fd` to `test_MultiChannelPoller`. Both fail on `main` with `KeyError: 35` and pass with this change. Full `t/unit/transport/test_redis.py` suite (153 tests) passes.
