### PR TITLE
ci: Drop the archived useblacksmith/setup-python GitHub Action

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v7
       - name: Set up Python ${{ matrix.python-version }}
         id: python
-        uses: useblacksmith/setup-python@v6
+        uses: actions/setup-python@v6
         with:
             python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -43,7 +43,7 @@ jobs:
       run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev libssl-dev
     - uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}
-      uses: useblacksmith/setup-python@v6
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
@@ -110,7 +110,7 @@ jobs:
 
           -   uses: actions/checkout@v7
           -   name: Set up Python ${{ matrix.python-version }}
-              uses: useblacksmith/setup-python@v6
+              uses: actions/setup-python@v6
               with:
                   python-version: ${{ matrix.python-version }}
                   allow-prereleases: true


### PR DESCRIPTION
Like:
* celery/django-celery-beat#1062

As recommended in the ***archive notice*** for the GitHub Action `useblacksmith/setup-python`:
* https://github.com/useblacksmith/setup-python#%EF%B8%8F-archive-notice
> Blacksmith now supports transparent caching as explained in https://www.blacksmith.sh/blog/cache. To this effect, it is recommended to switch to the upstream, maintained versions of this action, as you will continue to leverage our much faster caching without any code changes. This action will no longer receive dependency or security updates.