### PR TITLE
Redis: deliver rotating StreamingCredentialProvider tokens to long-lived BRPOP and pub/sub connections

### DIFF
--- a/docs/reference/kombu.transport.redis.rst
+++ b/docs/reference/kombu.transport.redis.rst
@@ -35,6 +35,57 @@
     .. versionadded:: 5.7.0
     Supports Queue TTL
 
+    Streaming credentials / automatic re-authentication
+    ----------------------------------------------------
+    .. versionadded:: 5.7.0
+
+    The transport supports rotating credentials supplied by a
+    :class:`redis.credentials.StreamingCredentialProvider` (for example the
+    Microsoft Entra ID provider from ``redis-entraid``, or an AWS ElastiCache
+    IAM provider).  Configure it like any other credential provider:
+
+    .. code-block:: python
+
+        app.conf.broker_transport_options = {
+            "credential_provider": my_streaming_credential_provider,
+        }
+
+    Such providers emit a fresh authentication token in the background before
+    the current one expires.  redis-py delivers these tokens to *pooled*
+    connections when they are released back to the pool, but the Redis
+    transport keeps two connections busy for the entire lifetime of the
+    worker — the ``BRPOP`` connection (used to consume regular queues) and the
+    pub/sub ``LISTEN`` connection (used to consume fanout queues) — so they are
+    never released and would otherwise never receive a rotated token.  The
+    broker then severs them once the original credentials expire (e.g. AWS
+    ElastiCache with IAM auth enforces a hard 12-hour connection limit),
+    causing redelivered messages, interrupted in-flight tasks and brief worker
+    unavailability.
+
+    To avoid this, the transport periodically flushes any pending token onto
+    those long-lived connections from the event loop:
+
+    * the ``BRPOP`` connection is re-authenticated in place with an ``AUTH``
+      command, sent only when no blocking pop is in flight;
+    * the pub/sub ``LISTEN`` connection cannot process ``AUTH`` while
+      subscribed under RESP2, so it is transparently reconnected (and
+      re-subscribed) to pick up the new credentials.  Under RESP3, redis-py
+      re-authenticates pub/sub connections itself and the transport leaves
+      them untouched.
+
+    How often the flush runs is controlled by the ``reauth_check_interval``
+    transport option (seconds, default ``10``):
+
+    .. code-block:: python
+
+        app.conf.broker_transport_options = {
+            "credential_provider": my_streaming_credential_provider,
+            "reauth_check_interval": 10,
+        }
+
+    When no streaming credential provider is configured this machinery is a
+    cheap no-op, so it is always safe to leave enabled.
+
     Queue arguments
     ---------------
     The following queue argument is supported. Pass it per-queue via

--- a/docs/reference/kombu.transport.redis.rst
+++ b/docs/reference/kombu.transport.redis.rst
@@ -40,7 +40,7 @@
     .. versionadded:: 5.7.0
 
     The transport supports rotating credentials supplied by a
-    :class:`redis.credentials.StreamingCredentialProvider` (for example the
+    ``redis.credentials.StreamingCredentialProvider`` (for example the
     Microsoft Entra ID provider from ``redis-entraid``, or an AWS ElastiCache
     IAM provider).  Configure it like any other credential provider:
 

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -615,10 +615,14 @@ class MultiChannelPoller:
             try:
                 channel.maybe_reauth()
             except channel.connection_errors:
+                # Connection is broken; skip this cycle and retry next tick.
+                # Stop iterating to avoid repeated exceptions/log spam when
+                # the broker is down (channels share the broken connection).
                 logger.debug(
                     'maybe_reauth: connection error, '
                     'will retry on next cycle', exc_info=True
                 )
+                return
 
     def on_readable(self, fileno):
         chan, type = self._fd_to_chan[fileno]
@@ -1080,7 +1084,7 @@ class Channel(virtual.Channel):
 
         redis-py only re-authenticates *subscribed* connections in place when
         the RESP3 protocol has been negotiated (see
-        :class:`redis.event.RegisterReAuthForPubSub`); a RESP2 subscriber
+        ``redis.event.RegisterReAuthForPubSub``); a RESP2 subscriber
         connection cannot process an ``AUTH`` command at all.  When RESP3 is in
         use we therefore leave the pub/sub connection to redis-py and avoid
         interfering with it.

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -48,6 +48,11 @@ Transport Options
 * ``queue_order_strategy``
 * ``max_connections``
 * ``health_check_interval``
+* ``reauth_check_interval``: (int) How often, in seconds, to flush pending
+  streaming re-authentication tokens (emitted by a
+  ``redis.credentials.StreamingCredentialProvider`` such as the Entra ID /
+  IAM providers) onto the long-lived BRPOP and pub/sub connections held by
+  the transport. Defaults to ``10``. See :meth:`Channel.maybe_reauth`.
 * ``retry_on_timeout``
 * ``priority_steps``
 * ``client_name``: (str) The name to use when connecting to Redis server.
@@ -112,6 +117,11 @@ DEFAULT_PORT = 6379
 DEFAULT_DB = 0
 
 DEFAULT_HEALTH_CHECK_INTERVAL = 25
+
+#: How often (in seconds) to flush pending streaming re-authentication
+#: tokens onto the long-lived BRPOP and pub/sub connections.  See
+#: :meth:`Channel.maybe_reauth` for why this is needed.
+DEFAULT_REAUTH_CHECK_INTERVAL = 10
 
 PRIORITY_STEPS = [0, 3, 6, 9]
 
@@ -600,6 +610,16 @@ class MultiChannelPoller:
                     )
                     return
 
+    def maybe_reauth(self):
+        for channel in self._channels:
+            try:
+                channel.maybe_reauth()
+            except channel.connection_errors:
+                logger.debug(
+                    'maybe_reauth: connection error, '
+                    'will retry on next cycle', exc_info=True
+                )
+
     def on_readable(self, fileno):
         chan, type = self._fd_to_chan[fileno]
         if chan.qos.can_consume():
@@ -1025,12 +1045,134 @@ class Channel(virtual.Channel):
                 raise Empty()
         finally:
             self._in_poll = None
+            # The BRPOP connection is now idle (its reply has been fully
+            # consumed and no new BRPOP has been issued yet): this is the
+            # safe moment to flush any pending streaming re-auth token.
+            self._flush_brpop_reauth()
 
     def _poll_error(self, type, **options):
         if type == 'LISTEN':
             self.subclient.parse_response()
         else:
             self.client.parse_response(self.client.connection, type)
+
+    @staticmethod
+    def _pending_reauth_token(connection):
+        """Return a streaming re-auth token stored on ``connection``, if any.
+
+        redis-py's :class:`~redis.event.RegisterReAuthForPooledConnections`
+        listener calls ``Connection.set_re_auth_token`` for every *in-use*
+        pooled connection whenever a
+        :class:`~redis.credentials.StreamingCredentialProvider` emits a fresh
+        token.  The token is stored on the connection and only turned into an
+        actual ``AUTH`` command when the connection is released back to the
+        pool.  We key off this attribute so that we do not have to couple to
+        the credential provider itself; it is only ever set when streaming
+        re-authentication is in effect.
+        """
+        if connection is None:
+            return None
+        return getattr(connection, '_re_auth_token', None)
+
+    @staticmethod
+    def _pubsub_reauth_handled_by_redis(connection):
+        """Whether redis-py re-authenticates ``connection`` itself.
+
+        redis-py only re-authenticates *subscribed* connections in place when
+        the RESP3 protocol has been negotiated (see
+        :class:`redis.event.RegisterReAuthForPubSub`); a RESP2 subscriber
+        connection cannot process an ``AUTH`` command at all.  When RESP3 is in
+        use we therefore leave the pub/sub connection to redis-py and avoid
+        interfering with it.
+        """
+        get_protocol = getattr(connection, 'get_protocol', None)
+        if get_protocol is not None:
+            protocol = get_protocol()
+        else:
+            protocol = getattr(connection, 'protocol', 2)
+        return str(protocol) == '3'
+
+    def maybe_reauth(self):
+        """Flush pending streaming re-auth tokens onto long-lived connections.
+
+        The transport holds two connections for the lifetime of the worker
+        that are never released back to the pool: the ``BRPOP`` connection
+        (used to consume from ordinary queues) and the pub/sub ``LISTEN``
+        connection (used to consume from fanout queues).  Because they are
+        never released, redis-py's release-triggered re-authentication never
+        fires for them, so a streaming credential provider's rotated tokens
+        never reach them and the broker eventually severs the connections when
+        the original credentials expire (e.g. the 12h limit imposed by AWS
+        ElastiCache with IAM auth).
+
+        This is called periodically from the event loop (a single thread), so
+        it can safely flush the tokens without racing the socket reads.
+        """
+        self._flush_brpop_reauth()
+        self._flush_listen_reauth()
+
+    def _flush_brpop_reauth(self):
+        """Send a pending re-auth token's ``AUTH`` on the BRPOP connection.
+
+        Only safe to do while no ``BRPOP`` command is in flight, otherwise the
+        ``AUTH`` reply would interleave with the blocking pop's reply.  We are
+        called both from the periodic timer and from :meth:`_brpop_read` (right
+        after a reply has been fully consumed), so the token is flushed at the
+        first idle moment after it is emitted.
+        """
+        if self._in_poll:
+            # A BRPOP is outstanding; retry at the next idle opportunity.
+            return
+        client = self.__dict__.get('client')  # only if property is cached
+        connection = getattr(client, 'connection', None)
+        if self._pending_reauth_token(connection) is None:
+            return
+        try:
+            connection.re_auth()
+        except self.connection_errors + (self.ResponseError,):
+            # The AUTH failed: a network/auth error (ConnectionError,
+            # AuthenticationError, ...) or a rejected token surfacing as a
+            # ResponseError.  Drop the socket so the next poll reconnects and
+            # authenticates with fresh credentials from the credential
+            # provider.  This runs from ``_brpop_read``'s ``finally`` block,
+            # so it must never raise.
+            warning('Redis streaming re-auth failed on BRPOP connection; '
+                    'reconnecting', exc_info=True)
+            try:
+                connection.disconnect()
+            except self.connection_errors:
+                pass
+
+    def _flush_listen_reauth(self):
+        """Refresh credentials on the long-lived pub/sub (LISTEN) connection.
+
+        A subscribed RESP2 connection cannot process an ``AUTH`` command, so
+        the stored re-auth token can never be flushed in place.  Instead we
+        drop the connection; the poller reconnects and re-subscribes on the
+        next tick, authenticating with the current credentials from the
+        credential provider.  Fanout delivery is best-effort, so the brief
+        reconnect is far less disruptive than a broker-forced disconnect.
+
+        Under RESP3, redis-py re-authenticates pub/sub connections itself, so
+        we leave those untouched.
+        """
+        subclient = self.__dict__.get('subclient')  # only if property cached
+        connection = getattr(subclient, 'connection', None)
+        if self._pending_reauth_token(connection) is None:
+            return
+        if self._pubsub_reauth_handled_by_redis(connection):
+            return
+        logger.info('Refreshing Redis pub/sub connection to apply rotated '
+                    'streaming credentials')
+        # Clear the stored token first so we do not reconnect again on the
+        # next cycle, then drop the socket.  The poller re-registers the
+        # LISTEN connection and re-subscribes on the next tick.
+        try:
+            connection.set_re_auth_token(None)
+        except AttributeError:
+            pass
+        self._in_listen = None
+        connection.disconnect()
 
     def _get(self, queue):
         with self.conn_or_acquire() as client:
@@ -1528,7 +1670,8 @@ class Transport(virtual.Transport):
         # registering new ones. Without this, each reconnect accumulates
         # an extra entry in hub.timer._queue; they all fire against the
         # same cycle and can crash the event loop during reconnect.
-        for attr in ('_restore_messages_tref', '_subclient_health_tref'):
+        for attr in ('_restore_messages_tref', '_subclient_health_tref',
+                     '_reauth_tref'):
             old_tref = getattr(cycle, attr, None)
             if old_tref is not None:
                 old_tref.cancel()
@@ -1543,6 +1686,14 @@ class Transport(virtual.Transport):
         cycle._subclient_health_tref = loop.call_repeatedly(
             health_check_interval,
             cycle.maybe_check_subclient_health
+        )
+        reauth_check_interval = connection.client.transport_options.get(
+            'reauth_check_interval',
+            DEFAULT_REAUTH_CHECK_INTERVAL
+        )
+        cycle._reauth_tref = loop.call_repeatedly(
+            reauth_check_interval,
+            cycle.maybe_reauth
         )
 
     def on_readable(self, fileno):

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -1127,6 +1127,17 @@ class Channel(virtual.Channel):
         connection = getattr(client, 'connection', None)
         if self._pending_reauth_token(connection) is None:
             return
+        if getattr(connection, '_sock', None) is None:
+            # The socket is already down (e.g. a BRPOP connection error just
+            # disconnected it, or a previous flush failed).  ``re_auth`` would
+            # transparently reconnect a *fresh* socket via ``send_command``,
+            # but behind the poller's back: ``_register_BRPOP`` would then skip
+            # re-registering it (its ``_chan_to_sock`` entry survives the
+            # disconnect and ``_sock`` is no longer ``None``), so the new fd is
+            # never handed to the event loop and the channel silently stalls.
+            # Leave it to ``_register_BRPOP`` to reconnect *and* re-register;
+            # ``on_connect`` re-authenticates with the current credentials.
+            return
         try:
             connection.re_auth()
         except self.connection_errors + (self.ResponseError,):
@@ -1134,10 +1145,18 @@ class Channel(virtual.Channel):
             # AuthenticationError, ...) or a rejected token surfacing as a
             # ResponseError.  Drop the socket so the next poll reconnects and
             # authenticates with fresh credentials from the credential
-            # provider.  This runs from ``_brpop_read``'s ``finally`` block,
-            # so it must never raise.
+            # provider.  Also clear the stored token: ``re_auth`` only clears
+            # it on success, and once the socket is dropped the reconnect
+            # applies the current credentials via ``on_connect`` — re-sending
+            # this same (possibly expired/rejected) token in place would just
+            # fail again on every tick.  This runs from ``_brpop_read``'s
+            # ``finally`` block, so it must never raise.
             warning('Redis streaming re-auth failed on BRPOP connection; '
                     'reconnecting', exc_info=True)
+            try:
+                connection.set_re_auth_token(None)
+            except AttributeError:
+                pass
             try:
                 connection.disconnect()
             except self.connection_errors:

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -1215,6 +1215,7 @@ class test_Channel:
         loop.call_repeatedly.assert_has_calls([
             call(10, transport.cycle.maybe_restore_messages),
             call(25, transport.cycle.maybe_check_subclient_health),
+            call(10, transport.cycle.maybe_reauth),
         ])
         loop.on_tick.add.assert_called()
         on_poll_start = loop.on_tick.add.call_args[0][0]
@@ -1266,6 +1267,7 @@ class test_Channel:
                                                    'on_poll_start',
                                                    'maybe_restore_messages',
                                                    'maybe_check_subclient_health',
+                                                   'maybe_reauth',
                                                    '_on_connection_disconnect'])
         transport.cycle.fds = {}
         transport.cycle._fd_to_chan = {42: Mock(name='chan')}
@@ -1295,6 +1297,7 @@ class test_Channel:
                                                    'on_poll_start',
                                                    'maybe_restore_messages',
                                                    'maybe_check_subclient_health',
+                                                   'maybe_reauth',
                                                    '_on_connection_disconnect'])
         transport.cycle.fds = {}
         transport.cycle._fd_to_chan = {99: Mock(name='chan')}
@@ -1323,6 +1326,7 @@ class test_Channel:
                                                    'on_poll_start',
                                                    'maybe_restore_messages',
                                                    'maybe_check_subclient_health',
+                                                   'maybe_reauth',
                                                    '_on_connection_disconnect'])
         transport.cycle.fds = {}
         transport.cycle._fd_to_chan = {}
@@ -1351,6 +1355,7 @@ class test_Channel:
                                                    'on_poll_start',
                                                    'maybe_restore_messages',
                                                    'maybe_check_subclient_health',
+                                                   'maybe_reauth',
                                                    '_on_connection_disconnect'])
         transport.cycle.fds = {}
         # fd 55 is NOT in _fd_to_chan — KeyError must be silently ignored
@@ -1381,6 +1386,7 @@ class test_Channel:
                                                    'on_poll_start',
                                                    'maybe_restore_messages',
                                                    'maybe_check_subclient_health',
+                                                   'maybe_reauth',
                                                    '_on_connection_disconnect'])
         transport.cycle.fds = {}
         # Suppose fd 42 (the original fd before close) is still in the map.
@@ -1424,6 +1430,7 @@ class test_Channel:
                                                    'on_poll_start',
                                                    'maybe_restore_messages',
                                                    'maybe_check_subclient_health',
+                                                   'maybe_reauth',
                                                    '_on_connection_disconnect'])
         transport.cycle.fds = {}
         # _fd_to_chan values are (channel, type) tuples in production
@@ -1460,6 +1467,7 @@ class test_Channel:
                                                    'on_poll_start',
                                                    'maybe_restore_messages',
                                                    'maybe_check_subclient_health',
+                                                   'maybe_reauth',
                                                    '_on_connection_disconnect'])
         transport.cycle.fds = {}
         transport.cycle._fd_to_chan = {30: (stale_chan, 'BRPOP')}
@@ -1486,6 +1494,7 @@ class test_Channel:
         loop.call_repeatedly.assert_has_calls([
             call(10, transport.cycle.maybe_restore_messages),
             call(15, transport.cycle.maybe_check_subclient_health),
+            call(10, transport.cycle.maybe_reauth),
         ])
         loop.on_tick.add.assert_called()
         on_poll_start = loop.on_tick.add.call_args[0][0]
@@ -1510,13 +1519,16 @@ class test_Channel:
         conn = Mock(name='conn')
         conn.client = Mock(name='client', transport_options={})
         loop = Mock(name='loop')
-        tref1, tref2 = Mock(name='tref_restore'), Mock(name='tref_health')
-        loop.call_repeatedly.side_effect = [tref1, tref2]
+        tref1, tref2, tref3 = (Mock(name='tref_restore'),
+                               Mock(name='tref_health'),
+                               Mock(name='tref_reauth'))
+        loop.call_repeatedly.side_effect = [tref1, tref2, tref3]
 
         redis.Transport.register_with_event_loop(transport, conn, loop)
 
         assert transport.cycle._restore_messages_tref is tref1
         assert transport.cycle._subclient_health_tref is tref2
+        assert transport.cycle._reauth_tref is tref3
 
     def test_register_with_event_loop_cancels_stale_trefs_on_reconnect(self):
         """Stale timer entries from a previous connection must be cancelled.
@@ -1534,13 +1546,16 @@ class test_Channel:
 
         old_restore_tref = Mock(name='old_restore_tref')
         old_health_tref = Mock(name='old_health_tref')
+        old_reauth_tref = Mock(name='old_reauth_tref')
         transport.cycle._restore_messages_tref = old_restore_tref
         transport.cycle._subclient_health_tref = old_health_tref
+        transport.cycle._reauth_tref = old_reauth_tref
 
         redis.Transport.register_with_event_loop(transport, conn, loop)
 
         old_restore_tref.cancel.assert_called_once()
         old_health_tref.cancel.assert_called_once()
+        old_reauth_tref.cancel.assert_called_once()
 
     def test_transport_on_readable(self):
         transport = self.connection.transport
@@ -1805,6 +1820,221 @@ class test_Channel:
             actual_calls = pipeline_mock.method_calls
             for expected_call in expected_calls:
                 assert expected_call in actual_calls
+
+
+class test_Channel_streaming_reauth:
+    """Streaming credential re-authentication of long-lived connections.
+
+    Redis-py defers re-authentication (``AUTH``) for *in-use* pooled
+    connections until they are released back to the pool.  The transport's
+    BRPOP and pub/sub (LISTEN) connections are held for the whole lifetime of
+    the worker and never released, so rotated tokens emitted by a
+    ``StreamingCredentialProvider`` never reach them.  The channel therefore
+    flushes them itself at safe points.
+
+    See https://github.com/celery/kombu/issues/2509.
+    """
+
+    def setup_method(self):
+        self.connection = Connection(
+            transport=Transport,
+            transport_options={'fanout_patterns': True},
+        )
+        self.channel = self.connection.default_channel
+
+    def _conn(self, token=None, protocol=2):
+        conn = Mock(name='connection')
+        conn._re_auth_token = token
+        conn.get_protocol.return_value = protocol
+        return conn
+
+    def _prime_client(self, conn):
+        client = Mock(name='client')
+        client.connection = conn
+        self.channel.__dict__['client'] = client
+        return client
+
+    def _prime_subclient(self, conn):
+        subclient = Mock(name='subclient')
+        subclient.connection = conn
+        self.channel.__dict__['subclient'] = subclient
+        return subclient
+
+    # -- _pending_reauth_token -------------------------------------------
+
+    def test_pending_reauth_token_none_connection(self):
+        assert self.channel._pending_reauth_token(None) is None
+
+    def test_pending_reauth_token_missing_attr(self):
+        assert self.channel._pending_reauth_token(object()) is None
+
+    def test_pending_reauth_token_unset(self):
+        conn = Mock()
+        conn._re_auth_token = None
+        assert self.channel._pending_reauth_token(conn) is None
+
+    def test_pending_reauth_token_present(self):
+        token = object()
+        conn = Mock()
+        conn._re_auth_token = token
+        assert self.channel._pending_reauth_token(conn) is token
+
+    def test_pending_reauth_token_reads_real_redis_attribute(self):
+        """Guard against redis-py renaming the stored-token attribute."""
+        conn = redis.redis.Connection()
+        assert self.channel._pending_reauth_token(conn) is None
+        token = Mock(name='token')
+        conn.set_re_auth_token(token)
+        assert self.channel._pending_reauth_token(conn) is token
+
+    # -- _pubsub_reauth_handled_by_redis ---------------------------------
+
+    def test_pubsub_reauth_handled_by_redis_resp3_int(self):
+        assert self.channel._pubsub_reauth_handled_by_redis(
+            self._conn(protocol=3)) is True
+
+    def test_pubsub_reauth_handled_by_redis_resp3_str(self):
+        assert self.channel._pubsub_reauth_handled_by_redis(
+            self._conn(protocol="3")) is True
+
+    def test_pubsub_reauth_handled_by_redis_resp2(self):
+        assert self.channel._pubsub_reauth_handled_by_redis(
+            self._conn(protocol=2)) is False
+
+    def test_pubsub_reauth_handled_by_redis_no_get_protocol(self):
+        conn = Mock(spec=['protocol'])
+        conn.protocol = 3
+        assert self.channel._pubsub_reauth_handled_by_redis(conn) is True
+
+    def test_pubsub_reauth_handled_by_redis_real_connection(self):
+        assert self.channel._pubsub_reauth_handled_by_redis(
+            redis.redis.Connection(protocol=2)) is False
+        assert self.channel._pubsub_reauth_handled_by_redis(
+            redis.redis.Connection(protocol=3)) is True
+
+    # -- _flush_brpop_reauth ---------------------------------------------
+
+    def test_flush_brpop_reauth_sends_auth_when_idle(self):
+        self.channel._in_poll = False
+        conn = self._conn(token=object())
+        self._prime_client(conn)
+        self.channel._flush_brpop_reauth()
+        conn.re_auth.assert_called_once_with()
+
+    def test_flush_brpop_reauth_skips_while_brpop_in_flight(self):
+        # A BRPOP is outstanding: sending AUTH now would interleave with the
+        # blocking pop's reply, so it must be deferred.
+        self.channel._in_poll = Mock(name='outstanding-brpop')
+        conn = self._conn(token=object())
+        self._prime_client(conn)
+        self.channel._flush_brpop_reauth()
+        conn.re_auth.assert_not_called()
+
+    def test_flush_brpop_reauth_noop_without_pending_token(self):
+        self.channel._in_poll = False
+        conn = self._conn(token=None)
+        self._prime_client(conn)
+        self.channel._flush_brpop_reauth()
+        conn.re_auth.assert_not_called()
+
+    def test_flush_brpop_reauth_noop_without_cached_client(self):
+        self.channel._in_poll = False
+        self.channel.__dict__.pop('client', None)
+        self.channel._flush_brpop_reauth()  # must not raise
+
+    def test_flush_brpop_reauth_disconnects_on_error(self):
+        self.channel._in_poll = False
+
+        class ConnError(Exception):
+            pass
+
+        self.channel.connection_errors = (ConnError,)
+        conn = self._conn(token=object())
+        conn.re_auth.side_effect = ConnError('boom')
+        self._prime_client(conn)
+        self.channel._flush_brpop_reauth()  # must not raise
+        conn.disconnect.assert_called_once_with()
+
+    def test_flush_brpop_reauth_disconnects_on_response_error(self):
+        # A rejected token surfaces as a ResponseError (a channel error, not a
+        # connection error); it must still be recovered from by reconnecting,
+        # and must not escape _brpop_read's finally block.
+        self.channel._in_poll = False
+        conn = self._conn(token=object())
+        conn.re_auth.side_effect = self.channel.ResponseError('WRONGPASS')
+        self._prime_client(conn)
+        self.channel._flush_brpop_reauth()  # must not raise
+        conn.disconnect.assert_called_once_with()
+
+    def test_flush_brpop_reauth_swallows_disconnect_error(self):
+        self.channel._in_poll = False
+
+        class ConnError(Exception):
+            pass
+
+        self.channel.connection_errors = (ConnError,)
+        conn = self._conn(token=object())
+        conn.re_auth.side_effect = ConnError('boom')
+        conn.disconnect.side_effect = ConnError('still down')
+        self._prime_client(conn)
+        self.channel._flush_brpop_reauth()  # must not raise
+
+    # -- _flush_listen_reauth --------------------------------------------
+
+    def test_flush_listen_reauth_reconnects_under_resp2(self):
+        conn = self._conn(token=object(), protocol=2)
+        self._prime_subclient(conn)
+        self.channel._in_listen = conn
+        self.channel._flush_listen_reauth()
+        conn.set_re_auth_token.assert_called_once_with(None)
+        conn.disconnect.assert_called_once_with()
+        assert self.channel._in_listen is None
+
+    def test_flush_listen_reauth_left_to_redis_under_resp3(self):
+        conn = self._conn(token=object(), protocol=3)
+        self._prime_subclient(conn)
+        self.channel._flush_listen_reauth()
+        conn.disconnect.assert_not_called()
+        conn.set_re_auth_token.assert_not_called()
+
+    def test_flush_listen_reauth_noop_without_pending_token(self):
+        conn = self._conn(token=None, protocol=2)
+        self._prime_subclient(conn)
+        self.channel._flush_listen_reauth()
+        conn.disconnect.assert_not_called()
+
+    def test_flush_listen_reauth_noop_without_cached_subclient(self):
+        self.channel.__dict__.pop('subclient', None)
+        self.channel._flush_listen_reauth()  # must not raise
+
+    def test_flush_listen_reauth_tolerates_missing_set_token(self):
+        conn = Mock(spec=['get_protocol', 'disconnect', '_re_auth_token'])
+        conn._re_auth_token = object()
+        conn.get_protocol.return_value = 2
+        self._prime_subclient(conn)
+        self.channel._flush_listen_reauth()  # must not raise
+        conn.disconnect.assert_called_once_with()
+
+    # -- maybe_reauth / _brpop_read integration --------------------------
+
+    def test_maybe_reauth_flushes_both_connections(self):
+        self.channel._flush_brpop_reauth = Mock(name='brpop')
+        self.channel._flush_listen_reauth = Mock(name='listen')
+        self.channel.maybe_reauth()
+        self.channel._flush_brpop_reauth.assert_called_once_with()
+        self.channel._flush_listen_reauth.assert_called_once_with()
+
+    def test_brpop_read_flushes_reauth_on_completion(self):
+        # _brpop_read must flush the BRPOP re-auth token in its finally block,
+        # i.e. at the exact moment the connection becomes idle again.
+        self.channel._flush_brpop_reauth = Mock(name='flush')
+        client = Mock(name='client')
+        client.parse_response.return_value = None  # BRPOP timed out (nil)
+        self.channel.__dict__['client'] = client
+        with pytest.raises(Empty):
+            self.channel._brpop_read()
+        assert self.channel._in_poll is None
+        self.channel._flush_brpop_reauth.assert_called_once_with()
 
 
 class test_Redis:
@@ -2101,6 +2331,36 @@ class test_MultiChannelPoller:
         p.maybe_check_subclient_health()
 
         client.check_health.assert_called_once()
+
+    def test_maybe_reauth_delegates_to_channels(self):
+        """Happy path: the timer flushes re-auth on every channel."""
+        p = self.Poller()
+        channel = Mock(name='channel')
+        p._channels = [channel]
+
+        p.maybe_reauth()
+
+        channel.maybe_reauth.assert_called_once_with()
+
+    def test_maybe_reauth_swallows_connection_error(self):
+        """Connection errors from the re-auth timer must not tear down the loop.
+
+        Same reasoning as test_maybe_restore_messages_swallows_connection_error.
+        """
+        p = self.Poller()
+
+        class ConnError(Exception):
+            pass
+
+        channel = Mock(name='channel')
+        channel.connection_errors = (ConnError,)
+        channel.maybe_reauth.side_effect = ConnError('connection lost')
+        p._channels = [channel]
+
+        # Must not raise
+        p.maybe_reauth()
+
+        channel.maybe_reauth.assert_called_once()
 
     def test_handle_event(self):
         p = self.Poller()

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -1842,10 +1842,13 @@ class test_Channel_streaming_reauth:
         )
         self.channel = self.connection.default_channel
 
-    def _conn(self, token=None, protocol=2):
+    def _conn(self, token=None, protocol=2, connected=True):
         conn = Mock(name='connection')
         conn._re_auth_token = token
         conn.get_protocol.return_value = protocol
+        # redis-py sets Connection._sock to the socket when connected and back
+        # to None on disconnect; the flush guards off it.
+        conn._sock = object() if connected else None
         return conn
 
     def _prime_client(self, conn):
@@ -1942,7 +1945,18 @@ class test_Channel_streaming_reauth:
         self.channel.__dict__.pop('client', None)
         self.channel._flush_brpop_reauth()  # must not raise
 
-    def test_flush_brpop_reauth_disconnects_on_error(self):
+    def test_flush_brpop_reauth_skips_when_socket_down(self):
+        # If the BRPOP socket is already disconnected (e.g. a connection error
+        # just dropped it), re_auth must NOT be called: sending AUTH would
+        # transparently reconnect a fresh socket behind the poller's back,
+        # which _register_BRPOP would never re-register -> silent stall.
+        self.channel._in_poll = False
+        conn = self._conn(token=object(), connected=False)
+        self._prime_client(conn)
+        self.channel._flush_brpop_reauth()
+        conn.re_auth.assert_not_called()
+
+    def test_flush_brpop_reauth_disconnects_and_clears_token_on_error(self):
         self.channel._in_poll = False
 
         class ConnError(Exception):
@@ -1954,6 +1968,9 @@ class test_Channel_streaming_reauth:
         self._prime_client(conn)
         self.channel._flush_brpop_reauth()  # must not raise
         conn.disconnect.assert_called_once_with()
+        # The token is cleared so we do not re-send the same failing token in
+        # place on every tick (reconnect re-auths via on_connect instead).
+        conn.set_re_auth_token.assert_called_once_with(None)
 
     def test_flush_brpop_reauth_disconnects_on_response_error(self):
         # A rejected token surfaces as a ResponseError (a channel error, not a
@@ -1965,6 +1982,7 @@ class test_Channel_streaming_reauth:
         self._prime_client(conn)
         self.channel._flush_brpop_reauth()  # must not raise
         conn.disconnect.assert_called_once_with()
+        conn.set_re_auth_token.assert_called_once_with(None)
 
     def test_flush_brpop_reauth_swallows_disconnect_error(self):
         self.channel._in_poll = False
@@ -2035,6 +2053,37 @@ class test_Channel_streaming_reauth:
             self.channel._brpop_read()
         assert self.channel._in_poll is None
         self.channel._flush_brpop_reauth.assert_called_once_with()
+
+    def test_brpop_read_connection_error_does_not_eager_reconnect(self):
+        # Regression guard for #2509: after a BRPOP connection error drops the
+        # socket, the finally-block re-auth flush must NOT reconnect it (via
+        # re_auth -> send_command).  An eagerly-reconnected socket would be
+        # skipped by _register_BRPOP (its _chan_to_sock entry survives the
+        # disconnect) and never handed to the poller, silently stalling the
+        # channel.  The socket must be left down for _register_BRPOP to
+        # reconnect *and* re-register.
+        class ConnError(Exception):
+            pass
+
+        self.channel.connection_errors = (ConnError,)
+
+        conn = self._conn(token=object(), connected=True)
+
+        def _disconnect():
+            conn._sock = None  # mirror redis-py: disconnect clears the socket
+
+        conn.disconnect.side_effect = _disconnect
+        client = Mock(name='client')
+        client.connection = conn
+        client.parse_response.side_effect = ConnError('server closed')
+        self.channel.__dict__['client'] = client
+
+        with pytest.raises(ConnError):
+            self.channel._brpop_read()
+
+        conn.disconnect.assert_called_once_with()   # from the error path
+        conn.re_auth.assert_not_called()            # no eager reconnect
+        assert conn._sock is None                   # left down for _register
 
 
 class test_Redis:


### PR DESCRIPTION
Fixes #2509. Builds on #2507.

## Summary

When a `redis.credentials.StreamingCredentialProvider` (e.g. the Microsoft Entra ID
provider from `redis-entraid`, or an AWS ElastiCache IAM provider) is used with the
Redis transport, the rotated re-auth tokens it emits never reach the two connections
the transport holds for the entire lifetime of the worker: the **BRPOP** connection and
the pub/sub **LISTEN** connection. As a result the broker eventually severs those
connections when the original credentials expire (AWS ElastiCache with IAM auth enforces
a hard 12-hour connection limit), causing unacked messages to be redelivered, in-flight
tasks to be interrupted, and brief worker unavailability during the forced reconnect.

This PR makes the transport deliver those tokens itself, at safe points on the event loop.

## Root cause

redis-py's streaming re-auth (`RegisterReAuthForPooledConnections`) handles *in-use*
pooled connections by calling `Connection.set_re_auth_token(token)`, which only **stores**
the token; the actual `AUTH` command is deferred until the connection is released back to
the pool (`AfterConnectionReleasedEvent` → `ReAuthConnectionListener` → `Connection.re_auth()`).

The transport, however, pins two connections that are **never** released:

1. the **BRPOP** connection, assigned to `client.connection` in
   `MultiChannelPoller._client_registered`, and
2. the pub/sub **LISTEN** connection, opened when `subclient.subscribe()` runs.

Both live in `ConnectionPool._in_use_connections` for the worker's lifetime, so
`re_auth()` is never triggered and the stored token is never flushed. #2507 correctly
made sure the re-auth listener gets *registered* (by passing `credential_provider` through
to `redis.Redis(...)`); this PR makes sure the stored tokens actually get *applied*.

## What this PR does

A periodic, event-loop-driven flush of any pending token onto the two long-lived
connections. Because it runs on the single event-loop thread, it can never race the
socket reads:

- **BRPOP connection** — re-authenticated in place with `Connection.re_auth()`, but only
  when the connection is live and no blocking pop is in flight (`not _in_poll`), so the
  `AUTH` reply can't interleave with the pop's reply. It is flushed both from the periodic
  timer **and** from `_brpop_read`'s `finally` block (the guaranteed-idle moment right
  after a reply is consumed), so rotated tokens are applied promptly even under heavy
  consumption. Crucially, the flush is skipped when the socket is already down: sending
  `AUTH` on a disconnected connection would transparently reconnect a *fresh* socket
  behind the poller's back (which `_register_BRPOP` would then never re-register, silently
  stalling the channel). Instead the socket is left down and `_register_BRPOP` reconnects
  **and** re-registers it, with `on_connect` re-authenticating via the current
  credentials. On an `AUTH` failure the socket is dropped and the stale token cleared, so
  the reconnect's fresh `on_connect` auth stands and the same (possibly expired) token
  isn't re-sent in place on every tick.
- **Pub/sub LISTEN connection** — a subscribed RESP2 connection cannot process `AUTH`, so
  it is transparently reconnected (and re-subscribed) via the existing poller machinery,
  which re-authenticates on `on_connect` with the current credentials. Fanout delivery is
  best-effort, so the sub-second reconnect is far less disruptive than a broker-forced
  disconnect. Under RESP3, redis-py re-authenticates pub/sub connections itself
  (`RegisterReAuthForPubSub`), so the transport leaves those untouched to avoid
  double-`AUTH` and background-thread races.

Wiring:

- `MultiChannelPoller.maybe_reauth()` iterates channels and swallows `connection_errors`
  (like the existing `maybe_restore_messages` / `maybe_check_subclient_health` timers, so a
  transient error can't tear down the event loop).
- A new `_reauth_tref` timer is registered in `register_with_event_loop`, with the same
  stale-timer cancellation as the existing timers.
- New transport option `reauth_check_interval` (seconds, default `10`) controls the cadence.

## Design notes

- **Decoupled from the credential provider.** Detection keys off the connection's stored
  `_re_auth_token` (the attribute redis-py itself populates for in-use pooled connections),
  so there is no coupling to any specific provider and no new import surface.
- **No eager reconnects.** Both long-lived connections are only ever re-authenticated in
  place on a *live* socket; whenever a socket must be dropped, reconnection and
  re-registration are left to the existing `_register_BRPOP` / `_register_LISTEN` paths, so
  the poller's bookkeeping (`_chan_to_sock` / `_fd_to_chan`) stays consistent.
- **No-op unless streaming re-auth is active.** When no `StreamingCredentialProvider` is
  configured the token is never set, so every check is a cheap early return. Behaviour for
  existing users is unchanged.
- **Backwards compatible.** No signature changes; the new transport option is optional with
  a sensible default.

## Tests

28 new unit tests in `t/unit/transport/test_redis.py` covering:

- the token helper (including a test against a **real** `redis.Connection` to guard against
  redis-py renaming the stored-token attribute),
- RESP2 vs RESP3 protocol gating (including real connections),
- the BRPOP flush across live-idle / in-flight / socket-down / no-token / no-client /
  `ConnectionError` / `ResponseError` / disconnect-error paths, and that a rejected/failed
  `AUTH` both drops the socket and clears the stale token,
- an end-to-end regression test proving a BRPOP connection error does **not** eager-reconnect
  an unregistered socket (the socket is left down for `_register_BRPOP`),
- the pub/sub reconnect (RESP2 reconnect, RESP3 left to redis-py, no-token, no-subclient,
  missing-method tolerance),
- the `_brpop_read` `finally` hook, and
- the poller-level delegation and error swallowing.

The 10 existing `register_with_event_loop` tests were updated for the new timer.

## Docs

- New "Streaming credentials / automatic re-authentication" section in
  `docs/reference/kombu.transport.redis.rst`.
- `reauth_check_interval` documented in the transport module docstring.

I tagged the docs `versionadded:: 5.7.0` — happy to adjust to whatever the next release will be.

🤖 Heavily assisted by [Claude Code](https://claude.com/claude-code)
