### PR TITLE
Fix delayed-delivery routing key prefix accumulation on retries (#2556)

### DIFF
--- a/kombu/transport/native_delayed_delivery.py
+++ b/kombu/transport/native_delayed_delivery.py
@@ -4,6 +4,8 @@ Only relevant for RabbitMQ.
 """
 from __future__ import annotations
 
+import re
+
 from kombu import Connection, Exchange, Queue, binding
 from kombu.log import get_logger
 
@@ -12,6 +14,13 @@ logger = get_logger(__name__)
 MAX_NUMBER_OF_BITS_TO_USE = 28
 MAX_LEVEL = MAX_NUMBER_OF_BITS_TO_USE - 1
 CELERY_DELAYED_DELIVERY_EXCHANGE = "celery_delayed_delivery"
+
+# Matches a delayed-delivery prefix: the ``MAX_NUMBER_OF_BITS_TO_USE`` binary
+# digits (each ``0`` or ``1``) that :func:`calculate_routing_key` prepends,
+# joined and terminated by dots.
+DELAYED_DELIVERY_PREFIX_REGEX = re.compile(
+    r'^(?:[01]\.){%d}' % MAX_NUMBER_OF_BITS_TO_USE
+)
 
 
 def level_name(level: int, prefix: str | None = None) -> str:
@@ -153,5 +162,11 @@ def calculate_routing_key(countdown: int, routing_key: str) -> str:
 
     if not routing_key:
         raise ValueError("routing_key must be non-empty")
+
+    # On sequential delayed retries Celery re-reads the already-prefixed
+    # routing key from ``delivery_info`` and passes it back here. Strip any
+    # existing delayed-delivery prefix first so prefixes don't accumulate and
+    # eventually exceed AMQP's 255-byte short-string limit (see issue #2556).
+    routing_key = DELAYED_DELIVERY_PREFIX_REGEX.sub('', routing_key)
 
     return '.'.join(list(f'{countdown:028b}')) + f'.{routing_key}'

--- a/kombu/transport/native_delayed_delivery.py
+++ b/kombu/transport/native_delayed_delivery.py
@@ -169,4 +169,4 @@ def calculate_routing_key(countdown: int, routing_key: str) -> str:
     # eventually exceed AMQP's 255-byte short-string limit (see issue #2556).
     routing_key = DELAYED_DELIVERY_PREFIX_REGEX.sub('', routing_key)
 
-    return '.'.join(list(f'{countdown:028b}')) + f'.{routing_key}'
+    return '.'.join(f'{countdown:0{MAX_NUMBER_OF_BITS_TO_USE}b}') + f'.{routing_key}'

--- a/t/unit/transport/test_native_delayed_delivery.py
+++ b/t/unit/transport/test_native_delayed_delivery.py
@@ -166,3 +166,22 @@ class test_calculate_routing_key:
     def test_none_routing_key(self):
         with pytest.raises(ValueError, match="routing_key must be non-empty"):
             calculate_routing_key(1, None)
+
+    def test_calculate_routing_key_with_existing_prefix(self):
+        # A routing key that already carries a delayed-delivery prefix (for
+        # example, from a previous ``self.retry(countdown=...)``) must not
+        # accumulate a second prefix; the old prefix is stripped first.
+        prefixed = calculate_routing_key(1, 'destination')
+        assert (calculate_routing_key(2, prefixed)
+                == '0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1.0.destination')
+
+    def test_calculate_routing_key_does_not_accumulate_on_retries(self):
+        # Repeated calls (as happen across sequential delayed retries) must
+        # keep the routing key at a constant length instead of growing past
+        # the 255-byte AMQP short-string limit.
+        routing_key = 'my_routing_key'
+        expected = calculate_routing_key(5, routing_key)
+        for _ in range(10):
+            routing_key = calculate_routing_key(5, routing_key)
+            assert routing_key == expected
+            assert len(routing_key) <= 255

--- a/t/unit/transport/test_native_delayed_delivery.py
+++ b/t/unit/transport/test_native_delayed_delivery.py
@@ -184,4 +184,4 @@ class test_calculate_routing_key:
         for _ in range(10):
             routing_key = calculate_routing_key(5, routing_key)
             assert routing_key == expected
-            assert len(routing_key) <= 255
+            assert len(routing_key.encode()) <= 255


### PR DESCRIPTION
## Summary

When RabbitMQ Native Delayed Delivery is used (Quorum Queues), a task that repeatedly calls `self.retry(countdown=...)` accumulates a routing-key prefix on every delayed retry. Once the accumulated routing key exceeds AMQP's 255-byte short-string limit, the retry fails with:

```
celery.exceptions.Reject: (error("'B' format requires 0 <= number <= 255"), False)
```

Root cause: `kombu/transport/native_delayed_delivery.py::calculate_routing_key()` unconditionally prepended a 28-bit binary prefix. On each delayed retry, Celery re-reads the already-prefixed routing key from `request.delivery_info` and passes it back into `calculate_routing_key()`, so a fresh 56-character prefix (28 bits + 28 dots) was prepended each time. After ~5 retries the key crossed 255 bytes.

Fixes #2556.

## Fix

Before prepending a new prefix, strip any existing delayed-delivery prefix from the routing key. The prefix is a fixed 28-token dotted-binary pattern (`MAX_NUMBER_OF_BITS_TO_USE` digits, each `0`/`1`, each terminated by a dot), matched by an anchored regex `^(?:[01]\.){28}`. This keeps the routing key at a constant length across any number of retries while leaving ordinary (unprefixed) routing keys — including ones that contain dots — untouched.

## Tests

Added two regression tests in `t/unit/transport/test_native_delayed_delivery.py` (both fail on `main`, pass with the fix):

- `test_calculate_routing_key_with_existing_prefix` — a routing key that already carries a prefix gets the old prefix stripped, not doubled.
- `test_calculate_routing_key_does_not_accumulate_on_retries` — repeated calls keep the key identical and `<= 255` bytes.

All 22 tests in the file pass, and the surrounding transport unit suite is green (unrelated pre-existing failures only where optional broker deps are absent). `flake8` and `isort` are clean on the changed files.

Disclosure: prepared with AI assistance; reviewed and verified locally.
