### PR TITLE
Stop the topic '*' wildcard from matching across dots

### DIFF
--- a/kombu/transport/virtual/exchange.py
+++ b/kombu/transport/virtual/exchange.py
@@ -86,7 +86,7 @@ class TopicExchange(ExchangeType):
     type = 'topic'
 
     #: map of wildcard to regex conversions
-    wildcards = {'*': r'.*?[^\.]',
+    wildcards = {'*': r'[^\.]+',
                  '#': r'.*?'}
 
     #: compiled regex cache

--- a/t/unit/transport/virtual/test_exchange.py
+++ b/t/unit/transport/virtual/test_exchange.py
@@ -84,6 +84,8 @@ class test_Topic(ExchangeCase):
         ('eFoo', 'stock.europe.OSE', None, {'rFoo'}),
         ('eFoo', 'stockxeuropexOSE', None, set()),
         ('eFoo', 'candy.schleckpulver.snap_crackle', None, set()),
+        # '*' is a single word: only 'stock.#' may match a longer key.
+        ('eFoo', 'stock.us.nasdaq.tech', None, {'rFoo'}),
     ])
     def test_lookup(self, exchange, routing_key, default, expected):
         assert self.e.lookup(


### PR DESCRIPTION
A topic binding using `*` matches routing keys with *any* number of words, not one — so queues receive messages they never bound.

`TopicExchange`'s own docstring is the spec here:

> The `topic` exchange routes messages based on words separated by dots, using wildcard characters `*` (**any single word**), and `#` (one or more words).

### The bug

```python
wildcards = {'*': r'.*?[^\.]',
             '#': r'.*?'}
```

`*` compiles to `.*?[^\.]` — "anything, then a non-dot". The intent reads as "one word, not ending in a dot", but the leading `.*?` is unconstrained and `.` matches dots, so only the *final* character is actually restricted. `a.*.c` becomes `^a\..*?[^\.]\.c$`, which happily matches `a.b.x.c`.

### Reproducer

Through the public API, no mocks — `Connection('memory://')`, a queue bound with `a.*.c`, three messages published:

```
binding 'a.*.c' received:
   - CONTROL: routing_key='a.b.c'      (one word — should arrive)
   - routing_key='a.b.x.c'             (two words — should NOT arrive)
   - routing_key='a.b.x.y.c'           (three words — should NOT arrive)
```

The control arrives correctly, so this is the wildcard specifically rather than a broken reproducer. The compiled patterns:

| binding | current pattern | matches |
|---|---|---|
| `a.*.c` | `^a\..*?[^\.]\.c$` | `a.b.c`, **`a.b.x.c`**, **`a.b.x.y.c`** |
| `*.b` | `^.*?[^\.]\.b$` | `a.b`, **`a.x.b`** |
| `*` | `^.*?[^\.]$` | `a`, **`a.b`** |

### Scope

`virtual/base.py:448` sets `exchange_types = dict(STANDARD_EXCHANGE_TYPES)` and no transport overrides it, so every virtual transport routes through this — redis, mongodb, filesystem, SQS, kafka, and so on. Real AMQP brokers route server-side and are unaffected.

The failure direction is over-delivery rather than loss: a queue silently processes messages outside its binding, which is why I'd call it more than cosmetic.

### Fix

Compile `*` to a single dot-free word. `#` is untouched.

```python
wildcards = {'*': r'[^\.]+',
             '#': r'.*?'}
```

I checked the boundaries explicitly — `*` still matches exactly one word and still rejects an empty word (`a.*.c` vs `a..c`) and an empty key, and `a.#.c` still matches both `a.b.c` and `a.b.x.c`.

### On `#`

While here I noticed `a.#.c` doesn't match `a.c`, where AMQP defines `#` as *zero* or more words. I've deliberately left that alone: kombu's docstring says `#` is "one or more words", so the code matches its own documented contract, and changing it means restructuring the split/join rather than a wildcards entry. Happy to open a separate issue if you'd like it reconsidered.

### Tests

Added one case to the existing `test_Topic::test_lookup` table — `stock.us.nasdaq.tech` must reach only the `stock.#` queue, not the `stock.us.*` one. It fails on `main` (`Extra items in the left set: 'rBar'`) and passes with the fix.

There was no coverage for this: `test_Topic` and `test_TopicMultibind` only exercise `stock.us.*` against the single-word `stock.us.nasdaq`, so neither behaviour was pinned — no existing test changed.

Full unit suite, same command and tree both ways: **1184 passed with the fix vs. 1183 on `main`** (the extra one is the new case). Failures are byte-identical between the two runs — 16 pre-existing ones in my sandbox (15 `SQS`, 1 `pyro`, both missing local credentials/deps), none attributable to this change. `flake8` clean.

### Disclosure

AI-assisted, and I'd rather say so plainly. The reproducer, the controls, the boundary table, the `exchange_types` scope check, and the `main`-vs-branch baseline diff are all things I ran and read myself rather than assumed. Happy to adjust scope or framing.
