### PR TITLE
Honor the delivery_mode argument in Exchange.Message

### DIFF
--- a/kombu/entity.py
+++ b/kombu/entity.py
@@ -249,7 +249,8 @@ class Exchange(MaybeChannelBound):
             headers (Dict): Message headers.
         """
         properties = {} if properties is None else properties
-        properties['delivery_mode'] = maybe_delivery_mode(self.delivery_mode)
+        properties['delivery_mode'] = maybe_delivery_mode(
+            delivery_mode or self.delivery_mode)
         if (isinstance(body, str) and
                 properties.get('content_encoding', None)) is None:
             kwargs['content_encoding'] = 'utf-8'

--- a/t/unit/test_entity.py
+++ b/t/unit/test_entity.py
@@ -148,6 +148,20 @@ class test_Exchange:
         Exchange('foo', channel=chan).Message({'foo': 'bar'})
         assert 'prepare_message' in chan
 
+    def test_create_message_delivery_mode(self) -> None:
+        chan = get_conn().channel()
+        exchange = Exchange('foo', channel=chan, delivery_mode='persistent')
+
+        # an explicit delivery_mode overrides the exchange default
+        message = exchange.Message({'foo': 'bar'}, delivery_mode='transient')
+        assert message['properties']['delivery_mode'] == \
+            Exchange.TRANSIENT_DELIVERY_MODE
+
+        # without one, the exchange default is used
+        message = exchange.Message({'foo': 'bar'})
+        assert message['properties']['delivery_mode'] == \
+            Exchange.PERSISTENT_DELIVERY_MODE
+
     def test_publish(self) -> None:
         chan = get_conn().channel()
         Exchange('foo', channel=chan).publish('the quick brown fox')


### PR DESCRIPTION
`Exchange.Message` accepts a `delivery_mode` argument and documents it as:

> `delivery_mode` (bool): Set custom delivery mode. Defaults to `:attr:delivery_mode`.

but the method body never uses it — it always calls `maybe_delivery_mode(self.delivery_mode)`, so the caller's value is silently discarded:

```python
>>> ex = Exchange('ex', 'direct', delivery_mode='persistent')
>>> ex.Message(body, delivery_mode='transient')['properties']['delivery_mode']
2      # expected 1
>>> Exchange('e2', 'direct', delivery_mode='transient').Message(body, delivery_mode='persistent')['properties']['delivery_mode']
1      # expected 2
```

So a caller asking for a `transient` message on a persistent exchange still gets `delivery_mode=2` (RabbitMQ fsyncs and persists it), and one asking to persist can silently end up transient.

The sibling `Producer._delivery_details` already handles this correctly:

```python
return exchange.name, maybe_delivery_mode(
    delivery_mode or exchange.delivery_mode,
)
```

This change makes `Exchange.Message` use the same idiom, falling back to the exchange default only when no delivery mode is passed. `Exchange.publish()` calls `self.Message(message)` with no `delivery_mode`, so `None or self.delivery_mode` reproduces the current behaviour exactly — nothing changes for existing callers.

Added `t/unit/test_entity.py::test_Exchange::test_create_message_delivery_mode`, which fails before this change and passes after (the argument overrides the exchange default; without it the default is used).

`pytest t/unit/test_entity.py t/unit/test_messaging.py` → 128 passed; `flake8` (max-line-length 117) clean.
