### PR TITLE
fix(redis): replace deprecated ZREVRANGEBYSCORE with ZRANGE

### DIFF
--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -427,9 +427,10 @@ class QoS(virtual.QoS):
             try:
                 with Mutex(client, self.unacked_mutex_key,
                            self.unacked_mutex_expire):
-                    visible = client.zrevrangebyscore(
+                    visible = client.zrange(
                         self.unacked_index_key, ceil, 0,
-                        start=num and start, num=num, withscores=True)
+                        desc=True, byscore=True,
+                        offset=num and start, num=num, withscores=True)
                     for tag, score in visible or []:
                         self.restore_by_tag(tag, client)
             except MutexHeld:

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -742,13 +742,15 @@ class test_Channel:
         client.zrange.assert_called_once()
         args, kwargs = client.zrange.call_args
         assert args[0] == qos.unacked_index_key
-        assert args[1] == 0
-        assert args[2] >= 0
+        # redis-py passes the upper score first for ZRANGE ... BYSCORE REV.
+        assert args[1] >= args[2]
+        assert args[2] == 0
         assert kwargs['desc'] is True
         assert kwargs['byscore'] is True
         assert kwargs['offset'] == 0
         assert kwargs['num'] == 10
         assert kwargs['withscores'] is True
+
     def test_basic_consume_when_fanout_queue(self):
         self.channel.exchange_declare(exchange='txconfan', type='fanout')
         self.channel.queue_declare(queue='txconfanq')

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -741,11 +741,14 @@ class test_Channel:
         client.zrevrangebyscore.assert_not_called()
         client.zrange.assert_called_once()
         args, kwargs = client.zrange.call_args
+        assert args[0] == qos.unacked_index_key
+        assert args[1] == 0
+        assert args[2] >= 0
         assert kwargs['desc'] is True
         assert kwargs['byscore'] is True
+        assert kwargs['offset'] == 0
         assert kwargs['num'] == 10
         assert kwargs['withscores'] is True
-
     def test_basic_consume_when_fanout_queue(self):
         self.channel.exchange_declare(exchange='txconfan', type='fanout')
         self.channel.queue_declare(queue='txconfanq')

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -688,7 +688,7 @@ class test_Channel:
         def pipe(*args, **kwargs):
             return Pipeline(client)
         client.pipeline = pipe
-        client.zrevrangebyscore.return_value = [
+        client.zrange.return_value = [
             (1, 10),
             (2, 20),
             (3, 30),
@@ -697,7 +697,7 @@ class test_Channel:
         restore = qos.restore_by_tag = Mock(name='restore_by_tag')
         qos._vrestore_count = 1
         qos.restore_visible()
-        client.zrevrangebyscore.assert_not_called()
+        client.zrange.assert_not_called()
         assert qos._vrestore_count == 2
 
         qos._vrestore_count = 0
@@ -709,7 +709,7 @@ class test_Channel:
 
         qos._vrestore_count = 0
         restore.reset_mock()
-        client.zrevrangebyscore.return_value = []
+        client.zrange.return_value = []
         qos.restore_visible()
         restore.assert_not_called()
         assert qos._vrestore_count == 1
@@ -717,6 +717,34 @@ class test_Channel:
         qos._vrestore_count = 0
         client.setnx.side_effect = redis.MutexHeld()
         qos.restore_visible()
+
+    def test_qos_restore_visible_uses_zrange(self):
+        """Regression test for https://github.com/celery/kombu/issues/2050.
+
+        ZREVRANGEBYSCORE is deprecated since Redis 6.2 and is not implemented
+        by every Redis-compatible server, so restore_visible must issue an
+        equivalent ZRANGE ... BYSCORE REV query instead.
+        """
+        client = self.channel._create_client = Mock(name='client')
+        client = client()
+
+        def pipe(*args, **kwargs):
+            return Pipeline(client)
+        client.pipeline = pipe
+        client.zrange.return_value = []
+
+        qos = redis.QoS(self.channel)
+        qos.restore_by_tag = Mock(name='restore_by_tag')
+        qos._vrestore_count = 0
+        qos.restore_visible(start=0, num=10)
+
+        client.zrevrangebyscore.assert_not_called()
+        client.zrange.assert_called_once()
+        args, kwargs = client.zrange.call_args
+        assert kwargs['desc'] is True
+        assert kwargs['byscore'] is True
+        assert kwargs['num'] == 10
+        assert kwargs['withscores'] is True
 
     def test_basic_consume_when_fanout_queue(self):
         self.channel.exchange_declare(exchange='txconfan', type='fanout')


### PR DESCRIPTION
Closes #2050

`QoS.restore_visible()` called `ZREVRANGEBYSCORE`, deprecated in Redis 6.2 and not implemented by Redis-compatible servers such as Microsoft Garnet, so unacked-message restoration crashed the broker there. Swapped it for the equivalent `ZRANGE ... BYSCORE REV` (same emitted arguments apart from the command name) and added a regression test asserting the arguments that actually reach the client. Verified fail-without/pass-with; the full `t/unit/transport/test_redis.py` suite passes (154 tests).
