### PR TITLE
Add transport-aware batch publishing with Redis pipelines

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -4,6 +4,17 @@
  Change history
 ================
 
+Next release
+============
+
+What's Changed
+~~~~~~~~~~~~~~
+
+- Add a transport-aware :meth:`kombu.Producer.batch` API. The Redis transport
+  uses a non-transactional pipeline to publish multiple messages in fewer
+  network round trips while retaining normal serialization, routing,
+  priorities, queue expiry, and fanout behavior.
+
 .. _version-5.6.2:
 
 5.6.2

--- a/benchmarks/redis_publish_batch.py
+++ b/benchmarks/redis_publish_batch.py
@@ -1,0 +1,142 @@
+"""Compare ordinary and batched Redis publication with simulated latency."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import time
+from contextlib import nullcontext
+from unittest.mock import patch
+
+import redis
+
+from kombu import Connection, Producer
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--url', default='redis://localhost:6379/0')
+    parser.add_argument('--messages', type=int, default=100)
+    parser.add_argument('--latency-ms', type=float, default=10)
+    parser.add_argument('--rounds', type=int, default=7)
+    parser.add_argument('--warmups', type=int, default=1)
+    parser.add_argument('--max-size', type=int, default=1000)
+    parser.add_argument('--json', action='store_true', dest='as_json')
+    return parser.parse_args()
+
+
+def validate_args(args):
+    for name in ('messages', 'rounds', 'max_size'):
+        if getattr(args, name) <= 0:
+            raise SystemExit(f'--{name.replace("_", "-")} must be positive')
+    if args.warmups < 0:
+        raise SystemExit('--warmups cannot be negative')
+    if args.latency_ms < 0:
+        raise SystemExit('--latency-ms cannot be negative')
+
+
+def benchmark(args):
+    queue = 'kombu_publish_batch_benchmark'
+    delay = args.latency_ms / 1000
+    original_send = redis.connection.Connection.send_packed_command
+
+    def delayed_send(connection, command, check_health=True):
+        time.sleep(delay)
+        return original_send(
+            connection,
+            command,
+            check_health=check_health,
+        )
+
+    samples = {'ordinary': [], 'batched': []}
+    client = redis.Redis.from_url(args.url)
+    with Connection(args.url) as connection:
+        with connection.channel() as channel:
+            producer = Producer(channel, serializer='json')
+
+            def run(mode):
+                client.delete(queue)
+                context = (
+                    producer.batch(max_size=args.max_size)
+                    if mode == 'batched'
+                    else nullcontext()
+                )
+                started = time.perf_counter()
+                with patch.object(
+                    redis.connection.Connection,
+                    'send_packed_command',
+                    delayed_send,
+                ):
+                    with context:
+                        for index in range(args.messages):
+                            producer.publish(
+                                {'index': index},
+                                exchange='',
+                                routing_key=queue,
+                            )
+                elapsed = time.perf_counter() - started
+                queued = client.llen(queue)
+                if queued != args.messages:
+                    raise RuntimeError(
+                        f'expected {args.messages} messages, found {queued}',
+                    )
+                return elapsed
+
+            for _ in range(args.warmups):
+                run('ordinary')
+                run('batched')
+
+            for round_number in range(args.rounds):
+                modes = (
+                    ('ordinary', 'batched')
+                    if round_number % 2 == 0
+                    else ('batched', 'ordinary')
+                )
+                for mode in modes:
+                    samples[mode].append(run(mode))
+
+            client.delete(queue)
+
+    ordinary_median = statistics.median(samples['ordinary'])
+    batched_median = statistics.median(samples['batched'])
+    return {
+        'url': args.url,
+        'messages': args.messages,
+        'simulated_latency_ms': args.latency_ms,
+        'rounds': args.rounds,
+        'max_size': args.max_size,
+        'ordinary_seconds': samples['ordinary'],
+        'batched_seconds': samples['batched'],
+        'ordinary_median_seconds': ordinary_median,
+        'batched_median_seconds': batched_median,
+        'speedup': ordinary_median / batched_median,
+    }
+
+
+def main():
+    args = parse_args()
+    validate_args(args)
+    result = benchmark(args)
+    if args.as_json:
+        print(json.dumps(result, indent=2))
+        return
+
+    print(
+        f"{result['messages']} messages, "
+        f"{result['simulated_latency_ms']:.1f} ms simulated latency, "
+        f"{result['rounds']} rounds",
+    )
+    print(
+        'ordinary median: '
+        f"{result['ordinary_median_seconds']:.4f} seconds",
+    )
+    print(
+        'batched median:  '
+        f"{result['batched_median_seconds']:.4f} seconds",
+    )
+    print(f"speedup:         {result['speedup']:.1f}x")
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/reference/kombu.exceptions.rst
+++ b/docs/reference/kombu.exceptions.rst
@@ -15,4 +15,4 @@
     .. autoexception:: LimitExceeded
     .. autoexception:: ConnectionLimitExceeded
     .. autoexception:: ChannelLimitExceeded
-
+    .. autoexception:: BatchPublishError

--- a/docs/reference/kombu.rst
+++ b/docs/reference/kombu.rst
@@ -162,7 +162,9 @@
         .. autoattribute:: auto_declare
         .. autoattribute:: on_return
         .. autoattribute:: connection
+        .. autoattribute:: supports_batch_publish
 
+        .. automethod:: batch
         .. automethod:: declare
         .. automethod:: maybe_declare
         .. automethod:: publish

--- a/docs/userguide/producers.rst
+++ b/docs/userguide/producers.rst
@@ -107,6 +107,8 @@ empty string, and set the routing key to be the name of the queue:
 Batch publishing
 ----------------
 
+.. versionadded:: 5.7
+
 :meth:`~kombu.Producer.batch` groups normal :meth:`~kombu.Producer.publish`
 calls so a supporting transport can send their final broker operations
 together:
@@ -172,7 +174,11 @@ The standard Redis, Redis TLS, and Redis Sentinel transports share this batch
 implementation. Standard Redis is covered by integration tests. TLS and
 Sentinel use the same channel implementation but are not covered by
 real-service batch integration tests. Redis Cluster is not currently an
-upstream Kombu transport and is not supported or tested by this API.
+upstream Kombu transport and is not supported or tested by this API. Redis
+publishing also remains immediate when the underlying connection pool enables
+automatic retries, including ``retry_on_timeout`` or a custom retry policy,
+because replaying a pipeline after an ambiguous failure can publish duplicate
+messages.
 
 Serialization
 =============

--- a/docs/userguide/producers.rst
+++ b/docs/userguide/producers.rst
@@ -104,6 +104,76 @@ empty string, and set the routing key to be the name of the queue:
     ...     routing_key=task_queue.name,
     ... )
 
+Batch publishing
+----------------
+
+:meth:`~kombu.Producer.batch` groups normal :meth:`~kombu.Producer.publish`
+calls so a supporting transport can send their final broker operations
+together:
+
+.. code-block:: python
+
+    with producer.batch(max_size=500) as batch:
+        producer.publish(
+            {'task': 1},
+            exchange='',
+            routing_key='tasks',
+            declare=[task_queue],
+        )
+        producer.publish(
+            {'task': 2},
+            exchange='',
+            routing_key='tasks',
+        )
+
+        # Optional: send everything accumulated so far and keep batching.
+        batch.flush()
+
+Message preparation, serialization, declarations, and routing still use the
+normal publishing path. Declarations and routing operations whose results are
+needed immediately are not buffered.
+
+The Redis transport buffers its final ``LPUSH``, ``PEXPIRE``, and ``PUBLISH``
+commands in a non-transactional redis-py pipeline. This reduces network round
+trips without making publication atomic. Commands are added in publication
+order, preserving FIFO order within each Redis priority queue.
+
+The batch has the following lifecycle:
+
+* A successful outermost context exit flushes pending operations.
+* :meth:`~kombu.Producer.batch` contexts may be nested. They share the
+  outermost context's batch and ``max_size``; an inner successful exit does
+  not flush.
+* An exception leaving any nested batch context aborts the whole batch and
+  discards operations that have not already been flushed. Operations sent by
+  an explicit or size-triggered flush cannot be rolled back.
+* An empty batch performs no transport work.
+* ``max_size`` is a positive integer and defaults to 1000. For Redis it limits
+  final Redis commands, not calls to :meth:`~kombu.Producer.publish`. One
+  publication routed to many queues is kept together and may temporarily
+  exceed this limit.
+* Transports without batch support publish immediately inside the context.
+  Check :attr:`~kombu.Producer.supports_batch_publish` when an application
+  requires actual deferred publication.
+
+A Redis pipeline failure raises
+:exc:`~kombu.exceptions.BatchPublishError`. If the response to
+``pipeline.execute()`` is lost, Redis may have accepted none, some, or all of
+the commands. Kombu therefore does not automatically replay the batch, even
+when individual calls used ``retry=True``. Applications may retry explicitly
+when at-least-once publication and possible duplicates are acceptable.
+
+``max_size`` bounds memory use. Batch contexts do not start a timer or a
+background flush; long-running producers should call ``batch.flush()`` at
+their own time boundary. Use the Redis ``socket_timeout`` transport option to
+bound how long a pipeline network operation may block.
+
+The standard Redis, Redis TLS, and Redis Sentinel transports share this batch
+implementation. Standard Redis is covered by integration tests. TLS and
+Sentinel use the same channel implementation but are not covered by
+real-service batch integration tests. Redis Cluster is not currently an
+upstream Kombu transport and is not supported or tested by this API.
+
 Serialization
 =============
 

--- a/kombu/exceptions.py
+++ b/kombu/exceptions.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from kombu.asynchronous.http import Response
 
 __all__ = (
-    'reraise', 'KombuError', 'OperationalError',
+    'reraise', 'KombuError', 'OperationalError', 'BatchPublishError',
     'NotBoundError', 'MessageStateError', 'TimeoutError',
     'LimitExceeded', 'ConnectionLimitExceeded',
     'ChannelLimitExceeded', 'ConnectionError', 'ChannelError',
@@ -41,6 +41,10 @@ class KombuError(Exception):
 
 class OperationalError(KombuError):
     """Recoverable message transport connection error."""
+
+
+class BatchPublishError(KombuError):
+    """Batch publication failed with an uncertain delivery outcome."""
 
 
 class SerializationError(KombuError):

--- a/kombu/messaging.py
+++ b/kombu/messaging.py
@@ -22,25 +22,6 @@ __all__ = ('Exchange', 'Queue', 'Producer', 'Consumer')
 DEFAULT_BATCH_SIZE = 1000
 
 
-class _ImmediatePublishBatch:
-    """Transport-neutral batch that retains immediate publication."""
-
-    def __init__(self, channel):
-        self.channel = channel
-
-    def publish(self, message, **kwargs):
-        return self.channel.basic_publish(message, **kwargs)
-
-    def flush(self):
-        """Flush buffered messages (there are none)."""
-
-    def discard(self):
-        """Discard buffered messages (there are none)."""
-
-    def close(self):
-        """Release batch resources (there are none)."""
-
-
 class _ProducerBatchState:
     """State shared by nested batch contexts in one producer thread."""
 
@@ -48,15 +29,18 @@ class _ProducerBatchState:
         self.max_size = max_size
         self.aborted = False
         self.session = None
+        self.immediate = False
 
     def _get_session(self, channel):
+        if self.immediate:
+            return None
         if self.session is None:
             create_batch = getattr(channel, 'create_publish_batch', None)
-            self.session = (
-                create_batch(max_size=self.max_size)
-                if create_batch is not None
-                else _ImmediatePublishBatch(channel)
-            )
+            supports_batch = getattr(channel, 'supports_batch_publish', True)
+            if create_batch is None or not supports_batch:
+                self.immediate = True
+                return None
+            self.session = create_batch(max_size=self.max_size)
         elif self.session.channel is not channel:
             raise RuntimeError(
                 'Producer channel changed while a publish batch was active',
@@ -66,7 +50,10 @@ class _ProducerBatchState:
     def publish(self, channel, message, **kwargs):
         if self.aborted:
             raise RuntimeError('Cannot publish through an aborted batch')
-        return self._get_session(channel).publish(message, **kwargs)
+        session = self._get_session(channel)
+        if session is None:
+            return channel.basic_publish(message, **kwargs)
+        return session.publish(message, **kwargs)
 
     def flush(self):
         if self.aborted:
@@ -116,19 +103,33 @@ class _ProducerBatch:
         if state is None:
             return None
 
+        cleanup_error = None
         try:
-            if exc_type is not None:
-                state.abort()
-
             if self.is_outermost:
                 del self.producer._batch_local.current
+
+            if exc_type is not None:
                 try:
-                    if exc_type is None and not state.aborted:
+                    state.abort()
+                except BaseException as exc:
+                    cleanup_error = exc
+
+            if self.is_outermost:
+                if exc_type is None and not state.aborted:
+                    try:
                         state.flush()
-                finally:
+                    except BaseException as exc:
+                        cleanup_error = exc
+                try:
                     state.close()
+                except BaseException as exc:
+                    if cleanup_error is None:
+                        cleanup_error = exc
         finally:
             self.active = False
+
+        if exc_type is None and cleanup_error is not None:
+            raise cleanup_error
         return None
 
     def flush(self):
@@ -233,9 +234,23 @@ class Producer:
         if connection is None:
             return False
         try:
-            return connection.transport.implements.batch_publish
+            transport_support = connection.transport.implements.batch_publish
         except AttributeError:
             return False
+        channel = self._channel
+        if channel is not None and not isinstance(channel, ChannelPromise):
+            configured_support = getattr(
+                channel,
+                'supports_batch_publish',
+                transport_support,
+            )
+        else:
+            configured_support = getattr(
+                connection.transport,
+                'supports_batch_publish',
+                transport_support,
+            )
+        return bool(transport_support and configured_support)
 
     def batch(self, max_size=DEFAULT_BATCH_SIZE):
         """Group normal :meth:`publish` calls into transport-owned batches.

--- a/kombu/messaging.py
+++ b/kombu/messaging.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from itertools import count
+from threading import local
 from typing import TYPE_CHECKING
 
 from .common import maybe_declare
@@ -17,6 +18,124 @@ if TYPE_CHECKING:
     from types import TracebackType
 
 __all__ = ('Exchange', 'Queue', 'Producer', 'Consumer')
+
+DEFAULT_BATCH_SIZE = 1000
+
+
+class _ImmediatePublishBatch:
+    """Transport-neutral batch that retains immediate publication."""
+
+    def __init__(self, channel):
+        self.channel = channel
+
+    def publish(self, message, **kwargs):
+        return self.channel.basic_publish(message, **kwargs)
+
+    def flush(self):
+        """Flush buffered messages (there are none)."""
+
+    def discard(self):
+        """Discard buffered messages (there are none)."""
+
+    def close(self):
+        """Release batch resources (there are none)."""
+
+
+class _ProducerBatchState:
+    """State shared by nested batch contexts in one producer thread."""
+
+    def __init__(self, max_size):
+        self.max_size = max_size
+        self.aborted = False
+        self.session = None
+
+    def _get_session(self, channel):
+        if self.session is None:
+            create_batch = getattr(channel, 'create_publish_batch', None)
+            self.session = (
+                create_batch(max_size=self.max_size)
+                if create_batch is not None
+                else _ImmediatePublishBatch(channel)
+            )
+        elif self.session.channel is not channel:
+            raise RuntimeError(
+                'Producer channel changed while a publish batch was active',
+            )
+        return self.session
+
+    def publish(self, channel, message, **kwargs):
+        if self.aborted:
+            raise RuntimeError('Cannot publish through an aborted batch')
+        return self._get_session(channel).publish(message, **kwargs)
+
+    def flush(self):
+        if self.aborted:
+            raise RuntimeError('Cannot flush an aborted batch')
+        if self.session is not None:
+            self.session.flush()
+
+    def abort(self):
+        if self.aborted:
+            return
+        self.aborted = True
+        if self.session is not None:
+            self.session.discard()
+
+    def close(self):
+        if self.session is not None:
+            self.session.close()
+
+
+class _ProducerBatch:
+    """Context manager returned by :meth:`Producer.batch`."""
+
+    def __init__(self, producer, max_size):
+        self.producer = producer
+        self.max_size = max_size
+        self.state = None
+        self.is_outermost = False
+        self.entered = False
+        self.active = False
+
+    def __enter__(self):
+        if self.entered:
+            raise RuntimeError('Publish batch context cannot be re-entered')
+        self.entered = True
+        self.active = True
+
+        state = getattr(self.producer._batch_local, 'current', None)
+        if state is None:
+            state = _ProducerBatchState(self.max_size)
+            self.producer._batch_local.current = state
+            self.is_outermost = True
+        self.state = state
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        state = self.state
+        if state is None:
+            return None
+
+        try:
+            if exc_type is not None:
+                state.abort()
+
+            if self.is_outermost:
+                del self.producer._batch_local.current
+                try:
+                    if exc_type is None and not state.aborted:
+                        state.flush()
+                finally:
+                    state.close()
+        finally:
+            self.active = False
+        return None
+
+    def flush(self):
+        """Flush messages buffered by the active batch."""
+        if not self.active:
+            raise RuntimeError('Publish batch context is not active')
+        self.state.flush()
 
 
 class Producer:
@@ -72,6 +191,7 @@ class Producer:
         self.compression = compression or self.compression
         self.on_return = on_return or self.on_return
         self._channel_promise = None
+        self._batch_local = local()
         if self.exchange is None:
             self.exchange = Exchange('')
         if auto_declare is not None:
@@ -105,6 +225,33 @@ class Producer:
         """Declare exchange if not already declared during this session."""
         if entity:
             return maybe_declare(entity, self.channel, retry, **retry_policy)
+
+    @property
+    def supports_batch_publish(self):
+        """Return whether the active transport can defer batched publishes."""
+        connection = self.connection
+        if connection is None:
+            return False
+        try:
+            return connection.transport.implements.batch_publish
+        except AttributeError:
+            return False
+
+    def batch(self, max_size=DEFAULT_BATCH_SIZE):
+        """Group normal :meth:`publish` calls into transport-owned batches.
+
+        Unsupported transports retain immediate publication.  A successful
+        outermost context exit flushes pending messages; an exceptional exit
+        discards messages that have not already been flushed.
+
+        :param max_size: Maximum transport operations to buffer before an
+            automatic flush. Must be a positive integer.
+        :type max_size: int
+        """
+        if (isinstance(max_size, bool) or
+                not isinstance(max_size, int) or max_size <= 0):
+            raise ValueError('max_size must be a positive integer')
+        return _ProducerBatch(self, max_size)
 
     def _delivery_details(self, exchange, delivery_mode=None,
                           maybe_delivery_mode=maybe_delivery_mode,
@@ -211,12 +358,18 @@ class Producer:
         reply_to = properties.get('reply_to')
         if isinstance(reply_to, Queue):
             properties['reply_to'] = reply_to.name
-        return channel.basic_publish(
-            message,
-            exchange=exchange, routing_key=routing_key,
-            mandatory=mandatory, immediate=immediate,
-            timeout=timeout, confirm_timeout=confirm_timeout
-        )
+        publish_kwargs = {
+            'exchange': exchange,
+            'routing_key': routing_key,
+            'mandatory': mandatory,
+            'immediate': immediate,
+            'timeout': timeout,
+            'confirm_timeout': confirm_timeout,
+        }
+        batch = getattr(self._batch_local, 'current', None)
+        if batch is not None:
+            return batch.publish(channel, message, **publish_kwargs)
+        return channel.basic_publish(message, **publish_kwargs)
 
     def _get_channel(self):
         channel = self._channel

--- a/kombu/transport/base.py
+++ b/kombu/transport/base.py
@@ -145,6 +145,7 @@ class Implements(dict):
 
 default_transport_capabilities = Implements(
     asynchronous=False,
+    batch_publish=False,
     exchange_type=frozenset(['direct', 'topic', 'fanout', 'headers']),
     heartbeats=False,
 )

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -787,7 +787,7 @@ class PublishBatch:
             raise RuntimeError('Redis publish batch is aborted')
         if self._failed is not None:
             raise BatchPublishError(
-                'Redis publish batch cannot be reused after flush failure',
+                'Redis publish batch cannot be reused after a previous failure',
             ) from self._failed
 
 

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -83,7 +83,7 @@ import numbers
 import socket
 from bisect import bisect
 from collections import namedtuple
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from importlib.metadata import version
 from queue import Empty
 from time import time
@@ -91,7 +91,8 @@ from time import time
 from packaging.version import Version
 from vine import promise
 
-from kombu.exceptions import InconsistencyError, VersionMismatch
+from kombu.exceptions import (BatchPublishError, InconsistencyError,
+                              VersionMismatch)
 from kombu.log import get_logger
 from kombu.transport.base import to_rabbitmq_queue_arguments
 from kombu.utils import symbol_by_name
@@ -692,6 +693,104 @@ class MultiChannelPoller:
         return self._fd_to_chan
 
 
+class PublishBatch:
+    """Buffer Redis publish commands in a non-transactional pipeline."""
+
+    def __init__(self, channel, max_size):
+        self.channel = channel
+        self.max_size = max_size
+        self._buffered = 0
+        self._collecting = None
+        self._failed = None
+        self._aborted = False
+        self._closed = False
+        self._stack = ExitStack()
+        try:
+            client = self._stack.enter_context(channel.conn_or_acquire())
+            self.pipeline = self._stack.enter_context(
+                client.pipeline(transaction=False),
+            )
+        except BaseException:
+            self._stack.close()
+            raise
+
+    def publish(self, message, **kwargs):
+        """Route one prepared message and buffer its final Redis commands."""
+        self._check_usable()
+        commands = []
+        self._collecting = commands
+        try:
+            result = self.channel.basic_publish(
+                message,
+                _publish_batch=self,
+                **kwargs,
+            )
+        finally:
+            self._collecting = None
+
+        if commands:
+            if self._buffered and self._buffered + len(commands) > self.max_size:
+                self.flush()
+            try:
+                for name, args in commands:
+                    getattr(self.pipeline, name)(*args)
+            except BaseException as exc:
+                self._failed = exc
+                self._buffered = 0
+                self.pipeline.reset()
+                raise
+            self._buffered += len(commands)
+            if self._buffered >= self.max_size:
+                self.flush()
+        return result
+
+    def add(self, name, *args):
+        """Add one final Redis command for the message being routed."""
+        if self._collecting is None:
+            raise RuntimeError('Redis publish command added outside publication')
+        self._collecting.append((name, args))
+
+    def flush(self):
+        """Execute all pending Redis commands once, without automatic retry."""
+        self._check_usable()
+        if not self._buffered:
+            return
+        try:
+            self.pipeline.execute()
+        except BaseException as exc:
+            self._failed = exc
+            self._buffered = 0
+            self.pipeline.reset()
+            if isinstance(exc, Exception):
+                raise BatchPublishError(
+                    'Redis publish batch failed; delivery is uncertain',
+                ) from exc
+            raise
+        self._buffered = 0
+
+    def discard(self):
+        """Discard commands that have not already been executed."""
+        self._aborted = True
+        self._buffered = 0
+        self.pipeline.reset()
+
+    def close(self):
+        """Reset the pipeline and release its resources."""
+        if not self._closed:
+            self._closed = True
+            self._stack.close()
+
+    def _check_usable(self):
+        if self._closed:
+            raise RuntimeError('Redis publish batch is closed')
+        if self._aborted:
+            raise RuntimeError('Redis publish batch is aborted')
+        if self._failed is not None:
+            raise BatchPublishError(
+                'Redis publish batch cannot be reused after flush failure',
+            ) from self._failed
+
+
 class Channel(virtual.Channel):
     """Redis Channel."""
 
@@ -1260,10 +1359,26 @@ class Channel(virtual.Channel):
         steps = self.priority_steps
         return steps[bisect(steps, n) - 1]
 
+    def create_publish_batch(self, max_size):
+        """Create a producer-scoped Redis publish batch."""
+        return PublishBatch(self, max_size)
+
     def _put(self, queue, message, **kwargs):
         """Deliver message."""
         pri = self._get_message_priority(message, reverse=False)
         key = self._q_for_pri(queue, pri)
+        publish_batch = kwargs.pop('_publish_batch', None)
+
+        if publish_batch is not None:
+            publish_batch.add('lpush', key, dumps(message))
+            if self._expires and queue in self._expires:
+                for p in self.priority_steps:
+                    publish_batch.add(
+                        'pexpire',
+                        self._q_for_pri(queue, p),
+                        self._expires[queue],
+                    )
+            return
 
         with self.conn_or_acquire() as client:
             if self._expires and queue in self._expires:
@@ -1277,11 +1392,14 @@ class Channel(virtual.Channel):
 
     def _put_fanout(self, exchange, message, routing_key, **kwargs):
         """Deliver fanout message."""
+        publish_batch = kwargs.pop('_publish_batch', None)
+        topic = self._get_publish_topic(exchange, routing_key)
+        payload = dumps(message)
+        if publish_batch is not None:
+            publish_batch.add('publish', topic, payload)
+            return
         with self.conn_or_acquire() as client:
-            client.publish(
-                self._get_publish_topic(exchange, routing_key),
-                dumps(message),
-            )
+            client.publish(topic, payload)
 
     def _new_queue(self, queue, auto_delete=False, **kwargs):
         if auto_delete:
@@ -1630,7 +1748,8 @@ class Transport(virtual.Transport):
 
     implements = virtual.Transport.implements.extend(
         asynchronous=True,
-        exchange_type=frozenset(['direct', 'topic', 'fanout'])
+        batch_publish=True,
+        exchange_type=frozenset(['direct', 'topic', 'fanout']),
     )
 
     if redis:

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -69,7 +69,7 @@ import numbers
 import socket
 from bisect import bisect
 from collections import namedtuple
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from importlib.metadata import version
 from queue import Empty
 from time import time
@@ -77,7 +77,8 @@ from time import time
 from packaging.version import Version
 from vine import promise
 
-from kombu.exceptions import InconsistencyError, VersionMismatch
+from kombu.exceptions import (BatchPublishError, InconsistencyError,
+                              VersionMismatch)
 from kombu.log import get_logger
 from kombu.transport.base import to_rabbitmq_queue_arguments
 from kombu.utils import symbol_by_name
@@ -655,6 +656,104 @@ class MultiChannelPoller:
         return self._fd_to_chan
 
 
+class PublishBatch:
+    """Buffer Redis publish commands in a non-transactional pipeline."""
+
+    def __init__(self, channel, max_size):
+        self.channel = channel
+        self.max_size = max_size
+        self._buffered = 0
+        self._collecting = None
+        self._failed = None
+        self._aborted = False
+        self._closed = False
+        self._stack = ExitStack()
+        try:
+            client = self._stack.enter_context(channel.conn_or_acquire())
+            self.pipeline = self._stack.enter_context(
+                client.pipeline(transaction=False),
+            )
+        except BaseException:
+            self._stack.close()
+            raise
+
+    def publish(self, message, **kwargs):
+        """Route one prepared message and buffer its final Redis commands."""
+        self._check_usable()
+        commands = []
+        self._collecting = commands
+        try:
+            result = self.channel.basic_publish(
+                message,
+                _publish_batch=self,
+                **kwargs,
+            )
+        finally:
+            self._collecting = None
+
+        if commands:
+            if self._buffered and self._buffered + len(commands) > self.max_size:
+                self.flush()
+            try:
+                for name, args in commands:
+                    getattr(self.pipeline, name)(*args)
+            except BaseException as exc:
+                self._failed = exc
+                self._buffered = 0
+                self.pipeline.reset()
+                raise
+            self._buffered += len(commands)
+            if self._buffered >= self.max_size:
+                self.flush()
+        return result
+
+    def add(self, name, *args):
+        """Add one final Redis command for the message being routed."""
+        if self._collecting is None:
+            raise RuntimeError('Redis publish command added outside publication')
+        self._collecting.append((name, args))
+
+    def flush(self):
+        """Execute all pending Redis commands once, without automatic retry."""
+        self._check_usable()
+        if not self._buffered:
+            return
+        try:
+            self.pipeline.execute()
+        except BaseException as exc:
+            self._failed = exc
+            self._buffered = 0
+            self.pipeline.reset()
+            if isinstance(exc, Exception):
+                raise BatchPublishError(
+                    'Redis publish batch failed; delivery is uncertain',
+                ) from exc
+            raise
+        self._buffered = 0
+
+    def discard(self):
+        """Discard commands that have not already been executed."""
+        self._aborted = True
+        self._buffered = 0
+        self.pipeline.reset()
+
+    def close(self):
+        """Reset the pipeline and release its resources."""
+        if not self._closed:
+            self._closed = True
+            self._stack.close()
+
+    def _check_usable(self):
+        if self._closed:
+            raise RuntimeError('Redis publish batch is closed')
+        if self._aborted:
+            raise RuntimeError('Redis publish batch is aborted')
+        if self._failed is not None:
+            raise BatchPublishError(
+                'Redis publish batch cannot be reused after flush failure',
+            ) from self._failed
+
+
 class Channel(virtual.Channel):
     """Redis Channel."""
 
@@ -1070,10 +1169,26 @@ class Channel(virtual.Channel):
         steps = self.priority_steps
         return steps[bisect(steps, n) - 1]
 
+    def create_publish_batch(self, max_size):
+        """Create a producer-scoped Redis publish batch."""
+        return PublishBatch(self, max_size)
+
     def _put(self, queue, message, **kwargs):
         """Deliver message."""
         pri = self._get_message_priority(message, reverse=False)
         key = self._q_for_pri(queue, pri)
+        publish_batch = kwargs.pop('_publish_batch', None)
+
+        if publish_batch is not None:
+            publish_batch.add('lpush', key, dumps(message))
+            if self._expires and queue in self._expires:
+                for p in self.priority_steps:
+                    publish_batch.add(
+                        'pexpire',
+                        self._q_for_pri(queue, p),
+                        self._expires[queue],
+                    )
+            return
 
         with self.conn_or_acquire() as client:
             if self._expires and queue in self._expires:
@@ -1087,11 +1202,14 @@ class Channel(virtual.Channel):
 
     def _put_fanout(self, exchange, message, routing_key, **kwargs):
         """Deliver fanout message."""
+        publish_batch = kwargs.pop('_publish_batch', None)
+        topic = self._get_publish_topic(exchange, routing_key)
+        payload = dumps(message)
+        if publish_batch is not None:
+            publish_batch.add('publish', topic, payload)
+            return
         with self.conn_or_acquire() as client:
-            client.publish(
-                self._get_publish_topic(exchange, routing_key),
-                dumps(message),
-            )
+            client.publish(topic, payload)
 
     def _new_queue(self, queue, auto_delete=False, **kwargs):
         if auto_delete:
@@ -1440,7 +1558,8 @@ class Transport(virtual.Transport):
 
     implements = virtual.Transport.implements.extend(
         asynchronous=True,
-        exchange_type=frozenset(['direct', 'topic', 'fanout'])
+        batch_publish=True,
+        exchange_type=frozenset(['direct', 'topic', 'fanout']),
     )
 
     if redis:

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -693,6 +693,15 @@ class MultiChannelPoller:
         return self._fd_to_chan
 
 
+def _batch_publish_retry_safe(connection_kwargs):
+    """Return whether Redis will execute a pipeline without retrying it."""
+    return not (
+        connection_kwargs.get('retry_on_timeout')
+        or connection_kwargs.get('retry_on_error')
+        or connection_kwargs.get('retry') is not None
+    )
+
+
 class PublishBatch:
     """Buffer Redis publish commands in a non-transactional pipeline."""
 
@@ -832,6 +841,14 @@ class Channel(virtual.Channel):
     max_connections = 10
     health_check_interval = DEFAULT_HEALTH_CHECK_INTERVAL
     client_name = None
+
+    @property
+    def supports_batch_publish(self):
+        """Return whether pipelines can run without ambiguous write replay."""
+        return (
+            not self.retry_on_timeout
+            and _batch_publish_retry_safe(self.pool.connection_kwargs)
+        )
     #: Transport option to disable fanout keyprefix.
     #: Can also be string, in which case it changes the default
     #: prefix ('/{db}.') into to something else.  The prefix must
@@ -1751,6 +1768,17 @@ class Transport(virtual.Transport):
         batch_publish=True,
         exchange_type=frozenset(['direct', 'topic', 'fanout']),
     )
+
+    @property
+    def supports_batch_publish(self):
+        """Return whether configured timeout handling permits safe batching."""
+        if not _batch_publish_retry_safe(self.client.transport_options):
+            return False
+        hostname = self.client.hostname or ''
+        if '://' not in hostname:
+            return True
+        *_, query = _parse_url(hostname)
+        return _batch_publish_retry_safe(query)
 
     if redis:
         connection_errors, channel_errors = get_redis_error_classes()

--- a/t/integration/test_redis.py
+++ b/t/integration/test_redis.py
@@ -222,6 +222,57 @@ class test_RedisPriority(BasePriority):
 @pytest.mark.flaky(reruns=5, reruns_delay=2)
 class test_RedisPublishBatch:
 
+    def test_retry_on_timeout_keeps_publication_immediate(self, connection):
+        connection.transport_options = {
+            **connection.transport_options,
+            'retry_on_timeout': True,
+        }
+        queue = kombu.Queue('batch_retry_on_timeout_queue')
+
+        with connection as conn:
+            with conn.channel() as channel:
+                producer = kombu.Producer(channel, serializer='json')
+
+                assert producer.supports_batch_publish is False
+                with producer.batch():
+                    producer.publish(
+                        {'delivery': 'immediate'},
+                        exchange='',
+                        routing_key=queue.name,
+                        declare=[queue],
+                    )
+                    message = queue(channel).get(no_ack=True)
+
+        assert message.payload == {'delivery': 'immediate'}
+
+    def test_manual_flush_sends_and_batch_continues(self, connection):
+        queue = kombu.Queue('batch_manual_flush_queue')
+
+        with connection as conn:
+            with conn.channel() as channel:
+                producer = kombu.Producer(channel, serializer='json')
+                bound_queue = queue(channel)
+
+                with producer.batch() as batch:
+                    producer.publish(
+                        {'position': 'first'},
+                        exchange='',
+                        routing_key=queue.name,
+                        declare=[queue],
+                    )
+                    batch.flush()
+                    first = bound_queue.get(no_ack=True)
+                    producer.publish(
+                        {'position': 'second'},
+                        exchange='',
+                        routing_key=queue.name,
+                    )
+
+                second = bound_queue.get(no_ack=True)
+
+        assert first.payload == {'position': 'first'}
+        assert second.payload == {'position': 'second'}
+
     def test_direct_priority_and_fifo(self, connection):
         exchange = kombu.Exchange('batch_direct_exchange', type='direct')
         queue = kombu.Queue(

--- a/t/integration/test_redis.py
+++ b/t/integration/test_redis.py
@@ -9,6 +9,7 @@ import redis
 
 import kombu
 from kombu.transport.redis import Transport
+from kombu.utils.json import loads
 
 from .common import (BaseExchangeTypes, BaseMessage, BasePriority,
                      BasicFunctionality)
@@ -215,6 +216,120 @@ class test_RedisPriority(BasePriority):
                 assert received_message_bodies[1] == {'msg': 'second'}
                 assert received_message_bodies[2] == {'msg': 'first'}
                 assert received_message_bodies[3] == {'msg': 'third'}
+
+
+@pytest.mark.env('redis')
+@pytest.mark.flaky(reruns=5, reruns_delay=2)
+class test_RedisPublishBatch:
+
+    def test_direct_priority_and_fifo(self, connection):
+        exchange = kombu.Exchange('batch_direct_exchange', type='direct')
+        queue = kombu.Queue(
+            'batch_direct_queue',
+            exchange=exchange,
+            routing_key='batch.direct',
+            max_priority=10,
+        )
+
+        with connection as conn:
+            with conn.channel() as channel:
+                producer = kombu.Producer(channel)
+                with producer.batch():
+                    for body, priority in [
+                        ({'position': 'first'}, 6),
+                        ({'position': 'second'}, 3),
+                        ({'position': 'third'}, 6),
+                    ]:
+                        producer.publish(
+                            body,
+                            exchange=exchange,
+                            routing_key='batch.direct',
+                            declare=[queue],
+                            serializer='json',
+                            priority=priority,
+                        )
+
+                bound_queue = queue(channel)
+                received = [
+                    bound_queue.get(no_ack=True).payload
+                    for _ in range(3)
+                ]
+
+        assert received == [
+            {'position': 'second'},
+            {'position': 'first'},
+            {'position': 'third'},
+        ]
+
+    def test_topic_routing(self, connection):
+        exchange = kombu.Exchange('batch_topic_exchange', type='topic')
+        queue = kombu.Queue(
+            'batch_topic_queue',
+            exchange=exchange,
+            routing_key='events.*',
+        )
+
+        with connection as conn:
+            with conn.channel() as channel:
+                producer = kombu.Producer(channel)
+                with producer.batch():
+                    producer.publish(
+                        {'event': 'matching'},
+                        exchange=exchange,
+                        routing_key='events.created',
+                        declare=[queue],
+                        serializer='json',
+                    )
+                    producer.publish(
+                        {'event': 'other'},
+                        exchange=exchange,
+                        routing_key='other.created',
+                        serializer='json',
+                    )
+
+                bound_queue = queue(channel)
+                message = bound_queue.get(no_ack=True)
+                assert message.payload == {'event': 'matching'}
+                assert bound_queue.get(no_ack=True) is None
+
+    def test_fanout_is_deferred_until_flush(self, connection, redis_client):
+        exchange = kombu.Exchange('batch_fanout_exchange', type='fanout')
+
+        with connection as conn:
+            with conn.channel() as channel:
+                channel.pool
+                topic = channel._get_publish_topic(
+                    exchange.name,
+                    'worker.created',
+                )
+                keyprefix = connection.transport_options.get(
+                    'global_keyprefix',
+                    '',
+                )
+                with redis_client.pubsub() as subscriber:
+                    subscriber.subscribe(f'{keyprefix}{topic}')
+                    subscribed = subscriber.get_message(timeout=1)
+                    assert subscribed['type'] == 'subscribe'
+
+                    producer = kombu.Producer(channel)
+                    with producer.batch():
+                        producer.publish(
+                            {'event': 'fanout'},
+                            exchange=exchange,
+                            routing_key='worker.created',
+                            declare=[exchange],
+                            serializer='json',
+                        )
+                        assert subscriber.get_message(timeout=0.05) is None
+
+                    published = subscriber.get_message(timeout=1)
+
+        assert published['type'] == 'message'
+        message = loads(published['data'])
+        assert message['properties']['delivery_info'] == {
+            'exchange': exchange.name,
+            'routing_key': 'worker.created',
+        }
 
 
 @pytest.mark.env('redis')

--- a/t/unit/test_messaging.py
+++ b/t/unit/test_messaging.py
@@ -25,6 +25,8 @@ class RecordingPublishBatch:
         self.discard_count = 0
         self.close_count = 0
         self.flush_error = None
+        self.discard_error = None
+        self.close_error = None
 
     def publish(self, message, **kwargs):
         self.published.append((message, kwargs))
@@ -41,9 +43,13 @@ class RecordingPublishBatch:
     def discard(self):
         self.discard_count += 1
         self.pending = 0
+        if self.discard_error is not None:
+            raise self.discard_error
 
     def close(self):
         self.close_count += 1
+        if self.close_error is not None:
+            raise self.close_error
 
 
 class test_Producer:
@@ -322,6 +328,20 @@ class test_Producer:
         assert result[0]['body'] == '{"message": 1}'
         assert producer.supports_batch_publish is False
 
+    def test_unsupported_batch_tracks_a_revived_channel(self):
+        first_channel = self.connection.channel()
+        second_channel = self.connection.channel()
+        producer = Producer(first_channel, serializer='json')
+
+        with producer.batch():
+            producer.publish({'channel': 'first'})
+            producer.revive(second_channel)
+            result = producer.publish({'channel': 'second'})
+
+        assert 'basic_publish' in first_channel
+        assert 'basic_publish' in second_channel
+        assert result[0]['body'] == '{"channel": "second"}'
+
     def test_batch_successful_exit_flushes(self):
         channel = self.connection.channel()
         sessions = []
@@ -368,6 +388,14 @@ class test_Producer:
         with pytest.raises(RuntimeError, match='not active'):
             batch.flush()
 
+    def test_batch_context_cannot_be_reentered(self):
+        producer = Producer(self.connection.channel())
+        batch = producer.batch()
+
+        with batch:
+            with pytest.raises(RuntimeError, match='cannot be re-entered'):
+                batch.__enter__()
+
     def test_empty_batch_does_not_create_transport_session(self):
         channel = self.connection.channel()
         channel.create_publish_batch = Mock()
@@ -393,6 +421,23 @@ class test_Producer:
         channel.create_publish_batch.assert_called_once_with(max_size=10)
         assert session.flush_count == 1
 
+    def test_supported_batch_fails_closed_after_channel_revival(self):
+        first_channel = self.connection.channel()
+        second_channel = self.connection.channel()
+        session = RecordingPublishBatch(first_channel, 1000)
+        first_channel.create_publish_batch = Mock(return_value=session)
+        producer = Producer(first_channel, serializer='json')
+
+        with pytest.raises(RuntimeError, match='channel changed'):
+            with producer.batch():
+                producer.publish({'channel': 'first'})
+                producer.revive(second_channel)
+                producer.publish({'channel': 'second'})
+
+        assert session.discard_count == 1
+        assert session.close_count == 1
+        assert 'basic_publish' not in second_channel
+
     def test_batch_exception_discards_and_restores_producer(self):
         channel = self.connection.channel()
         session = RecordingPublishBatch(channel, 1000)
@@ -408,6 +453,24 @@ class test_Producer:
         assert session.flush_count == 0
         assert session.close_count == 1
 
+        producer.publish({'message': 2})
+        assert 'basic_publish' in channel
+
+    def test_batch_body_error_survives_discard_and_close_errors(self):
+        channel = self.connection.channel()
+        session = RecordingPublishBatch(channel, 1000)
+        session.discard_error = RuntimeError('discard failed')
+        session.close_error = RuntimeError('close failed')
+        channel.create_publish_batch = Mock(return_value=session)
+        producer = Producer(channel, serializer='json')
+
+        with pytest.raises(ValueError, match='body failed'):
+            with producer.batch():
+                producer.publish({'message': 1})
+                raise ValueError('body failed')
+
+        assert session.discard_count == 1
+        assert session.close_count == 1
         producer.publish({'message': 2})
         assert 'basic_publish' in channel
 
@@ -476,6 +539,22 @@ class test_Producer:
         producer = Producer(channel, serializer='json')
 
         with pytest.raises(RuntimeError, match='broker response lost'):
+            with producer.batch():
+                producer.publish({'message': 1})
+
+        assert session.close_count == 1
+        producer.publish({'message': 2})
+        assert 'basic_publish' in channel
+
+    def test_batch_flush_error_survives_close_error(self):
+        channel = self.connection.channel()
+        session = RecordingPublishBatch(channel, 1000)
+        session.flush_error = ValueError('flush failed')
+        session.close_error = RuntimeError('close failed')
+        channel.create_publish_batch = Mock(return_value=session)
+        producer = Producer(channel, serializer='json')
+
+        with pytest.raises(ValueError, match='flush failed'):
             with producer.batch():
                 producer.publish({'message': 1})
 

--- a/t/unit/test_messaging.py
+++ b/t/unit/test_messaging.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pickle
 import sys
+import threading
 from collections import defaultdict
 from unittest.mock import ANY, Mock, patch
 
@@ -12,6 +13,37 @@ from kombu.exceptions import MessageStateError, OperationalError
 from kombu.utils import json
 from kombu.utils.functional import ChannelPromise
 from t.mocks import Transport
+
+
+class RecordingPublishBatch:
+    def __init__(self, channel, max_size):
+        self.channel = channel
+        self.max_size = max_size
+        self.published = []
+        self.pending = 0
+        self.flush_count = 0
+        self.discard_count = 0
+        self.close_count = 0
+        self.flush_error = None
+
+    def publish(self, message, **kwargs):
+        self.published.append((message, kwargs))
+        self.pending += 1
+        return 'buffered'
+
+    def flush(self):
+        if self.flush_error is not None:
+            raise self.flush_error
+        if self.pending:
+            self.flush_count += 1
+            self.pending = 0
+
+    def discard(self):
+        self.discard_count += 1
+        self.pending = 0
+
+    def close(self):
+        self.close_count += 1
 
 
 class test_Producer:
@@ -277,6 +309,258 @@ class test_Producer:
         assert m['properties']['delivery_mode'] == 2
         assert exc == p.exchange.name
         assert rkey == 'process'
+
+    def test_batch_unsupported_transport_publishes_immediately(self):
+        channel = self.connection.channel()
+        producer = Producer(channel, serializer='json')
+
+        with producer.batch() as batch:
+            result = producer.publish({'message': 1})
+            batch.flush()
+            assert 'basic_publish' in channel
+
+        assert result[0]['body'] == '{"message": 1}'
+        assert producer.supports_batch_publish is False
+
+    def test_batch_successful_exit_flushes(self):
+        channel = self.connection.channel()
+        sessions = []
+
+        def create_publish_batch(max_size):
+            session = RecordingPublishBatch(channel, max_size)
+            sessions.append(session)
+            return session
+
+        channel.create_publish_batch = create_publish_batch
+        producer = Producer(channel, serializer='json')
+
+        with producer.batch(max_size=7):
+            assert producer.publish({'message': 1}) == 'buffered'
+            assert producer.publish({'message': 2}) == 'buffered'
+            assert sessions[0].flush_count == 0
+
+        assert sessions[0].max_size == 7
+        assert sessions[0].flush_count == 1
+        assert sessions[0].close_count == 1
+        assert 'basic_publish' not in channel
+
+    def test_batch_explicit_flush_and_continue(self):
+        channel = self.connection.channel()
+        session = RecordingPublishBatch(channel, 1000)
+        channel.create_publish_batch = lambda max_size: session
+        producer = Producer(channel, serializer='json')
+
+        with producer.batch() as batch:
+            producer.publish({'message': 1})
+            batch.flush()
+            producer.publish({'message': 2})
+
+        assert session.flush_count == 2
+
+    def test_batch_flush_requires_active_context(self):
+        producer = Producer(self.connection.channel())
+        batch = producer.batch()
+
+        with pytest.raises(RuntimeError, match='not active'):
+            batch.flush()
+        with batch:
+            batch.flush()
+        with pytest.raises(RuntimeError, match='not active'):
+            batch.flush()
+
+    def test_empty_batch_does_not_create_transport_session(self):
+        channel = self.connection.channel()
+        channel.create_publish_batch = Mock()
+        producer = Producer(channel)
+
+        with producer.batch() as batch:
+            batch.flush()
+
+        channel.create_publish_batch.assert_not_called()
+
+    def test_nested_batches_share_session_and_outer_exit_flushes(self):
+        channel = self.connection.channel()
+        session = RecordingPublishBatch(channel, 10)
+        channel.create_publish_batch = Mock(return_value=session)
+        producer = Producer(channel, serializer='json')
+
+        with producer.batch(max_size=10):
+            producer.publish({'message': 1})
+            with producer.batch(max_size=1):
+                producer.publish({'message': 2})
+            assert session.flush_count == 0
+
+        channel.create_publish_batch.assert_called_once_with(max_size=10)
+        assert session.flush_count == 1
+
+    def test_batch_exception_discards_and_restores_producer(self):
+        channel = self.connection.channel()
+        session = RecordingPublishBatch(channel, 1000)
+        channel.create_publish_batch = Mock(return_value=session)
+        producer = Producer(channel, serializer='json')
+
+        with pytest.raises(ValueError, match='message construction failed'):
+            with producer.batch():
+                producer.publish({'message': 1})
+                raise ValueError('message construction failed')
+
+        assert session.discard_count == 1
+        assert session.flush_count == 0
+        assert session.close_count == 1
+
+        producer.publish({'message': 2})
+        assert 'basic_publish' in channel
+
+    def test_message_serialization_failure_does_not_create_session(self):
+        channel = self.connection.channel()
+        channel.create_publish_batch = Mock()
+        producer = Producer(channel)
+
+        with pytest.raises(Exception):
+            with producer.batch():
+                producer.publish(object(), serializer='missing-serializer')
+
+        channel.create_publish_batch.assert_not_called()
+
+    def test_declaration_failure_does_not_create_session(self):
+        channel = self.connection.channel()
+        channel.create_publish_batch = Mock()
+        producer = Producer(channel, serializer='json')
+        producer.maybe_declare = Mock(
+            side_effect=RuntimeError('declaration failed'),
+        )
+
+        with pytest.raises(RuntimeError, match='declaration failed'):
+            with producer.batch():
+                producer.publish({'message': 1}, declare=[Mock()])
+
+        channel.create_publish_batch.assert_not_called()
+
+    def test_inner_exception_aborts_nested_batch(self):
+        channel = self.connection.channel()
+        session = RecordingPublishBatch(channel, 1000)
+        channel.create_publish_batch = Mock(return_value=session)
+        producer = Producer(channel, serializer='json')
+
+        with producer.batch():
+            producer.publish({'message': 1})
+            with pytest.raises(ValueError):
+                with producer.batch():
+                    raise ValueError('stop nested batch')
+            with pytest.raises(RuntimeError, match='aborted batch'):
+                producer.publish({'message': 2})
+
+        assert session.discard_count == 1
+        assert session.flush_count == 0
+
+    def test_propagated_nested_exception_discards_once(self):
+        channel = self.connection.channel()
+        session = RecordingPublishBatch(channel, 1000)
+        channel.create_publish_batch = Mock(return_value=session)
+        producer = Producer(channel, serializer='json')
+
+        with pytest.raises(ValueError):
+            with producer.batch():
+                producer.publish({'message': 1})
+                with producer.batch():
+                    raise ValueError('stop nested batch')
+
+        assert session.discard_count == 1
+        assert session.close_count == 1
+
+    def test_flush_failure_cleans_up_batch_state(self):
+        channel = self.connection.channel()
+        session = RecordingPublishBatch(channel, 1000)
+        session.flush_error = RuntimeError('broker response lost')
+        channel.create_publish_batch = Mock(return_value=session)
+        producer = Producer(channel, serializer='json')
+
+        with pytest.raises(RuntimeError, match='broker response lost'):
+            with producer.batch():
+                producer.publish({'message': 1})
+
+        assert session.close_count == 1
+        producer.publish({'message': 2})
+        assert 'basic_publish' in channel
+
+    def test_batch_is_scoped_to_one_producer(self):
+        channel = self.connection.channel()
+        session = RecordingPublishBatch(channel, 1000)
+        channel.create_publish_batch = Mock(return_value=session)
+        batched = Producer(channel, serializer='json')
+        immediate = Producer(channel, serializer='json')
+
+        with batched.batch():
+            batched.publish({'producer': 'batched'})
+            result = immediate.publish({'producer': 'immediate'})
+
+        assert len(session.published) == 1
+        assert result[0]['body'] == '{"producer": "immediate"}'
+        assert 'basic_publish' in channel
+
+    def test_batch_is_scoped_to_one_channel(self):
+        first_channel = self.connection.channel()
+        second_channel = self.connection.channel()
+        first_session = RecordingPublishBatch(first_channel, 1000)
+        second_session = RecordingPublishBatch(second_channel, 1000)
+        first_channel.create_publish_batch = Mock(return_value=first_session)
+        second_channel.create_publish_batch = Mock(return_value=second_session)
+        first = Producer(first_channel, serializer='json')
+        second = Producer(second_channel, serializer='json')
+
+        with first.batch():
+            first.publish({'channel': 'first'})
+            with second.batch():
+                second.publish({'channel': 'second'})
+
+        assert len(first_session.published) == 1
+        assert len(second_session.published) == 1
+        assert first_session.flush_count == second_session.flush_count == 1
+
+    def test_batch_is_scoped_to_one_thread(self):
+        channel = self.connection.channel()
+        sessions = []
+        sessions_lock = threading.Lock()
+        barrier = threading.Barrier(2)
+
+        def create_publish_batch(max_size):
+            session = RecordingPublishBatch(channel, max_size)
+            with sessions_lock:
+                sessions.append(session)
+            return session
+
+        channel.create_publish_batch = create_publish_batch
+        producer = Producer(channel, serializer='json')
+        errors = []
+
+        def publish(index):
+            try:
+                with producer.batch():
+                    producer.publish({'thread': index})
+                    barrier.wait()
+            except BaseException as exc:
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=publish, args=(index,))
+            for index in range(2)
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert not errors
+        assert len(sessions) == 2
+        assert all(len(session.published) == 1 for session in sessions)
+        assert all(session.flush_count == 1 for session in sessions)
+
+    @pytest.mark.parametrize('max_size', [0, -1, 1.5, True, None])
+    def test_batch_rejects_invalid_max_size(self, max_size):
+        producer = Producer(self.connection.channel())
+
+        with pytest.raises(ValueError, match='positive integer'):
+            producer.batch(max_size=max_size)
 
     def test_no_exchange(self):
         chan = self.connection.channel()

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -5,19 +5,20 @@ import copy
 import socket
 import types
 from collections import defaultdict
+from contextlib import contextmanager
 from itertools import count
 from queue import Empty
 from queue import Queue as _Queue
 from typing import TYPE_CHECKING
-from unittest.mock import ANY, Mock, call, patch
+from unittest.mock import ANY, MagicMock, Mock, call, patch
 
 import pytest
 
 from kombu import Connection, Consumer, Exchange, Producer, Queue
-from kombu.exceptions import VersionMismatch
+from kombu.exceptions import BatchPublishError, VersionMismatch
 from kombu.transport import virtual
 from kombu.utils import eventio  # patch poll
-from kombu.utils.json import dumps
+from kombu.utils.json import dumps, loads
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -308,6 +309,239 @@ class test_Channel:
             assert payload
             pymsg = chan.message_to_python(payload)
             return pymsg.delivery_tag
+
+    def _recording_batch_client(self):
+        client = MagicMock(wraps=self.channel._create_client())
+        pipeline = MagicMock()
+        pipeline.__enter__.return_value = pipeline
+        pipeline.__exit__.return_value = None
+        client.pipeline.return_value = pipeline
+
+        @contextmanager
+        def acquire(client=None):
+            yield client or client_instance
+
+        client_instance = client
+        self.channel.conn_or_acquire = acquire
+        return client, pipeline
+
+    def test_publish_batch_capability_is_advertised(self):
+        producer = Producer(self.channel)
+
+        assert producer.supports_batch_publish is True
+        assert self.connection.transport.implements.batch_publish is True
+
+    def test_publish_batch_uses_non_transactional_pipeline(self):
+        client, pipeline = self._recording_batch_client()
+        producer = Producer(self.channel)
+
+        with producer.batch():
+            producer.publish('message', exchange='', routing_key='batch-queue')
+
+        client.pipeline.assert_called_once_with(transaction=False)
+        pipeline.lpush.assert_called_once()
+        pipeline.execute.assert_called_once_with()
+
+    def test_publish_batch_preserves_direct_routing_priority_and_order(self):
+        exchange = Exchange('batch-direct', type='direct')
+        queue = Queue(
+            'batch-direct-queue',
+            exchange=exchange,
+            routing_key='batch.route',
+        )
+        queue(self.channel).declare()
+        _, pipeline = self._recording_batch_client()
+        producer = Producer(self.channel, serializer='json')
+
+        with producer.batch():
+            producer.publish(
+                {'position': 'first'},
+                exchange=exchange,
+                routing_key='batch.route',
+                priority=6,
+            )
+            producer.publish(
+                {'position': 'second'},
+                exchange=exchange,
+                routing_key='batch.route',
+                priority=6,
+            )
+
+        lpush_calls = [
+            method_call
+            for method_call in pipeline.method_calls
+            if method_call[0] == 'lpush'
+        ]
+        assert [method_call.args[0] for method_call in lpush_calls] == [
+            f'batch-direct-queue{self.channel.sep}6',
+            f'batch-direct-queue{self.channel.sep}6',
+        ]
+        messages = [loads(method_call.args[1]) for method_call in lpush_calls]
+        assert messages[0]['body'] != messages[1]['body']
+        assert pipeline.method_calls.index(lpush_calls[0]) < (
+            pipeline.method_calls.index(lpush_calls[1])
+        )
+
+    def test_publish_batch_preserves_topic_routing(self):
+        exchange = Exchange('batch-topic', type='topic')
+        matching = Queue(
+            'batch-topic-matching',
+            exchange=exchange,
+            routing_key='events.*',
+        )
+        other = Queue(
+            'batch-topic-other',
+            exchange=exchange,
+            routing_key='other.*',
+        )
+        matching(self.channel).declare()
+        other(self.channel).declare()
+        _, pipeline = self._recording_batch_client()
+        producer = Producer(self.channel, serializer='json')
+
+        with producer.batch():
+            producer.publish(
+                {'event': 1},
+                exchange=exchange,
+                routing_key='events.created',
+            )
+
+        pipeline.lpush.assert_called_once()
+        assert pipeline.lpush.call_args.args[0] == 'batch-topic-matching'
+
+    def test_publish_batch_preserves_fanout_topic(self):
+        exchange = Exchange('batch-fanout', type='fanout')
+        queue = Queue('batch-fanout-queue', exchange=exchange)
+        queue(self.channel).declare()
+        _, pipeline = self._recording_batch_client()
+        producer = Producer(self.channel, serializer='json')
+
+        with producer.batch():
+            producer.publish(
+                {'event': 1},
+                exchange=exchange,
+                routing_key='worker.*',
+            )
+
+        pipeline.publish.assert_called_once()
+        assert pipeline.publish.call_args.args[0] == (
+            self.channel._get_publish_topic('batch-fanout', 'worker.*')
+        )
+
+    def test_publish_batch_auto_flushes_at_max_size(self):
+        _, pipeline = self._recording_batch_client()
+        producer = Producer(self.channel, serializer='json')
+
+        with producer.batch(max_size=2):
+            for index in range(3):
+                producer.publish(
+                    {'index': index},
+                    exchange='',
+                    routing_key='batch-limit',
+                )
+
+        assert pipeline.execute.call_count == 2
+
+    def test_publish_batch_includes_queue_expiry_commands(self):
+        queue = Queue('batch-expiring', expires=5)
+        queue(self.channel).declare()
+        self.channel._expires[queue.name] = 5000
+        client, pipeline = self._recording_batch_client()
+        producer = Producer(self.channel, serializer='json')
+
+        with producer.batch():
+            producer.publish(
+                {'event': 1},
+                exchange='',
+                routing_key=queue.name,
+            )
+
+        pipeline.lpush.assert_called_once()
+        assert pipeline.pexpire.call_count == len(self.channel.priority_steps)
+        client.pipeline.assert_called_once_with(transaction=False)
+
+    def test_publish_batch_flush_failure_is_not_retried_and_cleans_up(self):
+        self.channel.queue_declare('batch-after-failure')
+        client, pipeline = self._recording_batch_client()
+        pipeline.execute.side_effect = RuntimeError('response lost')
+        producer = Producer(self.channel, serializer='json')
+
+        with pytest.raises(
+            BatchPublishError,
+            match='delivery is uncertain',
+        ) as exc_info:
+            with producer.batch():
+                producer.publish(
+                    {'event': 1},
+                    exchange='',
+                    routing_key='batch-failure',
+                )
+
+        pipeline.execute.assert_called_once_with()
+        pipeline.reset.assert_called()
+        pipeline.__exit__.assert_called_once()
+        assert str(exc_info.value.__cause__) == 'response lost'
+
+        pipeline.execute.side_effect = None
+        producer.publish(
+            {'event': 2},
+            exchange='',
+            routing_key='batch-after-failure',
+        )
+        client.lpush.assert_called_once()
+
+    def test_publish_batch_auto_flush_failure_ignores_publish_retry(self):
+        _, pipeline = self._recording_batch_client()
+        pipeline.execute.side_effect = redis.redis.ConnectionError(
+            'response lost',
+        )
+        producer = Producer(self.channel, serializer='json')
+
+        with pytest.raises(BatchPublishError, match='delivery is uncertain'):
+            with producer.batch(max_size=1):
+                producer.publish(
+                    {'event': 1},
+                    exchange='',
+                    routing_key='batch-retry',
+                    retry=True,
+                    retry_policy={'max_retries': 3},
+                )
+
+        pipeline.execute.assert_called_once_with()
+
+    def test_publish_batch_command_queueing_failure_cleans_up(self):
+        _, pipeline = self._recording_batch_client()
+        pipeline.lpush.side_effect = RuntimeError('cannot queue command')
+        producer = Producer(self.channel, serializer='json')
+
+        with pytest.raises(RuntimeError, match='cannot queue command'):
+            with producer.batch():
+                producer.publish(
+                    {'event': 1},
+                    exchange='',
+                    routing_key='batch-command-failure',
+                )
+
+        pipeline.execute.assert_not_called()
+        pipeline.reset.assert_called()
+        pipeline.__exit__.assert_called_once()
+
+    def test_sentinel_inherits_publish_batch_support(self):
+        assert issubclass(redis.SentinelChannel, redis.Channel)
+        assert redis.SentinelChannel.create_publish_batch is (
+            redis.Channel.create_publish_batch
+        )
+        assert redis.SentinelTransport.implements.batch_publish is True
+
+    def test_tls_uses_batch_capable_redis_transport(self):
+        connection = Connection('rediss://localhost:6379/0')
+        try:
+            producer = Producer(connection)
+
+            assert connection.transport.Channel is redis.Channel
+            assert producer.supports_batch_publish is True
+        finally:
+            connection.close()
 
     def test_delivery_tag_is_uuid(self):
         seen = set()

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -268,7 +268,7 @@ class Channel(redis.Channel):
         return Client
 
     def _get_pool(self, asynchronous=False):
-        return Mock()
+        return Mock(connection_kwargs={})
 
     def _get_response_error(self):
         return ResponseError
@@ -310,8 +310,9 @@ class test_Channel:
             pymsg = chan.message_to_python(payload)
             return pymsg.delivery_tag
 
-    def _recording_batch_client(self):
-        client = MagicMock(wraps=self.channel._create_client())
+    def _recording_batch_client(self, channel=None):
+        channel = channel or self.channel
+        client = MagicMock(wraps=channel._create_client())
         pipeline = MagicMock()
         pipeline.__enter__.return_value = pipeline
         pipeline.__exit__.return_value = None
@@ -322,7 +323,7 @@ class test_Channel:
             yield client or client_instance
 
         client_instance = client
-        self.channel.conn_or_acquire = acquire
+        channel.conn_or_acquire = acquire
         return client, pipeline
 
     def test_publish_batch_capability_is_advertised(self):
@@ -330,6 +331,65 @@ class test_Channel:
 
         assert producer.supports_batch_publish is True
         assert self.connection.transport.implements.batch_publish is True
+
+    def test_publish_batch_falls_back_when_redis_may_retry_timeouts(self):
+        connection = self.create_connection(
+            transport_options={'retry_on_timeout': True},
+        )
+        channel = connection.default_channel
+        channel.queue_declare('batch-retry-on-timeout')
+        client, pipeline = self._recording_batch_client(channel)
+        producer = Producer(channel)
+
+        try:
+            assert channel.retry_on_timeout is True
+            assert producer.supports_batch_publish is False
+            with producer.batch():
+                producer.publish(
+                    'message',
+                    exchange='',
+                    routing_key='batch-retry-on-timeout',
+                )
+        finally:
+            connection.close()
+
+        client.lpush.assert_called_once()
+        client.pipeline.assert_not_called()
+        pipeline.execute.assert_not_called()
+
+    def test_publish_batch_falls_back_for_socket_url_timeout_retry(self):
+        with patch('kombu.transport.redis.Channel._create_client'):
+            with Connection(
+                'redis+socket:///tmp/redis.sock?retry_on_timeout=True',
+            ) as connection:
+                lazy_producer = Producer(connection)
+                assert lazy_producer.supports_batch_publish is False
+
+                channel = connection.default_channel
+                producer = Producer(channel)
+
+                assert channel.pool.connection_kwargs[
+                    'retry_on_timeout'
+                ] == 'True'
+                assert channel.supports_batch_publish is False
+                assert producer.supports_batch_publish is False
+
+    @pytest.mark.parametrize(
+        'retry_options',
+        [
+            {'retry_on_error': [redis.redis.TimeoutError]},
+            {'retry': object()},
+        ],
+    )
+    def test_publish_batch_falls_back_for_pool_retry_policy(
+        self,
+        retry_options,
+    ):
+        self.channel._pool = Mock(connection_kwargs=retry_options)
+        producer = Producer(self.channel)
+
+        assert self.channel.supports_batch_publish is False
+        assert producer.supports_batch_publish is False
 
     def test_publish_batch_uses_non_transactional_pipeline(self):
         client, pipeline = self._recording_batch_client()
@@ -442,6 +502,38 @@ class test_Channel:
 
         assert pipeline.execute.call_count == 2
 
+    def test_publish_batch_flushes_before_multi_command_publication(self):
+        queue = Queue('batch-expiring-boundary', expires=5)
+        queue(self.channel).declare()
+        self.channel._expires[queue.name] = 5000
+        _, pipeline = self._recording_batch_client()
+        producer = Producer(self.channel, serializer='json')
+
+        with producer.batch(max_size=3):
+            producer.publish(
+                {'event': 'first'},
+                exchange='',
+                routing_key='batch-simple-boundary',
+            )
+            producer.publish(
+                {'event': 'second'},
+                exchange='',
+                routing_key=queue.name,
+            )
+
+        execute_indexes = [
+            index
+            for index, method_call in enumerate(pipeline.method_calls)
+            if method_call[0] == 'execute'
+        ]
+        lpush_indexes = [
+            index
+            for index, method_call in enumerate(pipeline.method_calls)
+            if method_call[0] == 'lpush'
+        ]
+        assert len(execute_indexes) == 2
+        assert lpush_indexes[0] < execute_indexes[0] < lpush_indexes[1]
+
     def test_publish_batch_includes_queue_expiry_commands(self):
         queue = Queue('batch-expiring', expires=5)
         queue(self.channel).declare()
@@ -525,6 +617,89 @@ class test_Channel:
         pipeline.execute.assert_not_called()
         pipeline.reset.assert_called()
         pipeline.__exit__.assert_called_once()
+
+    def test_publish_batch_creation_failure_releases_connection(self):
+        client = Mock()
+        client.pipeline.side_effect = RuntimeError('cannot create pipeline')
+        released = False
+
+        @contextmanager
+        def acquire():
+            nonlocal released
+            try:
+                yield client
+            finally:
+                released = True
+
+        self.channel.conn_or_acquire = acquire
+
+        with pytest.raises(RuntimeError, match='cannot create pipeline'):
+            redis.PublishBatch(self.channel, max_size=10)
+
+        assert released is True
+
+    def test_publish_batch_rejects_commands_outside_publication(self):
+        _, pipeline = self._recording_batch_client()
+        batch = redis.PublishBatch(self.channel, max_size=10)
+
+        try:
+            with pytest.raises(RuntimeError, match='outside publication'):
+                batch.add('lpush', 'queue', 'message')
+            pipeline.execute.assert_not_called()
+        finally:
+            batch.close()
+
+    def test_publish_batch_empty_flush_does_not_execute_pipeline(self):
+        _, pipeline = self._recording_batch_client()
+        batch = redis.PublishBatch(self.channel, max_size=10)
+
+        try:
+            batch.flush()
+            pipeline.execute.assert_not_called()
+        finally:
+            batch.close()
+
+    @pytest.mark.parametrize(
+        ('finish', 'error'),
+        [
+            ('discard', 'aborted'),
+            ('close', 'closed'),
+        ],
+    )
+    def test_publish_batch_cannot_publish_after_finish(self, finish, error):
+        self._recording_batch_client()
+        batch = redis.PublishBatch(self.channel, max_size=10)
+
+        getattr(batch, finish)()
+        with pytest.raises(RuntimeError, match=error):
+            batch.publish(
+                self.channel.prepare_message('message'),
+                exchange='',
+                routing_key='batch-finished',
+            )
+        batch.close()
+
+    def test_publish_batch_cannot_continue_after_command_queueing_failure(self):
+        _, pipeline = self._recording_batch_client()
+        pipeline.lpush.side_effect = RuntimeError('cannot queue command')
+        batch = redis.PublishBatch(self.channel, max_size=10)
+        message = self.channel.prepare_message('message')
+
+        try:
+            with pytest.raises(RuntimeError, match='cannot queue command'):
+                batch.publish(
+                    message,
+                    exchange='',
+                    routing_key='batch-failure',
+                )
+            with pytest.raises(BatchPublishError, match='previous failure'):
+                batch.publish(
+                    message,
+                    exchange='',
+                    routing_key='batch-after-failure',
+                )
+        finally:
+            batch.close()
 
     def test_sentinel_inherits_publish_batch_support(self):
         assert issubclass(redis.SentinelChannel, redis.Channel)


### PR DESCRIPTION
## Summary

Add a public, transport-neutral `Producer.batch()` context and implement it for
the Redis transport with `client.pipeline(transaction=False)`.

Normal `Producer.publish()` calls still own serialization, message preparation,
declarations, routing, queue priority selection, queue expiration, and fanout.
Only the final Redis `LPUSH`, `PEXPIRE`, and `PUBLISH` commands are deferred.
Transports that do not implement batching retain immediate publication.

This is motivated by [Apache Airflow #8854](https://github.com/apache/airflow/issues/8854).
Airflow may publish hundreds of Celery tasks in one scheduler iteration. Its
local prototype demonstrated the performance benefit, but had to replace
Kombu's private `_put()` and `_put_fanout()` methods.

## Public API

```python
with producer.batch(max_size=500) as batch:
    producer.publish(message_1, ...)
    producer.publish(message_2, ...)
    batch.flush()  # optional; the context remains usable
    producer.publish(message_3, ...)
```

- A successful outermost exit flushes pending operations.
- Nested contexts share the outer batch and its `max_size`.
- An exception leaving any nested context aborts the batch and discards
  operations that have not already been flushed.
- Empty contexts create no transport session.
- Unsupported transports publish immediately.
- `producer.supports_batch_publish` advertises actual transport support.

## Design decision

The selected design combines public `Producer.batch()` ergonomics with a
transport-owned channel session created by `create_publish_batch()`.

This keeps the API usable by Celery, which already passes a Kombu producer into
`Task.apply_async()`, while leaving broker command ownership with the transport.

Alternatives considered:

1. A producer-only implementation was rejected because the producer does not
   own Redis queue names, priority keys, wire encoding, or fanout topics.
2. Exposing only a channel/transport context was rejected because application
   callers would still need transport knowledge and Celery publishes through
   the producer API.
3. `publish_many(requests)` was rejected because it would duplicate the large
   `Producer.publish()` argument surface and force callers to construct a full
   list instead of using their existing publication loop.

## Failure semantics

Redis pipeline execution is non-transactional. If the response to
`pipeline.execute()` is lost, Redis may have accepted none, some, or all of the
commands.

Kombu raises `BatchPublishError` and does not automatically replay the batch,
including when an individual publication used `retry=True`. Applications may
start a new batch and retry explicitly when at-least-once delivery and possible
duplicates are acceptable.

`max_size` bounds buffered Redis commands. Long-running contexts can use
`batch.flush()` for an elapsed-time boundary, and Redis `socket_timeout` bounds
network blocking.

## Validation

- Full unit suite: `1611 passed, 178 skipped`
- Real Redis 8.6.1 integration suite: `64 passed`
- New real-service coverage runs with and without `global_keyprefix` and
  exercises direct routing, topic routing, priorities/FIFO, and fanout Pub/Sub.
- Pre-commit: all hooks passed, including flake8, isort, codespell, and mypy.
- Celery 5.6.3 smoke test: three `Task.apply_async(..., producer=producer)`
  calls remained deferred inside the context and all three appeared in Redis
  on successful exit.
- Non-strict Sphinx HTML build passed. The existing strict `-W` build still
  fails on unrelated warnings already present on `main`.

The included benchmark publishes 100 messages with 10 ms simulated per-request
latency over seven alternating rounds:

| Mode | Median |
| --- | ---: |
| Ordinary publication | 1.2290 s |
| Redis batch | 0.0164 s |

Observed speedup: **75.1x**.

## Compatibility

- Existing publication is unchanged unless `Producer.batch()` is used.
- Redis TLS and Sentinel share the same batch-capable channel code; their
  inheritance/capability paths have unit coverage.
- Standard Redis is covered with a real server.
- TLS and Sentinel were not tested against real services.
- Redis Cluster is not currently an upstream Kombu transport and is not
  supported or tested here.
