### PR TITLE
chore(redis): support redis 8.x

### DIFF
--- a/requirements/extras/redis.txt
+++ b/requirements/extras/redis.txt
@@ -1,2 +1,2 @@
-redis>=5.3.1,<8.0.0
+redis>=5.3.1,<9.0.0
 packaging


### PR DESCRIPTION
## Summary

Raises the `redis-py` cap from `<8.0.0` to `<9.0.0` so kombu can be installed alongside `redis-py` 8.x.

This follows the #2548 convention of increasing the cap to allow all minor and patch versions of v8.x.

No code changes are necessary for this upgrade -- all unit and integration tests passed locally with v8.0.1 and v8.1.0.

I did not change `tox.ini` to test more than one python version but am happy to add that.