### PR TITLE
fix: Queue.from_dict no longer drops queue options

### DIFF
--- a/kombu/entity.py
+++ b/kombu/entity.py
@@ -833,6 +833,12 @@ class Queue(MaybeChannelBound):
             expiring_queue = False
         return not expiring_queue and not self.auto_delete
 
+    #: Attributes handled explicitly by :meth:`from_dict`, every other
+    #: attribute in :attr:`attrs` is forwarded to :class:`Queue` as-is.
+    _from_dict_explicit_attrs = frozenset({
+        'name', 'exchange', 'routing_key', 'durable', 'auto_delete',
+    })
+
     @classmethod
     def from_dict(cls, queue, **options):
         binding_key = options.get('binding_key') or options.get('routing_key')
@@ -854,10 +860,6 @@ class Queue(MaybeChannelBound):
             q_auto_delete = options.get('auto_delete')
 
         e_arguments = options.get('exchange_arguments')
-        q_arguments = options.get('queue_arguments')
-        b_arguments = options.get('binding_arguments')
-        c_arguments = options.get('consumer_arguments')
-        bindings = options.get('bindings')
 
         exchange = Exchange(options.get('exchange'),
                             type=options.get('exchange_type'),
@@ -866,17 +868,21 @@ class Queue(MaybeChannelBound):
                             durable=e_durable,
                             auto_delete=e_auto_delete,
                             arguments=e_arguments)
+
+        # Forward every remaining Queue attribute (expires, message_ttl,
+        # max_length, max_priority, ...) so that the options declared in
+        # ``Queue.attrs`` survive an as_dict()/from_dict() round-trip.
+        kwargs = {
+            attr: options[attr]
+            for attr, _ in cls.attrs
+            if attr not in cls._from_dict_explicit_attrs and attr in options
+        }
         return Queue(queue,
                      exchange=exchange,
                      routing_key=binding_key,
                      durable=q_durable,
-                     exclusive=options.get('exclusive'),
                      auto_delete=q_auto_delete,
-                     no_ack=options.get('no_ack'),
-                     queue_arguments=q_arguments,
-                     binding_arguments=b_arguments,
-                     consumer_arguments=c_arguments,
-                     bindings=bindings)
+                     **kwargs)
 
     def as_dict(self, recurse=False):
         res = super().as_dict(recurse)

--- a/t/unit/test_entity.py
+++ b/t/unit/test_entity.py
@@ -437,6 +437,36 @@ class test_Queue:
         d = q.as_dict(recurse=True)
         assert d['exchange']['name'] == self.exchange.name
 
+    def test_as_dict_from_dict_roundtrip(self) -> None:
+        q = Queue(
+            'foo', Exchange('fooex', type='topic'), 'rk',
+            durable=False, exclusive=True, auto_delete=True, no_ack=True,
+            alias='fooalias', no_declare=True,
+            expires=30.0, message_ttl=20.0,
+            max_length=100, max_length_bytes=1000, max_priority=9,
+            queue_arguments={'x-queue-mode': 'lazy'},
+            binding_arguments={'x-match': 'all'},
+            consumer_arguments={'x-priority': 5},
+        )
+        d = q.as_dict(recurse=True)
+        # ``from_dict`` describes the exchange by name/type, not by object.
+        d['exchange'], d['exchange_type'] = q.exchange.name, q.exchange.type
+        q2 = Queue.from_dict(d['name'], **d)
+
+        for attr, _ in Queue.attrs:
+            if attr == 'exchange':
+                continue
+            assert getattr(q2, attr) == getattr(q, attr), attr
+        assert q2.exchange.name == 'fooex'
+        assert q2.exchange.type == 'topic'
+
+    def test_from_dict_does_not_override_defaults(self) -> None:
+        q = Queue.from_dict('foo', exchange='fooex')
+        assert q.max_length is None
+        assert q.expires is None
+        assert q.durable
+        assert not q.auto_delete
+
     def test_queue_dump(self) -> None:
         b = binding(self.exchange, 'rk')
         q = Queue('foo', self.exchange, 'rk', bindings=[b])


### PR DESCRIPTION
Closes #1236.

## The problem

`Queue.from_dict` passed a hardcoded list of kwargs to `Queue(...)`, so every option outside that list was silently dropped. A queue round-tripped through `as_dict()` / `from_dict()` came back missing most of its configuration:

```
LOST alias:            'al'  -> None
LOST no_declare:       True  -> None
LOST expires:          30.0  -> None
LOST message_ttl:      20.0  -> None
LOST max_length:       100   -> None
LOST max_length_bytes: 1000  -> None
LOST max_priority:     9     -> None
```

No error, no warning — the queue is just declared without the limits you configured. This is the shape of bug that keeps regressing, since every option added to `Queue.attrs` since the list was written has been forgotten again.

@auvipy said a PR was welcome on this one.

## The fix

Keep the explicit handling for the five fields that have prefix-resolution semantics (`name`, `exchange`, `routing_key`, `durable`, `auto_delete` — these read `queue_durable`/`exchange_durable`/`binding_key` and can't be forwarded blindly), then forward every *other* entry of `Queue.attrs` that is present in `options`.

Options added to `attrs` in future are then preserved automatically, which is what stops this from happening a third time.

Two details worth flagging, since both look like they could bite:

**Omitting absent keys is safe.** The old code always passed `exclusive=options.get('exclusive')` etc., i.e. `None` when absent; the new code omits the key. `Object.__init__` (`kombu/abstract.py:44-52`) treats a `None` value and an absent key identically — both fall through to the class default. I verified all six affected fields: `exclusive` None→False vs omitted→False, `no_ack` False/False, the three `*_arguments` None/None, and `bindings` `set()`/`set()` since `Queue.__init__` does `set(bindings or [])`. No behavior change.

**Type coercion still happens.** `Object.__init__` applies each attr's coercion function itself, so forwarding via `**kwargs` keeps it: `expires='30'` still becomes `30.0`, `no_declare='yes'` still becomes `True`.

## Known adjacent gap, not addressed here

`as_dict(recurse=True)` emits a nested Exchange dict, while `from_dict` expects the flat form (`exchange` as a name string plus `exchange_type`, `exchange_durable`, ...). That asymmetry predates this change and is a different bug; the test bridges it in two lines. Similarly, recursive `bindings` still don't round-trip (dicts are unhashable, so `set(bindings or [])` raises). Happy to take either on separately if you want them.

## Tests

`test_as_dict_from_dict_roundtrip` asserts every option survives. I checked it is load-bearing by stashing only the `entity.py` change and re-running it:

```
>   assert getattr(q2, attr) == getattr(q, attr), attr
E   AssertionError: alias
E   assert None == 'fooalias'
FAILED t/unit/test_entity.py::test_Queue::test_as_dict_from_dict_roundtrip
```

`test_from_dict_does_not_override_defaults` is a pure regression guard (it passes on unpatched code) pinning that an absent key doesn't overwrite a class default with `None`.

```
baseline t/unit:  1321 passed, 185 skipped
final    t/unit:  1323 passed, 185 skipped
flake8:           exit 0
```
