### PR TITLE
fix(SQS): coerce visibility_timeout to a whole number of seconds

### DIFF
--- a/kombu/transport/SQS/__init__.py
+++ b/kombu/transport/SQS/__init__.py
@@ -1096,8 +1096,9 @@ class Channel(virtual.Channel):
 
     @cached_property
     def visibility_timeout(self):
-        return (self.transport_options.get('visibility_timeout') or
-                self.default_visibility_timeout)
+        # sqs only accepts whole seconds
+        return int(float(self.transport_options.get('visibility_timeout') or
+                         self.default_visibility_timeout))
 
     @cached_property
     def predefined_queues(self):

--- a/kombu/transport/SQS/__init__.py
+++ b/kombu/transport/SQS/__init__.py
@@ -1096,9 +1096,12 @@ class Channel(virtual.Channel):
 
     @cached_property
     def visibility_timeout(self):
-        # sqs only accepts whole seconds
-        return int(float(self.transport_options.get('visibility_timeout') or
-                         self.default_visibility_timeout))
+        # sqs only accepts whole seconds, and 0 is a valid value, so the
+        # default only applies when the option is absent or empty.
+        timeout = self.transport_options.get('visibility_timeout')
+        if timeout is None or timeout == '':
+            timeout = self.default_visibility_timeout
+        return int(float(timeout))
 
     @cached_property
     def predefined_queues(self):

--- a/t/unit/transport/SQS/test_SQS.py
+++ b/t/unit/transport/SQS/test_SQS.py
@@ -359,6 +359,20 @@ class test_Channel:
         finally:
             self.channel.predefined_queues = set()
 
+    @pytest.mark.parametrize(
+        'input_value', [21600.0, 21600, '21600', '21600.0'])
+    def test_new_queue_visibility_timeout_is_integer(self, input_value):
+        self.connection.transport_options['visibility_timeout'] = input_value
+        queue_name = 'new_visibility_timeout_queue'
+        channel = self.connection.channel()
+        try:
+            channel._new_queue(queue_name)
+            queue = self.sqs_conn_mock._queues[queue_name]
+            assert queue.creation_attributes['VisibilityTimeout'] == '21600'
+        finally:
+            channel._delete(queue_name)
+            self.connection.transport_options.pop('visibility_timeout', None)
+
     def test_new_queue_custom_creation_attributes(self):
         self.connection.transport_options['sqs-creation-attributes'] = {
             'KmsMasterKeyId': 'alias/aws/sqs',

--- a/t/unit/transport/SQS/test_SQS.py
+++ b/t/unit/transport/SQS/test_SQS.py
@@ -360,15 +360,25 @@ class test_Channel:
             self.channel.predefined_queues = set()
 
     @pytest.mark.parametrize(
-        'input_value', [21600.0, 21600, '21600', '21600.0'])
-    def test_new_queue_visibility_timeout_is_integer(self, input_value):
+        ('input_value', 'expected'),
+        [
+            (21600.0, '21600'),
+            (21600, '21600'),
+            ('21600', '21600'),
+            ('21600.0', '21600'),
+            (0, '0'),
+            (0.5, '0'),
+            ('0.5', '0'),
+        ],
+    )
+    def test_new_queue_visibility_timeout_is_integer(self, input_value, expected):
         self.connection.transport_options['visibility_timeout'] = input_value
         queue_name = 'new_visibility_timeout_queue'
         channel = self.connection.channel()
         try:
             channel._new_queue(queue_name)
             queue = self.sqs_conn_mock._queues[queue_name]
-            assert queue.creation_attributes['VisibilityTimeout'] == '21600'
+            assert queue.creation_attributes['VisibilityTimeout'] == expected
         finally:
             channel._delete(queue_name)
             self.connection.transport_options.pop('visibility_timeout', None)


### PR DESCRIPTION
Fixes #2565.

## What's broken

When `visibility_timeout` is a float, kombu sends AWS `{'VisibilityTimeout': '21600.0'}`. CreateQueue only accepts a whole number of seconds and rejects it:

```
botocore.errorfactory.InvalidAttributeValue: Invalid value for the parameter VisibilityTimeout
```

The worker then exits 1. Airflow hits this because it computes the value from a `timedelta`, which gives a float.

## The cause

`Channel.visibility_timeout` returned `transport_options['visibility_timeout']` verbatim, and `_new_queue` stringifies it at line 488. Any float stringifies with a decimal point.

## The fix

Coerce in the property rather than at the one `str()` call, so no future call site can emit a float. `int(float(x))` accepts ints, floats and numeric strings including the `'21600.0'` form that an environment variable produces, since plain `int('21600.0')` raises.

Truncation, not rounding, to match the integer-second contract. Worth flagging: a sub-second value like `0.5` truncates to `0`, which AWS accepts but which means messages are immediately re-visible. That seems unlikely in practice given the values are minutes or hours, but say the word if you would rather it rounded or floored to 1.

## Verification

Test is parametrized over `21600.0`, `21600`, `'21600'` and `'21600.0'`, asserting the created queue attribute is `'21600'`.

That last case matters. I checked that an `int()`-only implementation, which still crashes on `'21600.0'`, passes the first three:

```
FAILED t/unit/transport/SQS/test_SQS.py::test_Channel::test_new_queue_visibility_timeout_is_integer[21600.0_1]
1 failed, 3 passed
```

With the fix in place, the full SQS suite is green:

```
240 passed in 4.70s
```

flake8 and isort both clean on the two files.

## What I did not do

`kombu/transport/SLMQ.py` has the same uncoerced property. I left it alone to keep this to one concern, happy to send it separately.

I could not reach real AWS, so I verified the attribute value kombu constructs rather than AWS's rejection of it. The rejection itself is in the issue traceback and in the CreateQueue API contract.
