### PR TITLE
style(http,typing): return generic BaseClient

### DIFF
--- a/kombu/asynchronous/http/__init__.py
+++ b/kombu/asynchronous/http/__init__.py
@@ -1,24 +1,19 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from kombu.asynchronous import get_event_loop
-from kombu.asynchronous.http.base import Headers, Request, Response
+from kombu.asynchronous.http.base import BaseClient, Headers, Request, Response
 from kombu.asynchronous.hub import Hub
 
-if TYPE_CHECKING:
-    from kombu.asynchronous.http.curl import CurlClient
-
-__all__ = ('Client', 'Headers', 'Response', 'Request')
+__all__ = ('Client', 'Headers', 'Response', 'Request', 'get_client')
 
 
-def Client(hub: Hub | None = None, **kwargs: int) -> CurlClient:
+def Client(hub: Hub | None = None, **kwargs: int) -> BaseClient:
     """Create new HTTP client."""
     from .curl import CurlClient
     return CurlClient(hub, **kwargs)
 
 
-def get_client(hub: Hub | None = None, **kwargs: int) -> CurlClient:
+def get_client(hub: Hub | None = None, **kwargs: int) -> BaseClient:
     """Get or create HTTP client bound to the current event loop."""
     hub = hub or get_event_loop()
     try:

--- a/kombu/asynchronous/http/__init__.py
+++ b/kombu/asynchronous/http/__init__.py
@@ -4,7 +4,7 @@ from kombu.asynchronous import get_event_loop
 from kombu.asynchronous.http.base import BaseClient, Headers, Request, Response
 from kombu.asynchronous.hub import Hub
 
-__all__ = ('Client', 'Headers', 'Response', 'Request', 'get_client')
+__all__ = ('Client', 'Headers', 'Response', 'Request', 'BaseClient', 'get_client')
 
 
 def Client(hub: Hub | None = None, **kwargs: int) -> BaseClient:

--- a/kombu/asynchronous/http/base.py
+++ b/kombu/asynchronous/http/base.py
@@ -16,7 +16,7 @@ from kombu.utils.functional import maybe_list, memoize
 if TYPE_CHECKING:
     from types import TracebackType
 
-__all__ = ('Headers', 'Response', 'Request')
+__all__ = ('Headers', 'Response', 'Request', 'BaseClient')
 
 PYPY = hasattr(sys, 'pypy_version_info')
 

--- a/kombu/asynchronous/http/base.py
+++ b/kombu/asynchronous/http/base.py
@@ -236,6 +236,8 @@ def header_parser(keyt=normalize_header):
 
 
 class BaseClient:
+    """Base HTTP client."""
+
     Headers = Headers
     Request = Request
     Response = Response


### PR DESCRIPTION
return Base/Parent class instead of `CurlClient`.

opens up `http.client` extensibility. still works on `CurlClient`