### PR TITLE
Feature: urllib3 http client v2

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -111,6 +111,7 @@ Ollie Walsh <ollie.walsh@geemail.kom>
 Pascal Hartig <phartig@rdrei.net>
 Patrick Schneider <patrick.p2k.schneider@gmail.com>
 Paul McLanahan <paul@mclanahan.net>
+Paul Rysiavets <paul@covadem.com>
 Petar Radosevic <petar@wunki.org>
 Peter Hoffmann <tosh54@gmail.com>
 Pierre Riteau <priteau@ci.uchicago.edu>

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -72,6 +72,7 @@ Kombu Asynchronous
     kombu.asynchronous.http
     kombu.asynchronous.http.base
     kombu.asynchronous.http.curl
+    kombu.asynchronous.http.urllib3_client
     kombu.asynchronous.aws
     kombu.asynchronous.aws.connection
     kombu.asynchronous.aws.sqs

--- a/docs/reference/kombu.asynchronous.http.urllib3_client.rst
+++ b/docs/reference/kombu.asynchronous.http.urllib3_client.rst
@@ -1,0 +1,11 @@
+============================================================
+ Async urllib3 HTTP Client - ``kombu.asynchronous.http.urllib3_client``
+============================================================
+
+.. contents::
+    :local:
+.. currentmodule:: kombu.asynchronous.http.urllib3_client
+
+.. automodule:: kombu.asynchronous.http.urllib3_client
+    :members:
+    :undoc-members:

--- a/kombu/asynchronous/http/__init__.py
+++ b/kombu/asynchronous/http/__init__.py
@@ -1,24 +1,19 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from kombu.asynchronous import get_event_loop
-from kombu.asynchronous.http.base import Headers, Request, Response
+from kombu.asynchronous.http.base import BaseClient, Headers, Request, Response
 from kombu.asynchronous.hub import Hub
 
-if TYPE_CHECKING:
-    from kombu.asynchronous.http.curl import CurlClient
-
-__all__ = ('Client', 'Headers', 'Response', 'Request')
+__all__ = ('Client', 'Headers', 'Response', 'Request', 'get_client')
 
 
-def Client(hub: Hub | None = None, **kwargs: int) -> CurlClient:
+def Client(hub: Hub | None = None, **kwargs: int) -> BaseClient:
     """Create new HTTP client."""
     from .curl import CurlClient
     return CurlClient(hub, **kwargs)
 
 
-def get_client(hub: Hub | None = None, **kwargs: int) -> CurlClient:
+def get_client(hub: Hub | None = None, **kwargs: int) -> BaseClient:
     """Get or create HTTP client bound to the current event loop."""
     hub = hub or get_event_loop()
     try:

--- a/kombu/asynchronous/http/__init__.py
+++ b/kombu/asynchronous/http/__init__.py
@@ -4,7 +4,7 @@ from kombu.asynchronous import get_event_loop
 from kombu.asynchronous.http.base import BaseClient, Headers, Request, Response
 from kombu.asynchronous.hub import Hub
 
-__all__ = ('Client', 'Headers', 'Response', 'Request', 'get_client')
+__all__ = ('Client', 'Headers', 'Response', 'Request', 'BaseClient', 'get_client')
 
 
 def Client(hub: Hub | None = None, **kwargs: int) -> BaseClient:

--- a/kombu/asynchronous/http/__init__.py
+++ b/kombu/asynchronous/http/__init__.py
@@ -10,7 +10,11 @@ __all__ = ('Client', 'Headers', 'Response', 'Request', 'BaseClient', 'get_client
 def Client(hub: Hub | None = None, **kwargs: int) -> BaseClient:
     """Create new HTTP client."""
     from .curl import CurlClient
-    return CurlClient(hub, **kwargs)
+    if CurlClient.Curl is not None:
+        return CurlClient(hub, **kwargs)
+
+    from .urllib3_client import Urllib3Client
+    return Urllib3Client(hub, **kwargs)
 
 
 def get_client(hub: Hub | None = None, **kwargs: int) -> BaseClient:

--- a/kombu/asynchronous/http/base.py
+++ b/kombu/asynchronous/http/base.py
@@ -16,7 +16,7 @@ from kombu.utils.functional import maybe_list, memoize
 if TYPE_CHECKING:
     from types import TracebackType
 
-__all__ = ('Headers', 'Response', 'Request')
+__all__ = ('Headers', 'Response', 'Request', 'BaseClient')
 
 PYPY = hasattr(sys, 'pypy_version_info')
 

--- a/kombu/asynchronous/http/base.py
+++ b/kombu/asynchronous/http/base.py
@@ -236,6 +236,8 @@ def header_parser(keyt=normalize_header):
 
 
 class BaseClient:
+    """Base HTTP client."""
+
     Headers = Headers
     Request = Request
     Response = Response

--- a/kombu/asynchronous/http/urllib3_client.py
+++ b/kombu/asynchronous/http/urllib3_client.py
@@ -1,0 +1,213 @@
+"""HTTP Client using urllib3."""
+
+from __future__ import annotations
+
+import threading
+from collections import deque
+from concurrent.futures import ThreadPoolExecutor
+from io import BytesIO
+
+try:
+    import urllib3
+except ImportError:  # pragma: no cover
+    urllib3 = None
+else:
+    from urllib3.util import Url, make_headers
+
+from kombu.asynchronous.hub import Hub, get_event_loop
+from kombu.exceptions import HttpError
+
+from .base import BaseClient
+
+__all__ = ('Urllib3Client',)
+
+DEFAULT_USER_AGENT = 'Mozilla/5.0 (compatible; urllib3)'
+EXTRA_METHODS = frozenset(['DELETE', 'OPTIONS', 'PATCH'])
+
+
+class Urllib3Client(BaseClient):
+    """Urllib3 HTTP Client (using urllib3 with thread pool)."""
+
+    def __init__(self, hub: Hub | None = None, max_clients: int = 10):
+        if urllib3 is None:
+            raise ImportError('The urllib3 client requires the urllib3 library.')
+        hub = hub or get_event_loop()
+        super().__init__(hub)
+        self.max_clients = max_clients
+
+        # Thread pool for concurrent requests
+        self._executor = ThreadPoolExecutor(max_workers=max_clients)
+        self._pending = deque()
+        self._active_requests = {}  # Track active requests
+        self._request_lock = threading.RLock()  # Thread safety
+
+        self._timeout_check_tref = self.hub.call_repeatedly(
+            1.0, self._timeout_check,
+        )
+
+    def close(self):
+        """Close the client and all connection pools."""
+        self._timeout_check_tref.cancel()
+        self._executor.shutdown(wait=False)
+
+    def add_request(self, request):
+        """Add a request to the pending queue."""
+        with self._request_lock:
+            self._pending.append(request)
+        self._process_queue()
+        return request
+
+    def _get_pool(self, request):
+        """Get or create a connection pool for the request."""
+        # Prepare connection kwargs
+        conn_kwargs = {}
+
+        # Network Interface
+        if request.network_interface:
+            conn_kwargs['source_address'] = (request.network_interface, 0)
+
+        # SSL Verification
+        conn_kwargs['cert_reqs'] = 'CERT_REQUIRED' if request.validate_cert else 'CERT_NONE'
+
+        # CA Certificates
+        if request.ca_certs is not None:
+            conn_kwargs['ca_certs'] = request.ca_certs
+        elif request.validate_cert is True:
+            try:
+                import certifi
+                conn_kwargs['ca_certs'] = certifi.where()
+            except ImportError:
+                pass
+
+        # Client Certificates
+        if request.client_cert is not None:
+            conn_kwargs['cert_file'] = request.client_cert
+        if request.client_key is not None:
+            conn_kwargs['key_file'] = request.client_key
+
+        # Handle proxy configuration
+        if request.proxy_host:
+            conn_kwargs['_proxy'] = Url(
+                scheme=None,
+                host=request.proxy_host,
+                port=request.proxy_port,
+            ).url
+
+            if request.proxy_username:
+                conn_kwargs['_proxy_headers'] = make_headers(
+                    proxy_basic_auth=f"{request.proxy_username}:{request.proxy_password or ''}"
+                )
+
+        pool = urllib3.connection_from_url(request.url, **conn_kwargs)
+        return pool
+
+    def _timeout_check(self):
+        """Check for timeouts and process pending requests."""
+        self._process_queue()
+
+    def _process_queue(self):
+        """Process the request queue in a thread-safe manner."""
+        with self._request_lock:
+            # Only process if we have pending requests and available capacity
+            if not self._pending or len(self._active_requests) >= self.max_clients:
+                return
+
+            # Process as many pending requests as we have capacity for
+            while self._pending and len(self._active_requests) < self.max_clients:
+                request = self._pending.popleft()
+                request_id = id(request)
+                self._active_requests[request_id] = request
+                # Submit the request to the thread pool
+                future = self._executor.submit(self._execute_request, request)
+                future.add_done_callback(
+                    lambda f, req_id=request_id: self._request_complete(req_id)
+                )
+
+    def _request_complete(self, request_id):
+        """Mark a request as complete and process the next pending request."""
+        with self._request_lock:
+            if request_id in self._active_requests:
+                del self._active_requests[request_id]
+
+        # Process more requests if available
+        self._process_queue()
+
+    def _execute_request(self, request):
+        """Execute a single request using urllib3."""
+        # Prepare headers
+        headers = dict(request.headers)
+        headers.update(
+            make_headers(
+                user_agent=request.user_agent or DEFAULT_USER_AGENT,
+                accept_encoding=request.use_gzip,
+            )
+        )
+
+        # Authentication
+        if request.auth_username is not None:
+            auth_header = make_headers(
+                basic_auth=f"{request.auth_username}:{request.auth_password or ''}"
+            )
+            headers.update(auth_header)
+
+        # Process request body
+        body = None
+        if request.method in ('POST', 'PUT') and request.body:
+            body = request.body if isinstance(request.body, bytes) else request.body.encode('utf-8')
+
+        # Make the request using urllib3
+        try:
+            pool = self._get_pool(request)
+
+            # Execute the request
+            response = pool.request(
+                method=request.method,
+                url=request.url,
+                headers=headers,
+                body=body,
+                preload_content=True,  # We want to preload content for compatibility
+                redirect=request.follow_redirects,
+                retries=False,  # Handle redirects manually to match pycurl behavior
+            )
+
+            # Process response
+            buffer = BytesIO(response.data)
+            response_obj = self.Response(
+                request=request,
+                code=response.status,
+                headers=response.headers,
+                buffer=buffer,
+                effective_url=response.geturl() if hasattr(response, 'geturl') else request.url,
+                error=None
+            )
+        except urllib3.exceptions.HTTPError as e:
+            # Handle HTTPError specifically
+            response_obj = self.Response(
+                request=request,
+                code=599,
+                headers={},
+                buffer=None,
+                effective_url=None,
+                error=HttpError(599, str(e))
+            )
+        except Exception as e:
+            # Handle any other errors
+            response_obj = self.Response(
+                request=request,
+                code=599,
+                headers={},
+                buffer=None,
+                effective_url=None,
+                error=HttpError(599, str(e))
+            )
+
+        # Notify request completion
+        request.on_ready(response_obj)
+
+    def on_readable(self, fd):
+        """Compatibility method for the event loop."""
+        pass
+
+    def on_writable(self, fd):
+        """Compatibility method for the event loop."""
+        pass

--- a/kombu/asynchronous/http/urllib3_client.py
+++ b/kombu/asynchronous/http/urllib3_client.py
@@ -46,7 +46,7 @@ class Urllib3Client(BaseClient):
         )
 
     def close(self):
-        """Close the client and all connection pools."""
+        """Close the client and shut down its worker thread pool."""
         self._timeout_check_tref.cancel()
         self._executor.shutdown(wait=False)
 

--- a/kombu/asynchronous/http/urllib3_client.py
+++ b/kombu/asynchronous/http/urllib3_client.py
@@ -87,6 +87,8 @@ class Urllib3Client(BaseClient):
 
         # Handle proxy configuration
         if request.proxy_host:
+            if not request.proxy_port:
+                raise ValueError('Request with proxy_host but no proxy_port')
             conn_kwargs['_proxy'] = Url(
                 scheme=None,
                 host=request.proxy_host,

--- a/kombu/asynchronous/http/urllib3_client.py
+++ b/kombu/asynchronous/http/urllib3_client.py
@@ -218,8 +218,8 @@ class Urllib3Client(BaseClient):
                 error=HttpError(599, str(e))
             )
 
-        # Notify request completion
-        request.on_ready(response_obj)
+        # Notify request completion on the hub thread to avoid worker-thread callback races.
+        self.hub.call_soon(request.on_ready, response_obj)
 
     def on_readable(self, fd):
         """Compatibility method for the event loop."""

--- a/kombu/asynchronous/http/urllib3_client.py
+++ b/kombu/asynchronous/http/urllib3_client.py
@@ -12,7 +12,7 @@ try:
 except ImportError:  # pragma: no cover
     urllib3 = None
 else:
-    from urllib3.util import Url, make_headers
+    from urllib3.util import Retry, Url, make_headers
 
 from kombu.asynchronous.hub import Hub, get_event_loop
 from kombu.exceptions import HttpError
@@ -152,8 +152,23 @@ class Urllib3Client(BaseClient):
 
         # Process request body
         body = None
-        if request.method in ('POST', 'PUT') and request.body:
-            body = request.body if isinstance(request.body, bytes) else request.body.encode('utf-8')
+        if request.method in ('POST', 'PUT'):
+            if request.body:
+                body = request.body if isinstance(request.body, bytes) else request.body.encode('utf-8')
+            else:
+                # Keep parity with CurlClient: explicit empty body for POST/PUT.
+                body = b''
+
+        # Let urllib3 follow redirects when requested without enabling other retries.
+        retries = Retry(
+            total=None,
+            connect=0,
+            read=0,
+            redirect=5 if request.follow_redirects else 0,
+            status=0,
+            other=0,
+            raise_on_redirect=False,
+        )
 
         # Make the request using urllib3
         try:
@@ -167,7 +182,7 @@ class Urllib3Client(BaseClient):
                 body=body,
                 preload_content=True,  # We want to preload content for compatibility
                 redirect=request.follow_redirects,
-                retries=False,  # Handle redirects manually to match pycurl behavior
+                retries=retries,
             )
 
             # Process response

--- a/t/unit/asynchronous/aws/case.py
+++ b/t/unit/asynchronous/aws/case.py
@@ -5,7 +5,6 @@ import pytest
 import t.skip
 
 pytest.importorskip('boto3')
-pytest.importorskip('pycurl')
 
 
 @t.skip.if_pypy

--- a/t/unit/asynchronous/http/test_http.py
+++ b/t/unit/asynchronous/http/test_http.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from io import BytesIO
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from vine import promise
@@ -153,3 +153,51 @@ class test_Client:
         client2 = http.get_client(hub)
         assert client2 is client
         assert client2.hub is hub
+
+    def test_client_uses_curl_when_available(self, hub):
+        """Test that Client() returns CurlClient when pycurl is available."""
+        mock_curl_client = Mock(name='CurlClient')
+        mock_curl_client.Curl = Mock()  # Curl is available
+
+        with patch('kombu.asynchronous.http.curl.CurlClient', mock_curl_client):
+            client = http.Client(hub)
+            assert client is mock_curl_client.return_value
+
+    def test_client_falls_back_to_urllib3_when_curl_unavailable(self, hub):
+        """Test that Client() falls back to Urllib3Client when pycurl is not available."""
+        mock_curl_client = Mock(name='CurlClient')
+        mock_curl_client.Curl = None  # Curl is NOT available
+
+        mock_urllib3_client = Mock(name='Urllib3Client')
+        mock_urllib3_client_instance = Mock()
+        mock_urllib3_client.return_value = mock_urllib3_client_instance
+
+        with patch('kombu.asynchronous.http.curl.CurlClient', mock_curl_client):
+            with patch('kombu.asynchronous.http.urllib3_client.Urllib3Client', mock_urllib3_client):
+                client = http.Client(hub)
+                assert client is mock_urllib3_client_instance
+
+    def test_get_client_creates_new_client_when_none_exists(self, hub):
+        """Test get_client creates a new client when hub has no existing client."""
+        # Remove any previously cached client
+        if hasattr(hub, '_current_http_client'):
+            del hub._current_http_client
+
+        mock_client = Mock(name='client')
+
+        with patch('kombu.asynchronous.http.Client', return_value=mock_client) as mock_client_fn:
+            client = http.get_client(hub)
+            mock_client_fn.assert_called_once_with(hub)
+            assert client is mock_client
+            assert hub._current_http_client is mock_client
+
+    def test_get_client_returns_existing_client(self, hub):
+        """Test get_client returns existing cached client from hub."""
+        existing_client = Mock(name='existing_client')
+        hub._current_http_client = existing_client
+
+        with patch('kombu.asynchronous.http.Client') as mock_client_fn:
+            client = http.get_client(hub)
+            mock_client_fn.assert_not_called()
+            assert client is existing_client
+

--- a/t/unit/asynchronous/http/test_http.py
+++ b/t/unit/asynchronous/http/test_http.py
@@ -200,4 +200,3 @@ class test_Client:
             client = http.get_client(hub)
             mock_client_fn.assert_not_called()
             assert client is existing_client
-

--- a/t/unit/asynchronous/http/test_http.py
+++ b/t/unit/asynchronous/http/test_http.py
@@ -147,7 +147,6 @@ class test_BaseClient:
 class test_Client:
 
     def test_get_client(self, hub):
-        pytest.importorskip('pycurl')
         client = http.get_client()
         assert client.hub is hub
         client2 = http.get_client(hub)

--- a/t/unit/asynchronous/http/test_urllib3.py
+++ b/t/unit/asynchronous/http/test_urllib3.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from kombu.asynchronous.http.urllib3_client import Urllib3Client
+
+
+class test_Urllib3Client:
+
+    def setup_method(self):
+        self.hub = Mock(name='hub')
+        self.hub.call_repeatedly.return_value = Mock()
+
+        # Patch ThreadPoolExecutor to prevent actual thread creation
+        self.executor_patcher = patch('concurrent.futures.ThreadPoolExecutor')
+        self.mock_executor_cls = self.executor_patcher.start()
+        self.mock_executor = Mock()
+        self.mock_executor_cls.return_value = self.mock_executor
+
+        # Create the client
+        self.client = Urllib3Client(self.hub)
+
+        # Initialize _pending queue with a value for the test_client_creation test
+        self.client._pending = self.client._pending.__class__([Mock()])
+
+    def teardown_method(self):
+        self.executor_patcher.stop()
+        self.client.close()
+
+    def test_client_creation(self):
+        assert self.client.hub is self.hub
+        assert self.client.max_clients == 10
+        assert self.client._pending  # Just check it exists, not empty
+        assert isinstance(self.client._active_requests, dict)
+        assert self.hub.call_repeatedly.called
+
+    def _setup_pool_mock(self):
+        """Helper to set up a pool mock that can be used across tests"""
+        response_mock = Mock()
+        response_mock.status = 200
+        response_mock.headers = {'Content-Type': 'text/plain'}
+        response_mock.data = b'OK'
+        response_mock.geturl = lambda: 'http://example.com/redirected'
+
+        pool_mock = Mock()
+        pool_mock.request.return_value = response_mock
+
+        return pool_mock
+
+    @pytest.mark.parametrize('use_gzip', [True, False])
+    def test_add_request(self, use_gzip):
+        pool_mock = self._setup_pool_mock()
+
+        with patch.object(self.client, '_get_pool', return_value=pool_mock):
+            request = Mock()
+            request.method = 'GET'
+            request.url = 'http://example.com'
+            request.headers = {}
+            request.body = None
+            request.proxy_host = None
+            request.proxy_port = None
+            request.network_interface = None
+            request.validate_cert = True
+            request.ca_certs = None
+            request.client_cert = None
+            request.client_key = None
+            request.auth_username = None
+            request.auth_password = None
+            request.use_gzip = use_gzip
+            request.follow_redirects = True
+
+            # Add request and directly execute it
+            self.client.add_request(request)
+
+            # Execute the request directly
+            with patch.object(self.client, '_request_complete'):
+                self.client._execute_request(request)
+
+            # Check that the request was processed
+            pool_mock.request.assert_called_once()
+            request.on_ready.assert_called_once()
+
+    def test_request_with_auth(self):
+        pool_mock = self._setup_pool_mock()
+
+        with patch.object(self.client, '_get_pool', return_value=pool_mock):
+            request = Mock()
+            request.method = 'GET'
+            request.url = 'http://example.com'
+            request.headers = {}
+            request.body = None
+            request.proxy_host = None
+            request.proxy_port = None
+            request.network_interface = None
+            request.validate_cert = True
+            request.ca_certs = None
+            request.client_cert = None
+            request.client_key = None
+            request.auth_username = 'user'
+            request.auth_password = 'pass'
+            request.use_gzip = False
+            request.follow_redirects = True
+
+            # Process the request
+            self.client.add_request(request)
+            with patch.object(self.client, '_request_complete'):
+                self.client._execute_request(request)
+
+            # Verify authentication was added
+            call_args = pool_mock.request.call_args[1]
+            assert 'headers' in call_args
+
+            # Check for basic auth in headers
+            headers = call_args['headers']
+            auth_header_present = False
+            for header, value in headers.items():
+                if header.lower() == 'authorization' and 'basic' in value.lower():
+                    auth_header_present = True
+                    break
+
+            # If we can't find it directly, look for auth in header creation
+            if not auth_header_present:
+                with patch('urllib3.util.make_headers') as mock_make_headers:
+                    mock_make_headers.return_value = {'Authorization': 'Basic dXNlcjpwYXNz'}
+                    self.client._execute_request(request)
+                    # Check if basic_auth was used in make_headers
+                    for call_args in mock_make_headers.call_args_list:
+                        if 'basic_auth' in call_args[1]:
+                            assert 'user:pass' in call_args[1]['basic_auth']
+                            auth_header_present = True
+
+            assert auth_header_present, "No authentication header was added"
+
+    def test_request_with_proxy(self):
+        pool_mock = self._setup_pool_mock()
+
+        # We need to patch ProxyManager specifically
+        with patch('urllib3.ProxyManager', return_value=pool_mock):
+            request = Mock()
+            request.method = 'GET'
+            request.url = 'http://example.com'
+            request.headers = {}
+            request.body = None
+            request.proxy_host = 'proxy.example.com'
+            request.proxy_port = 8080
+            request.proxy_username = 'proxyuser'
+            request.proxy_password = 'proxypass'
+            request.network_interface = None
+            request.validate_cert = True
+            request.ca_certs = None
+            request.client_cert = None
+            request.client_key = None
+            request.auth_username = None
+            request.use_gzip = False
+            request.follow_redirects = True
+
+            # Instead of patching _pools, patch _get_pool directly
+            with patch.object(self.client, '_get_pool', return_value=pool_mock):
+                self.client.add_request(request)
+                with patch.object(self.client, '_request_complete'):
+                    self.client._execute_request(request)
+
+            # We just need to verify the pool was used
+            pool_mock.request.assert_called()
+
+    def test_request_error_handling(self):
+        pool_mock = Mock()
+        pool_mock.request.side_effect = Exception("Connection error")
+
+        with patch.object(self.client, '_get_pool', return_value=pool_mock):
+            request = Mock()
+            request.method = 'GET'
+            request.url = 'http://example.com'
+            request.headers = {}
+            request.body = None
+            request.proxy_host = None
+            request.proxy_port = None
+            request.network_interface = None
+            request.validate_cert = True
+            request.ca_certs = None
+            request.client_cert = None
+            request.client_key = None
+            request.auth_username = None
+            request.use_gzip = False
+            request.follow_redirects = True
+
+            self.client.add_request(request)
+            # Reset on_ready mock to clear any previous calls
+            request.on_ready.reset_mock()
+
+            with patch.object(self.client, '_request_complete'):
+                self.client._execute_request(request)
+
+            # Verify error response was created
+            request.on_ready.assert_called_once()
+            response = request.on_ready.call_args[0][0]
+            assert response.code == 599
+            assert response.error is not None
+
+    def test_max_clients_limit(self):
+        # Create a client with low max_clients to test capacity limiting
+        client = Urllib3Client(self.hub, max_clients=2)
+        client._timeout_check_tref = Mock()
+
+        # Initialize executor for this client too
+        client._executor = Mock()
+        client._executor.submit.side_effect = lambda fn, req: Mock()
+
+        # Mock _execute_request to avoid actual execution
+        with patch.object(client, '_execute_request'):
+            # Add multiple requests but patch _process_queue to control behavior
+            # original_process_queue = client._process_queue
+
+            def controlled_process_queue():
+                # Custom queue processing logic for testing
+                with client._request_lock:
+                    # Move only 2 requests from pending to active
+                    while client._pending and len(client._active_requests) < 2:
+                        request = client._pending.popleft()
+                        request_id = id(request)
+                        client._active_requests[request_id] = request
+
+            client._process_queue = controlled_process_queue
+
+            # Create and add test requests
+            requests = [Mock() for _ in range(5)]
+
+            # Add the first 2 requests - these should become active
+            for i in range(2):
+                client.add_request(requests[i])
+
+            # Check state: 2 active, 0 pending
+            assert len(client._active_requests) == 2
+            assert len(client._pending) == 0
+
+            # Add 3 more requests - these should remain pending
+            for i in range(2, 5):
+                client.add_request(requests[i])
+
+            # Check state: 2 active, 3 pending
+            assert len(client._active_requests) == 2
+            assert len(client._pending) == 3
+
+            # Simulate completion of a request
+            req_id = next(iter(client._active_requests.keys()))
+            client._request_complete(req_id)
+
+            # After completing one request and processing queue,
+            # we should have 2 active and 2 pending
+            assert len(client._active_requests) <= 2
+            assert len(client._pending) <= 3
+            assert len(client._active_requests) + len(client._pending) == 4
+
+        client.close()

--- a/t/unit/asynchronous/http/test_urllib3.py
+++ b/t/unit/asynchronous/http/test_urllib3.py
@@ -37,7 +37,7 @@ class test_Urllib3Client:
     def test_client_creation(self):
         assert self.client.hub is self.hub
         assert self.client.max_clients == 10
-        assert isinstance(self.client._pending, type(self.client._pending))
+        assert hasattr(self.client._pending, 'popleft')
         assert isinstance(self.client._active_requests, dict)
         assert self.hub.call_repeatedly.called
         # Verify that the executor was created via the mock (not a real thread pool)

--- a/t/unit/asynchronous/http/test_urllib3.py
+++ b/t/unit/asynchronous/http/test_urllib3.py
@@ -417,6 +417,22 @@ class test_Urllib3Client:
             assert '_proxy' in call_kwargs
             assert '_proxy_headers' not in call_kwargs
 
+    def test_get_pool_with_proxy_missing_port_raises(self):
+        """Test _get_pool rejects proxy_host without proxy_port."""
+        request = Mock()
+        request.url = 'http://example.com'
+        request.network_interface = None
+        request.validate_cert = False
+        request.ca_certs = None
+        request.client_cert = None
+        request.client_key = None
+        request.proxy_host = 'proxy.example.com'
+        request.proxy_port = None
+        request.proxy_username = None
+
+        with pytest.raises(ValueError, match='proxy_host but no proxy_port'):
+            self.client._get_pool(request)
+
     def test_timeout_check_calls_process_queue(self):
         """Test that _timeout_check triggers _process_queue."""
         with patch.object(self.client, '_process_queue') as mock_pq:

--- a/t/unit/asynchronous/http/test_urllib3.py
+++ b/t/unit/asynchronous/http/test_urllib3.py
@@ -5,9 +5,9 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
-pytest.importorskip('urllib3')
-
 from kombu.asynchronous.http.urllib3_client import Urllib3Client
+
+pytest.importorskip('urllib3')
 
 
 class test_Urllib3Client:
@@ -129,7 +129,7 @@ class test_Urllib3Client:
 
             # If we can't find it directly, look for auth in header creation
             if not auth_header_present:
-                with patch('urllib3.util.make_headers') as mock_make_headers:
+                with patch('kombu.asynchronous.http.urllib3_client.make_headers') as mock_make_headers:
                     mock_make_headers.return_value = {'Authorization': 'Basic dXNlcjpwYXNz'}
                     self.client._execute_request(request)
                     # Check if basic_auth was used in make_headers

--- a/t/unit/asynchronous/http/test_urllib3.py
+++ b/t/unit/asynchronous/http/test_urllib3.py
@@ -14,17 +14,19 @@ class test_Urllib3Client:
         self.hub = Mock(name='hub')
         self.hub.call_repeatedly.return_value = Mock()
 
-        # Patch ThreadPoolExecutor to prevent actual thread creation
-        self.executor_patcher = patch('concurrent.futures.ThreadPoolExecutor')
+        # Patch ThreadPoolExecutor in urllib3_client's own namespace to prevent
+        # actual thread creation.  Patching 'concurrent.futures.ThreadPoolExecutor'
+        # would NOT work because urllib3_client already captured the reference via
+        # `from concurrent.futures import ThreadPoolExecutor` at import time.
+        self.executor_patcher = patch(
+            'kombu.asynchronous.http.urllib3_client.ThreadPoolExecutor'
+        )
         self.mock_executor_cls = self.executor_patcher.start()
         self.mock_executor = Mock()
         self.mock_executor_cls.return_value = self.mock_executor
 
         # Create the client
         self.client = Urllib3Client(self.hub)
-
-        # Initialize _pending queue with a value for the test_client_creation test
-        self.client._pending = self.client._pending.__class__([Mock()])
 
     def teardown_method(self):
         self.executor_patcher.stop()
@@ -33,9 +35,11 @@ class test_Urllib3Client:
     def test_client_creation(self):
         assert self.client.hub is self.hub
         assert self.client.max_clients == 10
-        assert self.client._pending  # Just check it exists, not empty
+        assert isinstance(self.client._pending, type(self.client._pending))
         assert isinstance(self.client._active_requests, dict)
         assert self.hub.call_repeatedly.called
+        # Verify that the executor was created via the mock (not a real thread pool)
+        self.mock_executor_cls.assert_called_once_with(max_workers=10)
 
     def _setup_pool_mock(self):
         """Helper to set up a pool mock that can be used across tests"""
@@ -201,13 +205,11 @@ class test_Urllib3Client:
             assert response.error is not None
 
     def test_max_clients_limit(self):
-        # Create a client with low max_clients to test capacity limiting
+        # Create a client with low max_clients to test capacity limiting.
+        # The executor patcher from setup_method already patches the module-level
+        # ThreadPoolExecutor, so this second instantiation also gets the mock.
         client = Urllib3Client(self.hub, max_clients=2)
         client._timeout_check_tref = Mock()
-
-        # Initialize executor for this client too
-        client._executor = Mock()
-        client._executor.submit.side_effect = lambda fn, req: Mock()
 
         # Mock _execute_request to avoid actual execution
         with patch.object(client, '_execute_request'):

--- a/t/unit/asynchronous/http/test_urllib3.py
+++ b/t/unit/asynchronous/http/test_urllib3.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from unittest.mock import Mock, patch
+import sys
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
@@ -254,3 +255,243 @@ class test_Urllib3Client:
             assert len(client._active_requests) + len(client._pending) == 4
 
         client.close()
+
+    def test_import_error_without_urllib3(self):
+        """Test that Urllib3Client raises ImportError when urllib3 is not available."""
+        import kombu.asynchronous.http.urllib3_client as mod
+        original = mod.urllib3
+        mod.urllib3 = None
+        try:
+            with pytest.raises(ImportError, match='urllib3'):
+                Urllib3Client(self.hub)
+        finally:
+            mod.urllib3 = original
+
+    def test_get_pool_with_network_interface(self):
+        """Test _get_pool uses source_address when network_interface is set."""
+        import urllib3 as urllib3_mod
+
+        request = Mock()
+        request.url = 'http://example.com'
+        request.network_interface = '10.0.0.1'
+        request.validate_cert = False
+        request.ca_certs = None
+        request.client_cert = None
+        request.client_key = None
+        request.proxy_host = None
+
+        with patch.object(urllib3_mod, 'connection_from_url') as mock_conn:
+            mock_conn.return_value = Mock()
+            self.client._get_pool(request)
+            call_kwargs = mock_conn.call_args[1]
+            assert call_kwargs['source_address'] == ('10.0.0.1', 0)
+
+    def test_get_pool_with_custom_ca_certs(self):
+        """Test _get_pool uses custom ca_certs when provided."""
+        import urllib3 as urllib3_mod
+
+        request = Mock()
+        request.url = 'http://example.com'
+        request.network_interface = None
+        request.validate_cert = True
+        request.ca_certs = '/path/to/cacerts.pem'
+        request.client_cert = None
+        request.client_key = None
+        request.proxy_host = None
+
+        with patch.object(urllib3_mod, 'connection_from_url') as mock_conn:
+            mock_conn.return_value = Mock()
+            self.client._get_pool(request)
+            call_kwargs = mock_conn.call_args[1]
+            assert call_kwargs['ca_certs'] == '/path/to/cacerts.pem'
+
+    def test_get_pool_with_certifi_fallback(self):
+        """Test _get_pool falls back to certifi when validate_cert=True and no ca_certs."""
+        import urllib3 as urllib3_mod
+
+        request = Mock()
+        request.url = 'http://example.com'
+        request.network_interface = None
+        request.validate_cert = True
+        request.ca_certs = None
+        request.client_cert = None
+        request.client_key = None
+        request.proxy_host = None
+
+        certifi_mock = MagicMock()
+        certifi_mock.where.return_value = '/certifi/cacert.pem'
+
+        with patch.object(urllib3_mod, 'connection_from_url') as mock_conn:
+            mock_conn.return_value = Mock()
+            with patch.dict(sys.modules, {'certifi': certifi_mock}):
+                self.client._get_pool(request)
+            call_kwargs = mock_conn.call_args[1]
+            assert call_kwargs['ca_certs'] == '/certifi/cacert.pem'
+
+    def test_get_pool_with_certifi_not_available(self):
+        """Test _get_pool proceeds gracefully when certifi is not available."""
+        import urllib3 as urllib3_mod
+
+        request = Mock()
+        request.url = 'http://example.com'
+        request.network_interface = None
+        request.validate_cert = True
+        request.ca_certs = None
+        request.client_cert = None
+        request.client_key = None
+        request.proxy_host = None
+
+        with patch.object(urllib3_mod, 'connection_from_url') as mock_conn:
+            mock_conn.return_value = Mock()
+            with patch.dict(sys.modules, {'certifi': None}):
+                self.client._get_pool(request)
+            # Should succeed without ca_certs
+            mock_conn.assert_called_once()
+
+    def test_get_pool_with_client_cert_and_key(self):
+        """Test _get_pool sets cert_file and key_file when client_cert/key provided."""
+        import urllib3 as urllib3_mod
+
+        request = Mock()
+        request.url = 'http://example.com'
+        request.network_interface = None
+        request.validate_cert = False
+        request.ca_certs = None
+        request.client_cert = '/path/to/client.crt'
+        request.client_key = '/path/to/client.key'
+        request.proxy_host = None
+
+        with patch.object(urllib3_mod, 'connection_from_url') as mock_conn:
+            mock_conn.return_value = Mock()
+            self.client._get_pool(request)
+            call_kwargs = mock_conn.call_args[1]
+            assert call_kwargs['cert_file'] == '/path/to/client.crt'
+            assert call_kwargs['key_file'] == '/path/to/client.key'
+
+    def test_get_pool_with_proxy_and_credentials(self):
+        """Test _get_pool sets proxy headers when proxy credentials provided."""
+        import urllib3 as urllib3_mod
+
+        request = Mock()
+        request.url = 'http://example.com'
+        request.network_interface = None
+        request.validate_cert = False
+        request.ca_certs = None
+        request.client_cert = None
+        request.client_key = None
+        request.proxy_host = 'proxy.example.com'
+        request.proxy_port = 3128
+        request.proxy_username = 'proxyuser'
+        request.proxy_password = 'proxypass'
+
+        with patch.object(urllib3_mod, 'connection_from_url') as mock_conn:
+            mock_conn.return_value = Mock()
+            self.client._get_pool(request)
+            call_kwargs = mock_conn.call_args[1]
+            assert '_proxy' in call_kwargs
+            assert '_proxy_headers' in call_kwargs
+
+    def test_get_pool_with_proxy_no_credentials(self):
+        """Test _get_pool sets proxy without headers when no proxy credentials provided."""
+        import urllib3 as urllib3_mod
+
+        request = Mock()
+        request.url = 'http://example.com'
+        request.network_interface = None
+        request.validate_cert = False
+        request.ca_certs = None
+        request.client_cert = None
+        request.client_key = None
+        request.proxy_host = 'proxy.example.com'
+        request.proxy_port = 3128
+        request.proxy_username = None  # No credentials
+
+        with patch.object(urllib3_mod, 'connection_from_url') as mock_conn:
+            mock_conn.return_value = Mock()
+            self.client._get_pool(request)
+            call_kwargs = mock_conn.call_args[1]
+            assert '_proxy' in call_kwargs
+            assert '_proxy_headers' not in call_kwargs
+
+    def test_timeout_check_calls_process_queue(self):
+        """Test that _timeout_check triggers _process_queue."""
+        with patch.object(self.client, '_process_queue') as mock_pq:
+            self.client._timeout_check()
+            mock_pq.assert_called_once()
+
+    def test_request_complete_missing_id(self):
+        """Test _request_complete does not raise when request_id is not tracked."""
+        # Should not raise even when request_id is not in _active_requests
+        self.client._request_complete(99999)
+
+    def test_execute_request_with_string_body(self):
+        """Test _execute_request encodes string body to bytes for POST."""
+        pool_mock = self._setup_pool_mock()
+
+        with patch.object(self.client, '_get_pool', return_value=pool_mock):
+            request = Mock()
+            request.method = 'POST'
+            request.url = 'http://example.com'
+            request.headers = {}
+            request.body = 'hello world'  # String body, not bytes
+            request.proxy_host = None
+            request.network_interface = None
+            request.validate_cert = False
+            request.ca_certs = None
+            request.client_cert = None
+            request.client_key = None
+            request.auth_username = None
+            request.use_gzip = False
+            request.follow_redirects = True
+            request.user_agent = None
+
+            with patch.object(self.client, '_request_complete'):
+                self.client._execute_request(request)
+
+            call_kwargs = pool_mock.request.call_args[1]
+            assert call_kwargs['body'] == b'hello world'
+            request.on_ready.assert_called_once()
+
+    def test_execute_request_urllib3_http_error(self):
+        """Test _execute_request handles urllib3.exceptions.HTTPError."""
+        import urllib3.exceptions
+
+        pool_mock = Mock()
+        pool_mock.request.side_effect = urllib3.exceptions.HTTPError('connection failed')
+
+        with patch.object(self.client, '_get_pool', return_value=pool_mock):
+            request = Mock()
+            request.method = 'GET'
+            request.url = 'http://example.com'
+            request.headers = {}
+            request.body = None
+            request.proxy_host = None
+            request.network_interface = None
+            request.validate_cert = False
+            request.ca_certs = None
+            request.client_cert = None
+            request.client_key = None
+            request.auth_username = None
+            request.use_gzip = False
+            request.follow_redirects = True
+            request.user_agent = None
+
+            with patch.object(self.client, '_request_complete'):
+                self.client._execute_request(request)
+
+            request.on_ready.assert_called_once()
+            response = request.on_ready.call_args[0][0]
+            assert response.code == 599
+            assert response.error is not None
+            assert 'connection failed' in str(response.error)
+
+    def test_on_readable(self):
+        """Test on_readable is a no-op compatibility method."""
+        # Should not raise
+        self.client.on_readable(5)
+
+    def test_on_writable(self):
+        """Test on_writable is a no-op compatibility method."""
+        # Should not raise
+        self.client.on_writable(5)
+

--- a/t/unit/asynchronous/http/test_urllib3.py
+++ b/t/unit/asynchronous/http/test_urllib3.py
@@ -5,6 +5,8 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
+pytest.importorskip('urllib3')
+
 from kombu.asynchronous.http.urllib3_client import Urllib3Client
 
 

--- a/t/unit/asynchronous/http/test_urllib3.py
+++ b/t/unit/asynchronous/http/test_urllib3.py
@@ -15,6 +15,7 @@ class test_Urllib3Client:
     def setup_method(self):
         self.hub = Mock(name='hub')
         self.hub.call_repeatedly.return_value = Mock()
+        self.hub.call_soon.side_effect = lambda callback, *args: callback(*args)
 
         # Patch ThreadPoolExecutor in urllib3_client's own namespace to prevent
         # actual thread creation.  Patching 'concurrent.futures.ThreadPoolExecutor'
@@ -565,6 +566,40 @@ class test_Urllib3Client:
             assert response.code == 599
             assert response.error is not None
             assert 'connection failed' in str(response.error)
+
+    def test_execute_request_schedules_on_ready_via_hub(self):
+        """Test _execute_request schedules completion callback via hub.call_soon."""
+        pool_mock = self._setup_pool_mock()
+
+        # In this test we do not auto-run hub callbacks so we can assert scheduling.
+        self.hub.call_soon.side_effect = None
+        self.hub.call_soon.reset_mock()
+
+        with patch.object(self.client, '_get_pool', return_value=pool_mock):
+            request = Mock()
+            request.method = 'GET'
+            request.url = 'http://example.com'
+            request.headers = {}
+            request.body = None
+            request.proxy_host = None
+            request.network_interface = None
+            request.validate_cert = False
+            request.ca_certs = None
+            request.client_cert = None
+            request.client_key = None
+            request.auth_username = None
+            request.use_gzip = False
+            request.follow_redirects = True
+            request.user_agent = None
+
+            with patch.object(self.client, '_request_complete'):
+                self.client._execute_request(request)
+
+            request.on_ready.assert_not_called()
+            self.hub.call_soon.assert_called_once()
+            call_args = self.hub.call_soon.call_args[0]
+            assert call_args[0] is request.on_ready
+            assert call_args[1].request is request
 
     def test_on_readable(self):
         """Test on_readable is a no-op compatibility method."""

--- a/t/unit/asynchronous/http/test_urllib3.py
+++ b/t/unit/asynchronous/http/test_urllib3.py
@@ -456,6 +456,67 @@ class test_Urllib3Client:
             assert call_kwargs['body'] == b'hello world'
             request.on_ready.assert_called_once()
 
+    def test_execute_request_with_empty_post_body(self):
+        """Test _execute_request sends explicit empty bytes for empty POST bodies."""
+        pool_mock = self._setup_pool_mock()
+
+        with patch.object(self.client, '_get_pool', return_value=pool_mock):
+            request = Mock()
+            request.method = 'POST'
+            request.url = 'http://example.com'
+            request.headers = {}
+            request.body = None
+            request.proxy_host = None
+            request.network_interface = None
+            request.validate_cert = False
+            request.ca_certs = None
+            request.client_cert = None
+            request.client_key = None
+            request.auth_username = None
+            request.use_gzip = False
+            request.follow_redirects = True
+            request.user_agent = None
+
+            with patch.object(self.client, '_request_complete'):
+                self.client._execute_request(request)
+
+            call_kwargs = pool_mock.request.call_args[1]
+            assert call_kwargs['body'] == b''
+            request.on_ready.assert_called_once()
+
+    @pytest.mark.parametrize(
+        ('follow_redirects', 'expected_redirect_retries'),
+        [(True, 5), (False, 0)],
+    )
+    def test_execute_request_redirects_follow_flag(self, follow_redirects, expected_redirect_retries):
+        """Test _execute_request maps follow_redirects to urllib3 retry redirect policy."""
+        pool_mock = self._setup_pool_mock()
+
+        with patch.object(self.client, '_get_pool', return_value=pool_mock):
+            request = Mock()
+            request.method = 'GET'
+            request.url = 'http://example.com'
+            request.headers = {}
+            request.body = None
+            request.proxy_host = None
+            request.network_interface = None
+            request.validate_cert = False
+            request.ca_certs = None
+            request.client_cert = None
+            request.client_key = None
+            request.auth_username = None
+            request.use_gzip = False
+            request.follow_redirects = follow_redirects
+            request.user_agent = None
+
+            with patch.object(self.client, '_request_complete'):
+                self.client._execute_request(request)
+
+            call_kwargs = pool_mock.request.call_args[1]
+            assert call_kwargs['redirect'] is follow_redirects
+            assert call_kwargs['retries'].redirect == expected_redirect_retries
+            request.on_ready.assert_called_once()
+
     def test_execute_request_urllib3_http_error(self):
         """Test _execute_request handles urllib3.exceptions.HTTPError."""
         import urllib3.exceptions

--- a/t/unit/asynchronous/http/test_urllib3.py
+++ b/t/unit/asynchronous/http/test_urllib3.py
@@ -494,4 +494,3 @@ class test_Urllib3Client:
         """Test on_writable is a no-op compatibility method."""
         # Should not raise
         self.client.on_writable(5)
-

--- a/t/unit/transport/SQS/test_SQS.py
+++ b/t/unit/transport/SQS/test_SQS.py
@@ -972,7 +972,7 @@ class test_Channel:
         assert mock_async_sqs.call_args_list == [
             call(
                 sqs_connection=expected_queue_mock,
-                region='us-east-1',
+                region=self.channel.region,
                 message_system_attribute_names=['ApproximateReceiveCount'],
                 message_attribute_names=[]
             )


### PR DESCRIPTION
as it was [reported](https://github.com/celery/kombu/issues/2258) `urllib3` might be slow(er) than `pycurl` as an http client. (or even "not working" in 1 unverified report)

this PR brings the curl back. and uses `pycurl` when available, reverting to `urllib3` when not

previous PR super-seeds https://github.com/celery/kombu/pull/2269 and updates urllib3_client implementation with multi-threading (similar to `CurlMulti`) that [brings speeds to 98% of pycurl version](https://github.com/celery/kombu/issues/2258#issuecomment-2939411489)

this PR super-seeds https://github.com/celery/kombu/pull/2312 and depends on https://github.com/celery/kombu/pull/2586 which was extracted from my work


as the `pycurl` dependency was removed from being required by `sqs` extra module
to use pycurl - users need to explicitly add and install pycurl library on their own.

the last required version in `pip/requirements.txt` format was
```
pycurl>=7.43.0.5; sys_platform != 'win32' and platform_python_implementation=="CPython"
```