### PR TITLE
Redis: drop half-open pub/sub connections the subclient health check can't see

### DIFF
--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -128,6 +128,11 @@ DEFAULT_DB = 0
 
 DEFAULT_HEALTH_CHECK_INTERVAL = 25
 
+#: Unanswered subclient PINGs tolerated before the pub/sub connection is
+#: treated as half-open and dropped.  Two full intervals must pass without
+#: a PONG, so a stalled event loop alone cannot trigger a reconnect.
+SUBCLIENT_MAX_MISSED_HEALTH_CHECKS = 2
+
 #: How often (in seconds) to flush pending streaming re-authentication
 #: tokens onto the long-lived BRPOP and pub/sub connections.  See
 #: :meth:`Channel.maybe_reauth` for why this is needed.
@@ -616,6 +621,23 @@ class MultiChannelPoller:
             if client is not None \
                     and callable(getattr(client, 'check_health', None)):
                 try:
+                    missed = getattr(
+                        client, 'health_check_response_counter', None)
+                    if isinstance(missed, int) and \
+                            missed >= SUBCLIENT_MAX_MISSED_HEALTH_CHECKS:
+                        # check_health() only *sends* PING; a half-open
+                        # socket accepts the write and the missing PONG is
+                        # never an error, so count unanswered pings and
+                        # drop the connection to force a resubscribe.
+                        warning(
+                            'Redis pub/sub connection missed %d health '
+                            'check responses; dropping stale connection',
+                            missed)
+                        client.health_check_response_counter = 0
+                        connection = client.connection
+                        if connection is not None:
+                            connection.disconnect()
+                        continue
                     client.check_health()
                 except channel.connection_errors:
                     logger.debug(

--- a/t/integration/test_redis.py
+++ b/t/integration/test_redis.py
@@ -8,8 +8,7 @@ import pytest
 import redis
 
 import kombu
-from kombu.transport.redis import SUBCLIENT_MAX_MISSED_HEALTH_CHECKS
-from kombu.transport.redis import Transport
+from kombu.transport.redis import SUBCLIENT_MAX_MISSED_HEALTH_CHECKS, Transport
 from kombu.utils.json import loads
 
 from .common import (BaseExchangeTypes, BaseMessage, BasePriority,

--- a/t/integration/test_redis.py
+++ b/t/integration/test_redis.py
@@ -8,6 +8,7 @@ import pytest
 import redis
 
 import kombu
+from kombu.transport.redis import SUBCLIENT_MAX_MISSED_HEALTH_CHECKS
 from kombu.transport.redis import Transport
 from kombu.utils.json import loads
 
@@ -581,3 +582,90 @@ class test_RedisQueueExpiration:
         for key in priority_keys:
             ttl = redis_client.pttl(key)
             assert ttl > 0 and ttl <= expires_ms, f"Expected TTL for {key} to be set but got {ttl}"
+
+
+@pytest.mark.env('redis')
+@pytest.mark.flaky(reruns=5, reruns_delay=2)
+class test_RedisSubclientHealthCheck:
+    """Integration tests for dropping half-open fanout (pub/sub) connections.
+
+    On a half-open socket (managed broker failover, expired NAT entry) the
+    health check PING write lands in the kernel buffer and no error is
+    raised, so the subclient health check alone never notices the dead
+    connection.  kombu counts unanswered pings through redis-py's
+    ``health_check_response_counter`` and drops the connection once two
+    full health check intervals pass with no PONG.
+    """
+
+    def _fanout_consumer(self, conn, name, received):
+        """Return a channel subscribed to a fanout exchange over pub/sub."""
+        exchange = kombu.Exchange(f'{name}_exchange', type='fanout')
+        queue = kombu.Queue(f'{name}_queue', exchange=exchange)
+        channel = conn.channel()
+        consumer = kombu.Consumer(
+            channel, [queue], accept=['json'], no_ack=True)
+        consumer.register_callback(
+            lambda body, message: received.append(body))
+        consumer.consume()
+        # first drain registers the subclient with the poller (LISTEN mode)
+        # and sends SUBSCRIBE; it may return on the subscribe confirmation
+        # or time out waiting for one
+        try:
+            conn.drain_events(timeout=0.1)
+        except socket.timeout:
+            pass
+        return channel, exchange
+
+    def test_healthy_subclient_connection_not_dropped(self, connection):
+        """A pub/sub connection with no missed PONGs must stay up."""
+        received = []
+        with connection as conn:
+            channel, exchange = self._fanout_consumer(
+                conn, 'health_live', received)
+            subclient = channel.__dict__['subclient']
+            assert subclient.connection._sock is not None
+
+            conn.transport.cycle.maybe_check_subclient_health()
+
+            # below the missed-pong threshold the connection is kept
+            assert subclient.connection._sock is not None
+
+            producer = kombu.Producer(channel)
+            producer.publish(
+                {'msg': 'alive'}, exchange=exchange, serializer='json')
+            conn.drain_events(timeout=1)
+
+        assert received == [{'msg': 'alive'}]
+
+    def test_missed_pongs_drop_connection_and_resubscribe(self, connection):
+        """Unanswered PINGs drop the connection; the next poll resubscribes."""
+        received = []
+        with connection as conn:
+            channel, exchange = self._fanout_consumer(
+                conn, 'health_drop', received)
+            subclient = channel.__dict__['subclient']
+            assert subclient.connection._sock is not None
+
+            # two health check intervals passed without a PONG: the socket
+            # is half-open and the connection must be dropped
+            subclient.health_check_response_counter = \
+                SUBCLIENT_MAX_MISSED_HEALTH_CHECKS
+
+            conn.transport.cycle.maybe_check_subclient_health()
+
+            assert subclient.connection._sock is None
+            assert subclient.health_check_response_counter == 0
+
+            # the next poll cycle reconnects and resubscribes
+            try:
+                conn.drain_events(timeout=0.1)
+            except socket.timeout:
+                pass
+
+            # fanout messages flow again
+            producer = kombu.Producer(channel)
+            producer.publish(
+                {'msg': 'recovered'}, exchange=exchange, serializer='json')
+            conn.drain_events(timeout=1)
+
+        assert received == [{'msg': 'recovered'}]

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -2872,6 +2872,90 @@ class test_MultiChannelPoller:
 
         client.check_health.assert_called_once()
 
+    def test_maybe_check_subclient_health_drops_stale_connection(self):
+        """Unanswered PINGs mean the pub/sub path is half-open.
+
+        check_health() only sends PING, and a half-open socket accepts the
+        write without error, so once health_check_response_counter reaches
+        the threshold the connection must be dropped to force a resubscribe.
+        """
+        p = self.Poller()
+        channel = Mock(name='channel')
+        client = Mock(name='subclient')
+        client.health_check_response_counter = \
+            redis.SUBCLIENT_MAX_MISSED_HEALTH_CHECKS
+        channel.__dict__['subclient'] = client
+        p._channels = [channel]
+
+        p.maybe_check_subclient_health()
+
+        client.connection.disconnect.assert_called_once()
+        assert client.health_check_response_counter == 0
+        client.check_health.assert_not_called()
+
+    def test_maybe_check_subclient_health_below_threshold_still_pings(self):
+        """A single outstanding PONG is tolerated (event loop may stall)."""
+        p = self.Poller()
+        channel = Mock(name='channel')
+        client = Mock(name='subclient')
+        client.health_check_response_counter = \
+            redis.SUBCLIENT_MAX_MISSED_HEALTH_CHECKS - 1
+        channel.__dict__['subclient'] = client
+        p._channels = [channel]
+
+        p.maybe_check_subclient_health()
+
+        client.check_health.assert_called_once()
+        client.connection.disconnect.assert_not_called()
+
+    def test_maybe_check_subclient_health_counter_reset_after_drop(self):
+        """The counter survives redis-py reconnects; reset it on our drop.
+
+        clean_health_check_responses() only drains responses that actually
+        arrive, so a counter inflated by the dead connection would otherwise
+        stay at the threshold forever and cause a reconnect loop.
+        """
+        p = self.Poller()
+        channel = Mock(name='channel')
+        client = Mock(name='subclient')
+        client.health_check_response_counter = \
+            redis.SUBCLIENT_MAX_MISSED_HEALTH_CHECKS + 3
+        channel.__dict__['subclient'] = client
+        p._channels = [channel]
+
+        p.maybe_check_subclient_health()
+
+        assert client.health_check_response_counter == 0
+        client.connection.disconnect.assert_called_once()
+
+    def test_maybe_check_subclient_health_no_counter_attribute(self):
+        """redis-py without health_check_response_counter: just send PING."""
+        p = self.Poller()
+        channel = Mock(name='channel')
+        client = Mock(name='subclient', spec=['check_health'])
+        channel.__dict__['subclient'] = client
+        p._channels = [channel]
+
+        p.maybe_check_subclient_health()
+
+        client.check_health.assert_called_once()
+
+    def test_maybe_check_subclient_health_stale_without_connection(self):
+        """Stale counter with no connection object must not raise."""
+        p = self.Poller()
+        channel = Mock(name='channel')
+        client = Mock(name='subclient')
+        client.health_check_response_counter = \
+            redis.SUBCLIENT_MAX_MISSED_HEALTH_CHECKS
+        client.connection = None
+        channel.__dict__['subclient'] = client
+        p._channels = [channel]
+
+        p.maybe_check_subclient_health()  # must not raise
+
+        assert client.health_check_response_counter == 0
+        client.check_health.assert_not_called()
+
     def test_maybe_reauth_delegates_to_channels(self):
         """Happy path: the timer flushes re-auth on every channel."""
         p = self.Poller()


### PR DESCRIPTION
Been following celery/celery#10502, where workers on managed Redis (ElastiCache/Valkey over TLS) silently stop consuming fanout messages and stop answering `inspect ping` after running for a while. Process alive, broker reachable, no traceback, restart fixes it. kokhlo narrowed it down in that thread: the pub/sub connection issues no commands while idle, it just waits to become readable, so if the TCP path dies silently (failover, NAT connection-table turnover) nothing on it ever times out.

#2498 added the `maybe_check_subclient_health` timer that calls redis-py's `check_health()`, which is the right idea, but I don't think it actually catches this case. `PubSub.check_health()` only *sends* the PING:

```python
if conn.health_check_interval and time.monotonic() > conn.next_health_check:
    conn.send_command("PING", self.HEALTH_CHECK_MESSAGE, check_health=False)
    self.health_check_response_counter += 1
```

On a half-open socket the write lands in the kernel send buffer and succeeds, so no error is ever raised and kombu never finds out. The timer fires every interval, the counter ticks up, and the worker stays catatonic until someone restarts it. (redis-py decrements the counter when a PONG gets parsed, so on a healthy connection it hovers at 0/1.)

So this makes the timer look at the other side of the exchange: once `health_check_response_counter` reaches 2, meaning two full health-check intervals passed with no PONG, the connection is treated as dead and dropped. The existing reconnect machinery takes it from there: `_on_connection_disconnect` prunes the fd, next `on_poll_start` re-registers and resubscribes. With the default `health_check_interval` of 25s that bounds detection to ~50s instead of riding on TCP keepalive defaults (7200s on Linux) or a manual container restart.

Two things I went back and forth on:

Threshold of 2, not 1. One outstanding PING can just mean the event loop was stalled for an interval (long callback, GC pause); two in a row means the path is gone. False reconnects on busy workers seemed worse than one extra interval of detection time.

And resetting the counter when we drop. `clean_health_check_responses()` only drains responses that actually arrive, so a counter inflated by the dead connection survives the reconnect and would pin us at the threshold forever, reconnect loop. Zeroing it mirrors what `PubSub.reset()` does.

If `health_check_interval` is 0 redis-py never sends pings, the counter never increments, and the new check stays inert. Older redis-py without the counter attribute falls back to the current send-only behavior.

Tests: new cases in `t/unit/transport/test_redis.py` covering the drop at threshold, sub-threshold pass-through, the counter reset, the missing-attribute fallback, and a stale counter with no connection object. Also ran the scenario against a real `redis.client.PubSub` with a fake half-open connection to make sure the counter interop works as expected, not just with mocks. Full `t/unit` passes (1152 passed, 186 skipped; the SQS/azure/gcpubsub collection errors in my env are missing optional deps, unrelated).
