### PR TITLE
Strip existing delay prefix before adding a new one on retry

### DIFF
--- a/kombu/transport/native_delayed_delivery.py
+++ b/kombu/transport/native_delayed_delivery.py
@@ -4,6 +4,8 @@ Only relevant for RabbitMQ.
 """
 from __future__ import annotations
 
+import re
+
 from kombu import Connection, Exchange, Queue, binding
 from kombu.log import get_logger
 
@@ -12,6 +14,8 @@ logger = get_logger(__name__)
 MAX_NUMBER_OF_BITS_TO_USE = 28
 MAX_LEVEL = MAX_NUMBER_OF_BITS_TO_USE - 1
 CELERY_DELAYED_DELIVERY_EXCHANGE = "celery_delayed_delivery"
+
+_delay_prefix_re = re.compile(r'^(?:[01]\.){%d}' % MAX_NUMBER_OF_BITS_TO_USE)
 
 
 def level_name(level: int, prefix: str | None = None) -> str:
@@ -153,5 +157,12 @@ def calculate_routing_key(countdown: int, routing_key: str) -> str:
 
     if not routing_key:
         raise ValueError("routing_key must be non-empty")
+
+    # A retried task carries its previous delivery's routing key forward
+    # (e.g. via Celery's signature_from_request), which may already carry a
+    # delay prefix from an earlier retry. Strip it before prepending a new
+    # one, otherwise the prefix keeps growing on every delayed retry until
+    # the routing key exceeds AMQP's 255-byte short string limit.
+    routing_key = _delay_prefix_re.sub('', routing_key, count=1)
 
     return '.'.join(list(f'{countdown:028b}')) + f'.{routing_key}'

--- a/kombu/transport/native_delayed_delivery.py
+++ b/kombu/transport/native_delayed_delivery.py
@@ -165,4 +165,4 @@ def calculate_routing_key(countdown: int, routing_key: str) -> str:
     # the routing key exceeds AMQP's 255-byte short string limit.
     routing_key = _delay_prefix_re.sub('', routing_key, count=1)
 
-    return '.'.join(list(f'{countdown:028b}')) + f'.{routing_key}'
+    return '.'.join(f'{countdown:0{MAX_NUMBER_OF_BITS_TO_USE}b}') + f'.{routing_key}'

--- a/t/unit/transport/test_native_delayed_delivery.py
+++ b/t/unit/transport/test_native_delayed_delivery.py
@@ -166,3 +166,14 @@ class test_calculate_routing_key:
     def test_none_routing_key(self):
         with pytest.raises(ValueError, match="routing_key must be non-empty"):
             calculate_routing_key(1, None)
+
+    def test_does_not_accumulate_prefix_on_retry(self):
+        first = calculate_routing_key(1, 'destination')
+        second = calculate_routing_key(2, first)
+        assert second == calculate_routing_key(2, 'destination')
+
+    def test_does_not_strip_a_partial_prefix_look_alike(self):
+        # '0.destination' only has a single leading segment, not the full
+        # 28-segment prefix, so it must not be mistaken for one and stripped.
+        assert (calculate_routing_key(1, '0.destination')
+                == '0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1.0.destination')


### PR DESCRIPTION
Closes #2556.

`calculate_routing_key` always prepends a fresh 28-bit binary prefix to whatever routing key it's given, with no check for whether the key already carries one from an earlier call.

When a task is retried with a countdown, Celery pulls the routing key back out of the delivered message's `delivery_info` and republishes with it as-is. If that task fails and retries again with a delay, the routing key it hands back already has a prefix on it, so kombu stacks a second one on top. Each additional delayed retry adds another 28 bits plus separators, and once the accumulated key passes AMQP's 255-byte short string limit, publishing fails with `error("'B' format requires 0 <= number <= 255")`.

This strips a leading 28-segment binary prefix, if the routing key already has one, before prepending the new one. A routing key that only looks like it might have a prefix (a single leading `0.` or `1.` segment, say) is left alone, since that's not the full 28-segment pattern this module ever produces.

Added two tests: one confirming a routing key that's already been through `calculate_routing_key` once doesn't grow on a second call, and one confirming a routing key that merely starts with a digit-dot isn't mistaken for a real prefix and stripped.
