### PR TITLE
Ensure consumer recovers from broker connection restart/issues

### DIFF
--- a/kombu/messaging.py
+++ b/kombu/messaging.py
@@ -571,6 +571,7 @@ class Consumer:
         self.on_message = on_message
         self.tag_prefix = tag_prefix
         self._active_tags = {}
+        self._active_queue_no_ack = {}
         if auto_declare is not None:
             self.auto_declare = auto_declare
         if on_decode_error is not None:
@@ -591,8 +592,9 @@ class Consumer:
 
     def revive(self, channel):
         """Revive consumer after connection loss."""
-        previously_active = set(self._active_tags)
+        previous_no_ack = self._active_queue_no_ack.copy()
         self._active_tags.clear()
+        self._active_queue_no_ack.clear()
         channel = self.channel = maybe_channel(channel)
         # modify dict size while iterating over it is not allowed
         for qname, queue in list(self._queues.items()):
@@ -609,7 +611,7 @@ class Consumer:
 
         # re-register the AMQP consumers, but only for queues that were
         # actually being consumed from before (not merely registered).
-        self._consume_previously_active(previously_active)
+        self._consume_previously_active(previous_no_ack)
 
     def declare(self):
         """Declare queues, exchanges and bindings.
@@ -677,33 +679,42 @@ class Consumer:
         ---------
             no_ack (bool): See :attr:`no_ack`.
         """
-        self._consume_queues(list(self._queues.values()), no_ack)
+        no_ack = self.no_ack if no_ack is None else no_ack
+        self._consume_queues(
+            {queue.name: no_ack for queue in self._queues.values()}
+        )
 
-    def _consume_previously_active(self, queue_names, no_ack=None):
+    def _consume_previously_active(self, active_no_ack):
         """Start consuming only from the given, previously active queues.
 
         Unlike :meth:`consume`, this will not start consuming from
         queues that were registered (e.g. via :meth:`add_queue`) but
-        never actually consumed from.
+        never actually consumed from, and it restores each queue's
+        own effective ``no_ack`` value instead of applying one value
+        to every queue.
 
         Arguments:
         ---------
-            queue_names (list): Names of the queues to resume consuming
-                from.
-            no_ack (bool): See :attr:`no_ack`.
+            active_no_ack (dict): Mapping of queue name to the
+                ``no_ack`` value it was consumed with.
         """
-        queue_names = set(queue_names)
-        queues = [q for q in self._queues.values() if q.name in queue_names]
-        self._consume_queues(queues, no_ack)
+        # thin wrapper kept for readability/intent at the revive() call site
+        self._consume_queues(active_no_ack)
 
-    def _consume_queues(self, queues, no_ack=None):
-        if queues:
-            no_ack = self.no_ack if no_ack is None else no_ack
-
-            H, T = queues[:-1], queues[-1]
-            for queue in H:
-                self._basic_consume(queue, no_ack=no_ack, nowait=True)
-            self._basic_consume(T, no_ack=no_ack, nowait=False)
+    def _consume_queues(self, no_ack_by_queue):
+        queues = [
+            q for q in self._queues.values() if q.name in no_ack_by_queue
+        ]
+        if not queues:
+            return
+        H, T = queues[:-1], queues[-1]
+        for queue in H:
+            self._basic_consume(
+                queue, no_ack=no_ack_by_queue[queue.name], nowait=True
+            )
+        self._basic_consume(
+            T, no_ack=no_ack_by_queue[T.name], nowait=False
+        )
 
     def cancel(self):
         """End all active queue consumers.
@@ -717,12 +728,14 @@ class Consumer:
         for tag in self._active_tags.values():
             cancel(tag)
         self._active_tags.clear()
+        self._active_queue_no_ack.clear()
 
     close = cancel
 
     def cancel_by_queue(self, queue):
         """Cancel consumer by queue name."""
         qname = queue.name if isinstance(queue, Queue) else queue
+        self._active_queue_no_ack.pop(qname, None)
         try:
             tag = self._active_tags.pop(qname)
         except KeyError:
@@ -829,7 +842,9 @@ class Consumer:
                        no_ack=no_ack, nowait=True):
         tag = self._active_tags.get(queue.name)
         if tag is None:
+            no_ack = queue.no_ack if no_ack is None else no_ack
             tag = self._add_tag(queue, consumer_tag)
+            self._active_queue_no_ack[queue.name] = no_ack
             queue.consume(tag, self._receive_callback,
                           no_ack=no_ack, nowait=nowait)
         return tag

--- a/kombu/messaging.py
+++ b/kombu/messaging.py
@@ -591,6 +591,7 @@ class Consumer:
 
     def revive(self, channel):
         """Revive consumer after connection loss."""
+        was_consuming = bool(self._active_tags)
         self._active_tags.clear()
         channel = self.channel = maybe_channel(channel)
         # modify dict size while iterating over it is not allowed
@@ -605,6 +606,10 @@ class Consumer:
 
         if self.prefetch_count is not None:
             self.qos(prefetch_count=self.prefetch_count)
+
+        if was_consuming:
+            # re-register the AMQP consumers on the new channel.
+            self.consume()
 
     def declare(self):
         """Declare queues, exchanges and bindings.

--- a/kombu/messaging.py
+++ b/kombu/messaging.py
@@ -591,7 +591,7 @@ class Consumer:
 
     def revive(self, channel):
         """Revive consumer after connection loss."""
-        was_consuming = bool(self._active_tags)
+        previously_active = set(self._active_tags)
         self._active_tags.clear()
         channel = self.channel = maybe_channel(channel)
         # modify dict size while iterating over it is not allowed
@@ -607,9 +607,12 @@ class Consumer:
         if self.prefetch_count is not None:
             self.qos(prefetch_count=self.prefetch_count)
 
-        if was_consuming:
-            # re-register the AMQP consumers on the new channel.
-            self.consume()
+        if previously_active:
+            # re-register the AMQP consumers on the new channel, but only
+            # for the queues that were actually being consumed from before
+            # (queues added via add_queue() but never consumed from should
+            # stay that way).
+            self.consume_previously_active(previously_active)
 
     def declare(self):
         """Declare queues, exchanges and bindings.
@@ -677,7 +680,26 @@ class Consumer:
         ---------
             no_ack (bool): See :attr:`no_ack`.
         """
-        queues = list(self._queues.values())
+        self._consume_queues(list(self._queues.values()), no_ack)
+
+    def consume_previously_active(self, queue_names, no_ack=None):
+        """Start consuming only from the given, previously active queues.
+
+        Unlike :meth:`consume`, this will not start consuming from
+        queues that were registered (e.g. via :meth:`add_queue`) but
+        never actually consumed from.
+
+        Arguments:
+        ---------
+            queue_names (Iterable[str]): Names of the queues to resume
+                consuming from.
+            no_ack (bool): See :attr:`no_ack`.
+        """
+        queue_names = set(queue_names)
+        queues = [q for q in self._queues.values() if q.name in queue_names]
+        self._consume_queues(queues, no_ack)
+
+    def _consume_queues(self, queues, no_ack=None):
         if queues:
             no_ack = self.no_ack if no_ack is None else no_ack
 

--- a/kombu/messaging.py
+++ b/kombu/messaging.py
@@ -609,7 +609,7 @@ class Consumer:
 
         # re-register the AMQP consumers, but only for queues that were
         # actually being consumed from before (not merely registered).
-        self._consume_previously_active(previously_active)
+        self._consume_previously_active(previously_active, no_ack=getattr(self, '_active_no_ack', None))
 
     def declare(self):
         """Declare queues, exchanges and bindings.

--- a/kombu/messaging.py
+++ b/kombu/messaging.py
@@ -607,12 +607,9 @@ class Consumer:
         if self.prefetch_count is not None:
             self.qos(prefetch_count=self.prefetch_count)
 
-        if previously_active:
-            # re-register the AMQP consumers on the new channel, but only
-            # for the queues that were actually being consumed from before
-            # (queues added via add_queue() but never consumed from should
-            # stay that way).
-            self.consume_previously_active(previously_active)
+        # re-register the AMQP consumers, but only for queues that were
+        # actually being consumed from before (not merely registered).
+        self._consume_previously_active(previously_active)
 
     def declare(self):
         """Declare queues, exchanges and bindings.
@@ -682,7 +679,7 @@ class Consumer:
         """
         self._consume_queues(list(self._queues.values()), no_ack)
 
-    def consume_previously_active(self, queue_names, no_ack=None):
+    def _consume_previously_active(self, queue_names, no_ack=None):
         """Start consuming only from the given, previously active queues.
 
         Unlike :meth:`consume`, this will not start consuming from
@@ -691,8 +688,8 @@ class Consumer:
 
         Arguments:
         ---------
-            queue_names (Iterable[str]): Names of the queues to resume
-                consuming from.
+            queue_names (list): Names of the queues to resume consuming
+                from.
             no_ack (bool): See :attr:`no_ack`.
         """
         queue_names = set(queue_names)

--- a/kombu/messaging.py
+++ b/kombu/messaging.py
@@ -609,7 +609,7 @@ class Consumer:
 
         # re-register the AMQP consumers, but only for queues that were
         # actually being consumed from before (not merely registered).
-        self._consume_previously_active(previously_active, no_ack=getattr(self, '_active_no_ack', None))
+        self._consume_previously_active(previously_active)
 
     def declare(self):
         """Declare queues, exchanges and bindings.

--- a/t/integration/test_py_amqp.py
+++ b/t/integration/test_py_amqp.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import socket
 import uuid
 
 import pytest
@@ -144,3 +145,65 @@ class test_PyAMQPConnectionPool:
             producer.publish(
                 {"foo": "bar"}, routing_key=str(uuid.uuid4()), retry=False, timeout=3
             )
+
+
+@pytest.mark.env('py-amqp')
+@pytest.mark.flaky(reruns=5, reruns_delay=2)
+class test_PyAMQPConsumerRevive:
+    """Regression tests for #814."""
+
+    def test_revive_resumes_active_queue_only(self, connection):
+        active_name = f'revive_active_{uuid.uuid4()}'
+        inactive_name = f'revive_inactive_{uuid.uuid4()}'
+        # default exchange requires routing_key == queue name
+        active_queue = kombu.Queue(active_name, routing_key=active_name)
+        inactive_queue = kombu.Queue(inactive_name, routing_key=inactive_name)
+
+        received = []
+
+        def callback(body, message):
+            received.append(body)
+            message.ack()
+
+        def _drain(conn, timeout):
+            try:
+                conn.drain_events(timeout=timeout)
+            except socket.timeout:
+                pass
+
+        with connection as conn:
+            with conn.channel():
+                consumer = kombu.Consumer(
+                    conn, [active_queue], accept=['pickle']
+                )
+                consumer.register_callback(callback)
+
+                with consumer:
+                    # registered but never consumed from
+                    consumer.add_queue(inactive_queue)
+                    assert inactive_queue.name not in consumer._active_tags
+
+                    # kill the socket to simulate the broker vanishing
+                    sock = conn.connection.transport.sock
+                    sock.shutdown(socket.SHUT_RDWR)
+                    sock.close()
+
+                    safe_drain = conn.ensure(consumer, _drain, max_retries=3)
+                    safe_drain(conn, 1)
+
+                    assert active_queue.name in consumer._active_tags
+                    assert inactive_queue.name not in consumer._active_tags
+
+                    # confirm messages are actually delivered post-recovery
+                    producer = kombu.Producer(conn)
+                    producer.publish(
+                        {'hello': 'world'},
+                        retry=True,
+                        exchange=active_queue.exchange,
+                        routing_key=active_queue.routing_key,
+                        declare=[active_queue],
+                        serializer='pickle',
+                    )
+                    safe_drain(conn, 1)
+
+        assert received == [{'hello': 'world'}]

--- a/t/unit/test_messaging.py
+++ b/t/unit/test_messaging.py
@@ -1119,10 +1119,7 @@ class test_Consumer:
         assert 'qname2' not in consumer._active_tags
 
     def test_active_tags_reflects_intent_not_broker_ack(self):
-        # _add_tag() records the tag in _active_tags before
-        # channel.basic_consume is called. Even if the broker
-        # never gets/acks the request (e.g. connection resets),
-        # the tag should be recorded locally.
+        # tag is recorded before channel.basic_consume is called
         channel = self.connection.channel()
         b1 = Queue('qname1', self.exchange, 'rkey')
         consumer = Consumer(channel, [b1])

--- a/t/unit/test_messaging.py
+++ b/t/unit/test_messaging.py
@@ -1118,6 +1118,27 @@ class test_Consumer:
         assert 'qname1' in consumer._active_tags
         assert 'qname2' not in consumer._active_tags
 
+    def test_revive__preserves_per_call_no_ack_override(self):
+        channel = self.connection.channel()
+        b1 = Queue('qname1', self.exchange, 'rkey')
+        b2 = Queue('qname2', self.exchange, 'rkey2')
+        consumer = Consumer(channel, [b1])
+        consumer.consume(no_ack=True)
+
+        # a later consume() call with a different override only
+        # affects the queue that wasn't already consuming.
+        consumer.add_queue(b2)
+        consumer.consume(no_ack=False)
+
+        assert consumer._active_queue_no_ack['qname1'] is True
+        assert consumer._active_queue_no_ack['qname2'] is False
+
+        channel2 = self.connection.channel()
+        consumer.revive(channel2)
+
+        assert consumer._active_queue_no_ack['qname1'] is True
+        assert consumer._active_queue_no_ack['qname2'] is False
+
     def test_active_tags_reflects_intent_not_broker_ack(self):
         # tag is recorded before channel.basic_consume is called
         channel = self.connection.channel()

--- a/t/unit/test_messaging.py
+++ b/t/unit/test_messaging.py
@@ -1078,6 +1078,47 @@ class test_Consumer:
         assert consumer.queues[0].channel is channel2
         assert consumer.queues[0].exchange.channel is channel2
 
+    def test_revive__resumes_consuming_if_active(self):
+        channel = self.connection.channel()
+        b1 = Queue('qname1', self.exchange, 'rkey')
+        consumer = Consumer(channel, [b1])
+        consumer.consume()
+        assert consumer._active_tags
+
+        channel2 = self.connection.channel()
+        consumer.revive(channel2)
+        assert consumer._active_tags
+        assert 'basic_consume' in channel2
+
+    def test_revive__does_not_consume_if_not_active(self):
+        channel = self.connection.channel()
+        b1 = Queue('qname1', self.exchange, 'rkey')
+        consumer = Consumer(channel, [b1])
+
+        channel2 = self.connection.channel()
+        consumer.revive(channel2)
+        assert not consumer._active_tags
+        assert 'basic_consume' not in channel2
+
+    def test_active_tags_reflects_intent_not_broker_ack(self):
+        # _add_tag() records the tag in _active_tags before
+        # channel.basic_consume is called. Even if the broker
+        # never gets/acks the request (e.g. connection resets),
+        # the tag should be recorded locally.
+        channel = self.connection.channel()
+        b1 = Queue('qname1', self.exchange, 'rkey')
+        consumer = Consumer(channel, [b1])
+
+        def _boom(*args, **kwargs):
+            raise OperationalError('connection lost before broker ack')
+        channel.basic_consume = _boom
+
+        with pytest.raises(OperationalError):
+            consumer.consume()
+
+        assert consumer._active_tags
+        assert 'basic_consume' not in channel
+
     def test_revive__with_prefetch_count(self):
         channel = Mock(name='channel')
         b1 = Queue('qname1', self.exchange, 'rkey')

--- a/t/unit/test_messaging.py
+++ b/t/unit/test_messaging.py
@@ -1100,6 +1100,24 @@ class test_Consumer:
         assert not consumer._active_tags
         assert 'basic_consume' not in channel2
 
+    def test_revive__does_not_resume_never_active_queue(self):
+        channel = self.connection.channel()
+        b1 = Queue('qname1', self.exchange, 'rkey')
+        b2 = Queue('qname2', self.exchange, 'rkey2')
+        consumer = Consumer(channel, [b1])
+        consumer.consume()
+        assert 'qname1' in consumer._active_tags
+
+        # registered but deliberately not consumed from yet
+        consumer.add_queue(b2)
+        assert 'qname2' not in consumer._active_tags
+
+        channel2 = self.connection.channel()
+        consumer.revive(channel2)
+
+        assert 'qname1' in consumer._active_tags
+        assert 'qname2' not in consumer._active_tags
+
     def test_active_tags_reflects_intent_not_broker_ack(self):
         # _add_tag() records the tag in _active_tags before
         # channel.basic_consume is called. Even if the broker


### PR DESCRIPTION
Issue #814 describes how a Kombu consumer fails to properly recover when the message broker experiences issues without explicitly calling `consumer.consume()`. This happens because, while the queues are still recorded, `consumer.revive()` will clear the active tags originally recorded in the consumer without setting new ones for the active queues.

A simple solution would be to modify revive to check whether the consumer had any active tags at the time, and call `consume` if it did. To prevent consumption from previously inactive queues at the time of the connection crash, I've created a new method `_consume_previously_active` so that revive will not silently activate them.

To avoid duplicating the basic_consume loop between `consume` and `_consume_previously_active`, I extracted it into a shared `_consume_queues` helper. Behavior should be unchanged.

Apart from unit tests, I've tested that case manually by modifying the consumer file provided in #814 to include a new queue that's never consumed from, then logged the active tags in `revive` at the start and end of the method. Upon RabbitMQ restart, the previously inactive queue remains inactive.

Closes #814 