### PR TITLE
fix(utils): don't evict a key when overwriting an existing LRUCache entry

### DIFF
--- a/kombu/utils/functional.py
+++ b/kombu/utils/functional.py
@@ -79,7 +79,13 @@ class LRUCache(UserDict):
     def __setitem__(self, key, value):
         # remove least recently used key.
         with self.mutex:
-            if self.limit and len(self.data) >= self.limit:
+            # Only an insert can push the cache over its limit; overwriting
+            # a key that is already there keeps the same number of entries,
+            # so evicting for it would shrink the cache below the limit and
+            # throw away an unrelated key. ``update`` already gets this
+            # right, it only trims once the data has actually grown.
+            if (key not in self.data and
+                    self.limit and len(self.data) >= self.limit):
                 self.data.pop(next(iter(self.data)))
             self.data[key] = value
 

--- a/t/unit/utils/test_functional.py
+++ b/t/unit/utils/test_functional.py
@@ -103,6 +103,25 @@ class test_LRUCache:
         x[7] = 7
         assert list(x.keys()), [3, 6 == 7]
 
+    def test_setitem_existing_key_does_not_evict(self):
+        x = LRUCache(limit=3)
+        x['a'], x['b'], x['c'] = 1, 2, 3
+
+        # overwriting a key already in the cache does not make it grow,
+        # so nothing may be evicted to make room for it.
+        x['c'] = 30
+
+        assert list(x.items()) == [('a', 1), ('b', 2), ('c', 30)]
+        assert len(x) == 3
+
+    def test_setitem_new_key_evicts_least_recently_used(self):
+        x = LRUCache(limit=2)
+        x['a'], x['b'] = 1, 2
+
+        x['c'] = 3
+
+        assert list(x.items()) == [('b', 2), ('c', 3)]
+
     def test_update_larger_than_cache_size(self):
         x = LRUCache(2)
         x.update({x: x for x in range(100)})


### PR DESCRIPTION
`LRUCache.__setitem__` evicts a key it should not, and the cache ends up smaller than its limit.

The eviction check in `kombu/utils/functional.py` (lines 79-84 on main) is `if self.limit and len(self.data) >= self.limit: self.data.pop(next(iter(self.data)))`. It never looks at whether `key` is already in the cache. Overwriting an existing key does not add an entry, so that eviction drops an unrelated key for nothing and the cache is left one entry short. With `LRUCache(limit=3)` holding `a`, `b`, `c`, writing `c` again drops `a` and leaves two entries:

```python
>>> from kombu.utils.functional import LRUCache
>>> x = LRUCache(limit=3)
>>> x['a'], x['b'], x['c'] = 1, 2, 3
>>> x['c'] = 30
>>> list(x.items())
[('b', 2), ('c', 30)]
```

`LRUCache.update` on the same class takes the other path: it writes into the `OrderedDict` first and trims only once `len(data)` has actually gone over the limit, so the same overwrite through `update` keeps all three keys. The two write paths disagreed about the same operation.

The fix is one condition: `__setitem__` evicts only when the key is not already present, which is what `update` does. Inserting a new key still evicts the least recently used entry.

Verification, on Python 3.11 with `requirements/test.txt` and `requirements/test-ci.txt` installed:

`python -m pytest t/unit/utils/test_functional.py -k setitem` on main with only the two new tests applied gives `1 failed, 1 passed`: `test_setitem_existing_key_does_not_evict` fails with `assert [('b', 2), ('c', 30)] == [('a', 1), ('b', 2), ('c', 30)]`, and `test_setitem_new_key_evicts_least_recently_used` already passes, so the fix does not change the eviction behaviour that works.

With the fix, `python -m pytest t/unit/utils/test_functional.py -q` gives `37 passed`, and the whole unit suite `python -m pytest t/unit -q` gives `1718 passed, 169 skipped in 50.42s`. `flake8 kombu/utils/functional.py t/unit/utils/test_functional.py` and `isort --check-only` are clean on both files, and `mypy` with the repository's `setup.cfg` file list reports `Success: no issues found in 22 source files`.
