### PR TITLE
Raise ValueError when fileno() is given None

### DIFF
--- a/kombu/utils/compat.py
+++ b/kombu/utils/compat.py
@@ -108,6 +108,10 @@ def fileno(f):
     """Get fileno from file-like object."""
     if isinstance(f, numbers.Integral):
         return f
+    if f is None:
+        # Celery's iterate_file_descriptors_safely catches ValueError,
+        # not AttributeError, so a closed/missing fd must be ValueError.
+        raise ValueError('file descriptor is None')
     return f.fileno()
 
 

--- a/t/unit/utils/test_compat.py
+++ b/t/unit/utils/test_compat.py
@@ -8,7 +8,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from kombu.utils import compat
-from kombu.utils.compat import entrypoints, maybe_fileno
+from kombu.utils.compat import entrypoints, fileno, maybe_fileno
 
 
 def test_entrypoints():
@@ -34,6 +34,12 @@ def test_maybe_fileno():
     assert maybe_fileno(f) is f.fileno()
     f.fileno.side_effect = ValueError()
     assert maybe_fileno(f) is None
+
+
+def test_fileno_none():
+    with pytest.raises(ValueError, match='None'):
+        fileno(None)
+    assert maybe_fileno(None) is None
 
 
 class test_detect_environment:


### PR DESCRIPTION
Closes #1649.

Celery asynpool's `iterate_file_descriptors_safely` catches `OSError` and `ValueError` when a worker fd is already gone. `fileno(None)` raised `AttributeError`, which is not in that list, so the hub crashed.

`maybe_fileno` already swallowed `AttributeError`. Raising `ValueError` from `fileno(None)` matches the recovery path callers already have.
