### PR TITLE
fix(redis): import from redis submodules

### DIFF
--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -108,6 +108,7 @@ from . import virtual
 
 try:
     import redis
+    from redis import client, exceptions
     _REDIS_GET_CONNECTION_WITHOUT_ARGS = Version(version("redis")) >= Version("5.3.0")
 except ImportError:  # pragma: no cover
     redis = None
@@ -220,7 +221,7 @@ def Mutex(client, name, expire):
         if lock_acquired:
             try:
                 lock.release()
-            except redis.exceptions.LockNotOwnedError:
+            except exceptions.LockNotOwnedError:
                 # when lock is expired
                 pass
 
@@ -328,7 +329,7 @@ class PrefixedStrictRedis(GlobalKeyPrefixMixin, redis.Redis):
         )
 
 
-class PrefixedRedisPipeline(GlobalKeyPrefixMixin, redis.client.Pipeline):
+class PrefixedRedisPipeline(GlobalKeyPrefixMixin, client.Pipeline):
     """Custom Redis pipeline that takes global_keyprefix into consideration.
 
     As the ``PrefixedStrictRedis`` client uses the `global_keyprefix` to prefix
@@ -338,10 +339,10 @@ class PrefixedRedisPipeline(GlobalKeyPrefixMixin, redis.client.Pipeline):
 
     def __init__(self, *args, **kwargs):
         self.global_keyprefix = kwargs.pop('global_keyprefix', '')
-        redis.client.Pipeline.__init__(self, *args, **kwargs)
+        client.Pipeline.__init__(self, *args, **kwargs)
 
 
-class PrefixedRedisPubSub(redis.client.PubSub):
+class PrefixedRedisPubSub(client.PubSub):
     """Redis pubsub client that takes global_keyprefix into consideration."""
 
     PUBSUB_COMMANDS = (

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import base64
 import copy
+import importlib
 import socket
+import sys
 import types
 from collections import defaultdict
 from contextlib import contextmanager
@@ -3579,3 +3581,17 @@ class test_GlobalKeyPrefixMixin:
             f"{self.global_keyprefix}fake_key",
             "not_prefixed",
         ]
+
+
+def test_transport_imports_when_redis_parent_module_was_evicted():
+    import kombu.transport
+
+    saved_redis = sys.modules.pop('redis')
+    saved_transport = sys.modules.pop('kombu.transport.redis')
+    try:
+        assert not hasattr(importlib.import_module('redis'), 'client')
+        assert importlib.import_module('kombu.transport.redis').Transport
+    finally:
+        sys.modules['redis'] = saved_redis
+        sys.modules['kombu.transport.redis'] = saved_transport
+        kombu.transport.redis = saved_transport


### PR DESCRIPTION
`kombu.transport.redis` fails to import for the rest of the process once the `redis` parent module has been evicted mid-import.

The transport reaches its base classes through the parent package attribute: `class PrefixedRedisPipeline(GlobalKeyPrefixMixin, redis.client.Pipeline)` at line 331 on main, `redis.client.Pipeline.__init__` at 341, `class PrefixedRedisPubSub(redis.client.PubSub)` at 344, and `redis.exceptions.LockNotOwnedError` in `Mutex` at 223.

A `BaseException` raised inside the first `import redis` makes CPython evict the half-initialized parent from `sys.modules` while leaving the submodules cached. A signal-based timeout around the import produces exactly that state. The next `import redis` reuses the cached submodule and never rebinds `client` on the fresh parent:

```python
>>> import redis, sys, kombu.transport.redis
>>> from kombu.utils import symbol_by_name
>>> del sys.modules['redis'], sys.modules['kombu.transport.redis']
>>> import redis
>>> hasattr(redis, 'client'), hasattr(redis, 'exceptions')
(False, False)
>>> symbol_by_name('kombu.transport.redis:Transport')
AttributeError: module 'redis' has no attribute 'client'
```

The same module already takes the other path for `sentinel`: line 120 is `from redis import CredentialProvider, sentinel`, and `sentinel` still resolves after the eviction because `IMPORT_FROM` falls back to `sys.modules`. `get_redis_error_classes` and `get_redis_ConnectionError` spell it the same way, `from redis import exceptions`.

The fix uses that spelling at module scope: `from redis import client, exceptions`. Only the surviving names change, so a plain `redis.Redis` and the rest are untouched.

Verification, Python 3.11 with `requirements/test.txt` and the sqs, azurestoragequeues and gcpubsub extras installed: on main with only the new test applied, `test_transport_imports_when_redis_parent_module_was_evicted` fails at `kombu/transport/redis.py:331` with `AttributeError: module 'redis' has no attribute 'client'`. With the fix, `python -m pytest t/unit/transport/test_redis.py -q` gives `216 passed` and `python -m pytest t/unit -q` gives `1586 passed, 183 skipped`. `flake8` and `isort --check-only` are clean on both files.

#2096 was closed as a redis-py bug and redis/redis-py#3353 was then closed as not planned, so the parent-attribute binding is the only side left to change.

Refs #2096 and apache/airflow#41359.
