### PR TITLE
fix(redis): add sentinel_fanout_compat transport option for mixed-version Sentinel clusters

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -14,6 +14,12 @@ What's Changed
   uses a non-transactional pipeline to publish multiple messages in fewer
   network round trips while retaining normal serialization, routing,
   priorities, queue expiry, and fanout behavior.
+- Add the ``sentinel_fanout_compat`` transport option to the Redis Sentinel
+  transport. When enabled, fanout messages are published to and consumed from
+  both the current ``/<db>.`` PUB/SUB topic and the legacy ``/{db}.`` topic
+  used by kombu < 5.4.0, so that mixed-version workers keep exchanging
+  broadcast messages such as Celery control commands during a rolling
+  upgrade (#2152).
 
 .. _version-5.6.2:
 

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -17,9 +17,13 @@ What's Changed
 - Add the ``sentinel_fanout_compat`` transport option to the Redis Sentinel
   transport. When enabled, fanout messages are published to and consumed from
   both the current ``/<db>.`` PUB/SUB topic and the legacy ``/{db}.`` topic
-  used by kombu < 5.4.0, so that mixed-version workers keep exchanging
-  broadcast messages such as Celery control commands during a rolling
-  upgrade (#2152).
+  used by kombu < 5.4.0, so that mixed-version workers and control clients
+  keep exchanging broadcast messages such as Celery control commands during
+  a rolling upgrade (#2152).
+- Fix the Redis transport cancelling fanout consumers with ``UNSUBSCRIBE``
+  although it subscribes with ``PSUBSCRIBE``, which left the pattern
+  subscriptions active on the pub/sub connection after a consumer was
+  cancelled.
 
 .. _version-5.6.2:
 

--- a/docs/reference/kombu.transport.redis.rst
+++ b/docs/reference/kombu.transport.redis.rst
@@ -157,6 +157,37 @@
     When no streaming credential provider is configured this machinery is a
     cheap no-op, so it is always safe to leave enabled.
 
+    Redis Sentinel: rolling upgrades from kombu < 5.4.0
+    ----------------------------------------------------
+    .. versionadded:: 5.7.0
+
+    kombu 5.4.0 changed the PUB/SUB topic that the Sentinel transport uses
+    for fanout exchanges: it now substitutes the database number into the
+    fanout prefix (``/0.celery.pidbox``), where earlier releases used the
+    literal prefix (``/{db}.celery.pidbox``).  Fanout is how Celery delivers
+    its control commands (``ping``, ``shutdown``, ``rate_limit``, Flower,
+    ...), so during a rolling upgrade workers on either side of that release
+    no longer see each other's broadcasts.
+
+    Set the ``sentinel_fanout_compat`` transport option on every upgraded
+    participant, workers as well as Flower or any other client sending
+    control commands, for the duration of the upgrade:
+
+    .. code-block:: python
+
+        app.conf.broker_transport_options = {
+            "master_name": "mymaster",
+            "sentinel_fanout_compat": True,
+        }
+
+    With the option enabled the channel publishes every fanout message to
+    both topics and subscribes to both, delivering a message that arrives
+    twice only once.  Remove the option once every participant runs a
+    release that understands the current topic; turning it off in a rolling
+    fashion is safe as well.  The option has no effect when ``fanout_prefix``
+    is set to a value without a ``{db}`` placeholder, because old and new
+    workers then already share the same topic.
+
     Queue arguments
     ---------------
     The following queue argument is supported. Pass it per-queue via

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -68,10 +68,11 @@ Transport Options
 * ``sentinel_fanout_compat``: (bool) Sentinel only.  When enabled the
   channel also publishes to, and subscribes on, the legacy fanout topic
   (literally ``/{db}.<exchange>``) used by kombu < 5.4.0, next to the
-  current ``/<db>.<exchange>`` topic.  Enable it on every worker while
-  performing a rolling upgrade from kombu < 5.4.0, so that mixed-version
-  workers keep exchanging broadcast messages such as Celery control
-  commands, and remove it once every worker has been upgraded.
+  current ``/<db>.<exchange>`` topic.  Enable it on every upgraded
+  participant of fanout traffic (workers as well as Flower or any other
+  client sending control commands) while performing a rolling upgrade
+  from kombu < 5.4.0, so that mixed-version participants keep exchanging
+  broadcast messages, and remove it once everything has been upgraded.
   Defaults to ``False``.
 
 Queue Arguments
@@ -1157,19 +1158,23 @@ class Channel(virtual.Channel):
         topics = self._get_subscribe_topics(queue)
         c = self.subclient
         if c.connection and c.connection._sock:
-            c.unsubscribe(topics)
+            # topics were registered with PSUBSCRIBE, so only PUNSUBSCRIBE
+            # removes them again.
+            c.punsubscribe(topics)
 
     def _handle_message(self, client, r):
-        if bytes_to_str(r[0]) == 'unsubscribe' and r[2] == 0:
-            client.subscribed = False
-            return
-
-        if bytes_to_str(r[0]) == 'pmessage':
-            type, pattern, channel, data = r[0], r[1], r[2], r[3]
+        message_type = bytes_to_str(r[0])
+        if message_type == 'pmessage':
+            pattern, channel, data = r[1], r[2], r[3]
         else:
-            type, pattern, channel, data = r[0], None, r[1], r[2]
+            pattern, channel, data = None, r[1], r[2]
+        if message_type in ('unsubscribe', 'punsubscribe'):
+            # Let redis-py update its own subscription bookkeeping, so that
+            # ``client.subscribed`` is cleared once nothing is left and a
+            # cancelled pattern is not re-subscribed to on reconnect.
+            client.handle_message(r)
         return {
-            'type': type,
+            'type': r[0],
             'pattern': pattern,
             'channel': channel,
             'data': data,
@@ -2021,13 +2026,13 @@ class SentinelChannel(Channel):
 
     #: Also publish to, and subscribe on, the legacy fanout topic used by
     #: kombu < 5.4.0 (literally ``/{db}.<exchange>``) in addition to the
-    #: current ``/<db>.<exchange>`` topic, so that workers running either
-    #: version keep exchanging broadcast messages (for example Celery
-    #: control commands) during a rolling upgrade.  A message that arrives
-    #: on both topics is delivered only once.
+    #: current ``/<db>.<exchange>`` topic, so that participants running
+    #: either version keep exchanging broadcast messages (for example
+    #: Celery control commands) during a rolling upgrade.  A message that
+    #: arrives on both topics is delivered only once.
     #:
-    #: Disabled by default; enable it via ``transport_options`` for the
-    #: duration of the upgrade only.
+    #: Disabled by default; enable it via ``transport_options`` on every
+    #: upgraded worker and control client for the duration of the upgrade.
     sentinel_fanout_compat = False
 
     #: Number of recently delivered fanout messages remembered for

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -65,6 +65,14 @@ Transport Options
 * ``retry_on_timeout``
 * ``priority_steps``
 * ``client_name``: (str) The name to use when connecting to Redis server.
+* ``sentinel_fanout_compat``: (bool) Sentinel only.  When enabled the
+  channel also publishes to, and subscribes on, the legacy fanout topic
+  (literally ``/{db}.<exchange>``) used by kombu < 5.4.0, next to the
+  current ``/<db>.<exchange>`` topic.  Enable it on every worker while
+  performing a rolling upgrade from kombu < 5.4.0, so that mixed-version
+  workers keep exchanging broadcast messages such as Celery control
+  commands, and remove it once every worker has been upgraded.
+  Defaults to ``False``.
 
 Queue Arguments
 ===============
@@ -82,7 +90,7 @@ import inspect
 import numbers
 import socket
 from bisect import bisect
-from collections import namedtuple
+from collections import OrderedDict, namedtuple
 from contextlib import ExitStack, contextmanager
 from importlib.metadata import version
 from queue import Empty
@@ -1117,13 +1125,26 @@ class Channel(virtual.Channel):
             return ''.join([self.keyprefix_fanout, exchange, '/', routing_key])
         return ''.join([self.keyprefix_fanout, exchange])
 
+    def _get_publish_topics(self, exchange, routing_key):
+        """Return every PUB/SUB topic a fanout message is published to.
+
+        Subclasses can return additional topics when the same message
+        has to reach subscribers that use a different topic layout.
+        """
+        return [self._get_publish_topic(exchange, routing_key)]
+
     def _get_subscribe_topic(self, queue):
         exchange, routing_key = self._fanout_queues[queue]
         return self._get_publish_topic(exchange, routing_key)
 
+    def _get_subscribe_topics(self, queue):
+        exchange, routing_key = self._fanout_queues[queue]
+        return self._get_publish_topics(exchange, routing_key)
+
     def _subscribe(self):
-        keys = [self._get_subscribe_topic(queue)
-                for queue in self.active_fanout_queues]
+        keys = [topic
+                for queue in self.active_fanout_queues
+                for topic in self._get_subscribe_topics(queue)]
         if not keys:
             return
         c = self.subclient
@@ -1133,10 +1154,10 @@ class Channel(virtual.Channel):
         c.psubscribe(keys)
 
     def _unsubscribe_from(self, queue):
-        topic = self._get_subscribe_topic(queue)
+        topics = self._get_subscribe_topics(queue)
         c = self.subclient
         if c.connection and c.connection._sock:
-            c.unsubscribe([topic])
+            c.unsubscribe(topics)
 
     def _handle_message(self, client, r):
         if bytes_to_str(r[0]) == 'unsubscribe' and r[2] == 0:
@@ -1186,9 +1207,15 @@ class Channel(virtual.Channel):
                                 channel, repr(payload)[:4096], exc_info=1)
                         raise Empty()
                     exchange = channel.split('/', 1)[0]
-                    self.connection._deliver(
-                        message, self._fanout_to_queue[exchange])
-                    return True
+                    return self._deliver_fanout_message(message, exchange)
+
+    def _deliver_fanout_message(self, message, exchange):
+        """Deliver a decoded fanout *message* received for *exchange*.
+
+        Returns True once the message has been delivered.
+        """
+        self.connection._deliver(message, self._fanout_to_queue[exchange])
+        return True
 
     def _brpop_start(self, timeout=None):
         if timeout is None:
@@ -1439,13 +1466,15 @@ class Channel(virtual.Channel):
     def _put_fanout(self, exchange, message, routing_key, **kwargs):
         """Deliver fanout message."""
         publish_batch = kwargs.pop('_publish_batch', None)
-        topic = self._get_publish_topic(exchange, routing_key)
+        topics = self._get_publish_topics(exchange, routing_key)
         payload = dumps(message)
         if publish_batch is not None:
-            publish_batch.add('publish', topic, payload)
+            for topic in topics:
+                publish_batch.add('publish', topic, payload)
             return
         with self.conn_or_acquire() as client:
-            client.publish(topic, payload)
+            for topic in topics:
+                client.publish(topic, payload)
 
     def _new_queue(self, queue, auto_delete=False, **kwargs):
         if auto_delete:
@@ -1984,10 +2013,34 @@ class SentinelChannel(Channel):
     from_transport_options = Channel.from_transport_options + (
         'master_name',
         'min_other_sentinels',
-        'sentinel_kwargs')
+        'sentinel_kwargs',
+        'sentinel_fanout_compat')
 
     connection_class = sentinel.SentinelManagedConnection if sentinel else None
     connection_class_ssl = SentinelManagedSSLConnection if sentinel else None
+
+    #: Also publish to, and subscribe on, the legacy fanout topic used by
+    #: kombu < 5.4.0 (literally ``/{db}.<exchange>``) in addition to the
+    #: current ``/<db>.<exchange>`` topic, so that workers running either
+    #: version keep exchanging broadcast messages (for example Celery
+    #: control commands) during a rolling upgrade.  A message that arrives
+    #: on both topics is delivered only once.
+    #:
+    #: Disabled by default; enable it via ``transport_options`` for the
+    #: duration of the upgrade only.
+    sentinel_fanout_compat = False
+
+    #: Number of recently delivered fanout messages remembered for
+    #: de-duplication while :attr:`sentinel_fanout_compat` is enabled.
+    _fanout_compat_dedup_size = 1000
+
+    #: The unformatted fanout prefix (``/{db}.``), captured before
+    #: :meth:`_get_pool` substitutes the database number into it.
+    _legacy_keyprefix_fanout = None
+
+    def __init__(self, *args, **kwargs):
+        self._seen_fanout_tags = OrderedDict()
+        super().__init__(*args, **kwargs)
 
     def _sentinel_managed_pool(self, asynchronous=False):
         connparams = self._connparams(asynchronous)
@@ -2034,8 +2087,73 @@ class SentinelChannel(Channel):
 
     def _get_pool(self, asynchronous=False):
         params = self._connparams(asynchronous=asynchronous)
+        if self._legacy_keyprefix_fanout is None:
+            # kombu < 5.4.0 never substituted the database number into the
+            # sentinel fanout prefix, so older workers publish and listen
+            # on the literal '/{db}.' topic.  Keep the unformatted prefix
+            # so that ``sentinel_fanout_compat`` can still address them.
+            self._legacy_keyprefix_fanout = self.keyprefix_fanout
         self.keyprefix_fanout = self.keyprefix_fanout.format(db=params['db'])
         return self._sentinel_managed_pool(asynchronous)
+
+    @property
+    def _fanout_compat_active(self):
+        """Whether fanout traffic must also use the legacy topic.
+
+        This is the case when :attr:`sentinel_fanout_compat` is enabled
+        and formatting the prefix actually changed it: with a custom
+        prefix that has no ``{db}`` placeholder, old and new workers
+        already share the same topic.
+        """
+        return bool(
+            self.sentinel_fanout_compat
+            and self._legacy_keyprefix_fanout is not None
+            and self._legacy_keyprefix_fanout != self.keyprefix_fanout
+        )
+
+    def _get_legacy_publish_topic(self, exchange, routing_key):
+        # Same layout as _get_publish_topic, using the unformatted prefix.
+        if routing_key and self.fanout_patterns:
+            return ''.join([
+                self._legacy_keyprefix_fanout, exchange, '/', routing_key,
+            ])
+        return ''.join([self._legacy_keyprefix_fanout, exchange])
+
+    def _get_publish_topics(self, exchange, routing_key):
+        topics = super()._get_publish_topics(exchange, routing_key)
+        if self._fanout_compat_active:
+            topics.append(
+                self._get_legacy_publish_topic(exchange, routing_key))
+        return topics
+
+    def _deliver_fanout_message(self, message, exchange):
+        if (self._fanout_compat_active and
+                self._is_duplicate_fanout_message(message, exchange)):
+            return False
+        return super()._deliver_fanout_message(message, exchange)
+
+    def _is_duplicate_fanout_message(self, message, exchange):
+        """Return True if *message* was already received on the other topic.
+
+        Every message published through kombu carries a unique
+        ``delivery_tag`` (see
+        :meth:`kombu.transport.virtual.Channel._inplace_augment_message`),
+        so seeing a tag again means the message arrived on both the
+        current and the legacy topic.  Messages without a tag cannot be
+        told apart and are never treated as duplicates.
+        """
+        try:
+            tag = message['properties']['delivery_tag']
+        except (KeyError, TypeError):
+            return False
+        key = (exchange, tag)
+        seen = self._seen_fanout_tags
+        if key in seen:
+            return True
+        seen[key] = None
+        if len(seen) > self._fanout_compat_dedup_size:
+            seen.popitem(last=False)
+        return False
 
 
 class SentinelTransport(Transport):

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -75,6 +75,8 @@ Transport Options
   broadcast messages, and remove it once everything has been upgraded.
   Defaults to ``False``.
 
+  .. versionadded:: 5.7.0
+
 Queue Arguments
 ===============
 * ``x-expires``: (int) Time in milliseconds for queues to expire if there's no activity.
@@ -2003,6 +2005,10 @@ class SentinelChannel(Channel):
     You must provide at least one option in Transport options:
      * `master_name` - name of the redis group to poll
 
+    Optional transport options:
+     * `sentinel_fanout_compat` - also use the fanout topic of kombu < 5.4.0
+       while performing a rolling upgrade, see :attr:`sentinel_fanout_compat`.
+
     Example:
     -------
     .. code-block:: python
@@ -2033,6 +2039,8 @@ class SentinelChannel(Channel):
     #:
     #: Disabled by default; enable it via ``transport_options`` on every
     #: upgraded worker and control client for the duration of the upgrade.
+    #:
+    #: .. versionadded:: 5.7.0
     sentinel_fanout_compat = False
 
     #: Number of recently delivered fanout messages remembered for

--- a/t/integration/test_redis.py
+++ b/t/integration/test_redis.py
@@ -2,13 +2,15 @@ from __future__ import annotations
 
 import os
 import socket
-from time import sleep
+from time import monotonic, sleep
+from unittest.mock import patch
 
 import pytest
 import redis
 
 import kombu
-from kombu.transport.redis import SUBCLIENT_MAX_MISSED_HEALTH_CHECKS, Transport
+from kombu.transport.redis import (SUBCLIENT_MAX_MISSED_HEALTH_CHECKS, Channel,
+                                   SentinelChannel, Transport)
 from kombu.utils.json import loads
 
 from .common import (BaseExchangeTypes, BaseMessage, BasePriority,
@@ -668,3 +670,189 @@ class test_RedisSubclientHealthCheck:
             conn.drain_events(timeout=1)
 
         assert received == [{'msg': 'recovered'}]
+
+
+class _LegacySentinelChannel(Channel):
+    """Behave like the ``SentinelChannel`` of kombu < 5.4.0.
+
+    Those versions never substituted the database number into the fanout
+    prefix, so their PUB/SUB topics are literally ``/{db}.<exchange>``.
+    """
+
+    def _get_pool(self, asynchronous=False):
+        return redis.ConnectionPool(**self._connparams(asynchronous))
+
+
+class _LegacySentinelTransport(Transport):
+    Channel = _LegacySentinelChannel
+
+
+@pytest.mark.env('redis')
+@pytest.mark.flaky(reruns=5, reruns_delay=2)
+class test_RedisSentinelFanoutCompat:
+    """``sentinel_fanout_compat`` keeps fanout working across kombu versions.
+
+    kombu < 5.4.0 sentinel workers use the literal ``/{db}.<exchange>``
+    PUB/SUB topic while newer ones use ``/<db>.<exchange>``, so broadcast
+    messages such as Celery control commands stop flowing between them
+    (celery/kombu#2152).
+
+    The integration environment runs no Sentinel, so master discovery is
+    bypassed and ``SentinelChannel`` connects straight to the Redis server;
+    the topic selection, PUB/SUB handling and de-duplication under test are
+    the real code.  The old side of the conversation is played by
+    :class:`_LegacySentinelChannel`.
+    """
+
+    @pytest.fixture(autouse=True)
+    def direct_sentinel_channel(self):
+        def direct_pool(channel, asynchronous=False):
+            return redis.ConnectionPool(**channel._connparams(asynchronous))
+
+        with patch.object(SentinelChannel, 'connection_class',
+                          redis.Connection), \
+                patch.object(SentinelChannel, '_sentinel_managed_pool',
+                             direct_pool):
+            yield
+
+    @staticmethod
+    def _host_port():
+        return (os.environ.get('REDIS_HOST', 'localhost'),
+                os.environ.get('REDIS_6379_TCP', '6379'))
+
+    def _sentinel_connection(self, **transport_options):
+        host, port = self._host_port()
+        transport_options.setdefault('master_name', 'mymaster')
+        return kombu.Connection(
+            f'sentinel://{host}:{port}/0',
+            transport_options=transport_options,
+        )
+
+    def _legacy_connection(self):
+        """Return a connection behaving like a kombu < 5.4.0 sentinel worker."""
+        host, port = self._host_port()
+        return kombu.Connection(
+            f'redis://{host}:{port}/0', transport=_LegacySentinelTransport)
+
+    @staticmethod
+    def _consume(channel, exchange, queue_name, received):
+        """Consume *exchange* on *channel*, collecting bodies in *received*."""
+        queue = kombu.Queue(queue_name, exchange=exchange)
+        consumer = kombu.Consumer(
+            channel, [queue], accept=['json'], no_ack=True)
+        consumer.register_callback(
+            lambda body, message: received.append(body))
+        consumer.consume()
+        return consumer
+
+    @staticmethod
+    def _drain(conn, timeout):
+        """Handle events on *conn* for *timeout* seconds.
+
+        ``drain_events()`` returns on any readable event, including
+        subscription confirmations, so keep draining until the time is
+        up and let the tests assert on what was received.
+        """
+        deadline = monotonic() + timeout
+        while (remaining := deadline - monotonic()) > 0:
+            try:
+                conn.drain_events(timeout=remaining)
+            except socket.timeout:
+                return
+
+    @classmethod
+    def _subscribe(cls, conn):
+        # the first drain registers the pub/sub connection with the poller
+        # and sends PSUBSCRIBE; give the server time to confirm it.
+        cls._drain(conn, 0.2)
+
+    @staticmethod
+    def _publish(conn, exchange, body):
+        # declare the exchange on the publishing channel, otherwise the
+        # virtual transport treats an unknown exchange as a direct one.
+        kombu.Producer(
+            conn.default_channel, exchange=exchange, serializer='json',
+        ).publish(body, declare=[exchange])
+
+    def test_legacy_consumer_receives_compat_publisher(self):
+        exchange = kombu.Exchange('sfc_compat_to_legacy', type='fanout')
+        received = []
+        with self._legacy_connection() as legacy, \
+                self._sentinel_connection(sentinel_fanout_compat=True) as new:
+            self._consume(legacy, exchange, 'sfc_compat_to_legacy_q', received)
+            self._subscribe(legacy)
+
+            self._publish(new, exchange, {'cmd': 'ping'})
+            self._drain(legacy, 1)
+
+        assert received == [{'cmd': 'ping'}]
+
+    def test_compat_consumer_receives_legacy_publisher(self):
+        exchange = kombu.Exchange('sfc_legacy_to_compat', type='fanout')
+        received = []
+        with self._legacy_connection() as legacy, \
+                self._sentinel_connection(sentinel_fanout_compat=True) as new:
+            self._consume(new, exchange, 'sfc_legacy_to_compat_q', received)
+            self._subscribe(new)
+
+            self._publish(legacy, exchange, {'cmd': 'ping'})
+            self._drain(new, 1)
+
+        assert received == [{'cmd': 'ping'}]
+
+    def test_compat_peers_receive_each_message_once(self):
+        exchange = kombu.Exchange('sfc_compat_to_compat', type='fanout')
+        received = []
+        with self._sentinel_connection(sentinel_fanout_compat=True) as one, \
+                self._sentinel_connection(sentinel_fanout_compat=True) as two:
+            self._consume(one, exchange, 'sfc_compat_to_compat_q', received)
+            self._subscribe(one)
+
+            # published to both topics, so it arrives twice on the
+            # subscription connection and must be delivered once.
+            self._publish(two, exchange, {'cmd': 'ping'})
+            self._drain(one, 1)
+
+        assert received == [{'cmd': 'ping'}]
+
+    def test_without_compat_legacy_and_current_topics_are_isolated(self):
+        # the situation reported in celery/kombu#2152
+        exchange = kombu.Exchange('sfc_isolated', type='fanout')
+        received = []
+        with self._legacy_connection() as legacy, \
+                self._sentinel_connection() as new:
+            self._consume(new, exchange, 'sfc_isolated_new_q', received)
+            self._subscribe(new)
+            self._publish(legacy, exchange, {'cmd': 'ping'})
+            self._drain(new, 1)
+
+            self._consume(legacy, exchange, 'sfc_isolated_legacy_q', received)
+            self._subscribe(legacy)
+            self._publish(new, exchange, {'cmd': 'ping'})
+            self._drain(legacy, 1)
+
+        assert received == []
+
+    def test_cancelled_consumer_no_longer_receives(self):
+        """Cancelling must PUNSUBSCRIBE from both topics.
+
+        A leaked pattern subscription would deliver the message published
+        after the cancellation for an exchange the channel no longer
+        consumes from.
+        """
+        cancelled = kombu.Exchange('sfc_cancelled', type='fanout')
+        kept = kombu.Exchange('sfc_kept', type='fanout')
+        received = []
+        with self._sentinel_connection(sentinel_fanout_compat=True) as new, \
+                self._legacy_connection() as legacy:
+            consumer = self._consume(
+                new, cancelled, 'sfc_cancelled_q', received)
+            self._consume(new, kept, 'sfc_kept_q', received)
+            self._subscribe(new)
+
+            consumer.cancel()
+            self._publish(legacy, cancelled, {'cmd': 'stale'})
+            self._publish(legacy, kept, {'cmd': 'ping'})
+            self._drain(new, 1)
+
+        assert received == [{'cmd': 'ping'}]

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -3586,6 +3586,17 @@ class test_SentinelChannel_fanout_compat:
             '/3.celery.pidbox', '/{db}.celery.pidbox',
         ]
 
+    def test_legacy_prefix_survives_creating_a_second_pool(self):
+        from kombu.transport.redis import SentinelChannel
+
+        channel = self._channel(sentinel_fanout_compat=True)
+        with patch.object(SentinelChannel, '_sentinel_managed_pool'):
+            channel._get_pool(asynchronous=True)
+
+        assert channel.keyprefix_fanout == '/0.'
+        assert channel._legacy_keyprefix_fanout == '/{db}.'
+        assert channel._fanout_compat_active
+
     def test_enabled_topics_honour_fanout_patterns(self):
         channel = self._channel(sentinel_fanout_compat=True)
 

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -3519,6 +3519,211 @@ class test_RedisSentinel:
             connection.close()
 
 
+class test_SentinelChannel_fanout_compat:
+    """The ``sentinel_fanout_compat`` transport option.
+
+    kombu < 5.4.0 used the literal ``/{db}.`` fanout prefix with Redis
+    Sentinel, while newer versions substitute the database number, so
+    mixed-version workers publish and listen on different PUB/SUB topics.
+    See https://github.com/celery/kombu/issues/2152.
+    """
+
+    def _channel(self, db=0, **transport_options):
+        from kombu.transport.redis import SentinelChannel
+
+        transport_options.setdefault('master_name', 'not_important')
+        with patch.object(SentinelChannel, '_sentinel_managed_pool'):
+            connection = Connection(
+                f'sentinel://localhost:65532/{db}',
+                transport_options=transport_options,
+            )
+            return connection.channel()
+
+    def _receiving_channel(self, **transport_options):
+        channel = self._channel(**transport_options)
+        channel._fanout_to_queue['celery.pidbox'] = 'q'
+        channel.connection._deliver = Mock(name='_deliver')
+        channel.subclient = Mock(name='subclient')
+        return channel
+
+    @staticmethod
+    def _receive(channel, topic, message):
+        channel.subclient.parse_response.return_value = [
+            'pmessage', topic, topic, dumps(message),
+        ]
+        return channel._receive_one(channel.subclient)
+
+    @staticmethod
+    def _message(tag):
+        return {
+            'body': 'ping',
+            'properties': {
+                'delivery_tag': tag,
+                'delivery_info': {'exchange': 'celery.pidbox',
+                                  'routing_key': ''},
+            },
+        }
+
+    def test_disabled_by_default(self):
+        channel = self._channel()
+
+        assert channel.sentinel_fanout_compat is False
+        assert channel.keyprefix_fanout == '/0.'
+        assert channel._legacy_keyprefix_fanout == '/{db}.'
+        assert not channel._fanout_compat_active
+        assert channel._get_publish_topics('celery.pidbox', '') == [
+            '/0.celery.pidbox',
+        ]
+
+    def test_enabled_uses_current_and_legacy_topics(self):
+        channel = self._channel(db=3, sentinel_fanout_compat=True)
+
+        assert channel.sentinel_fanout_compat is True
+        assert channel.keyprefix_fanout == '/3.'
+        assert channel._legacy_keyprefix_fanout == '/{db}.'
+        assert channel._fanout_compat_active
+        assert channel._get_publish_topics('celery.pidbox', '') == [
+            '/3.celery.pidbox', '/{db}.celery.pidbox',
+        ]
+
+    def test_enabled_topics_honour_fanout_patterns(self):
+        channel = self._channel(sentinel_fanout_compat=True)
+
+        assert channel._get_publish_topics('celery.pidbox', 'worker.*') == [
+            '/0.celery.pidbox/worker.*', '/{db}.celery.pidbox/worker.*',
+        ]
+
+    @pytest.mark.parametrize('fanout_prefix', [False, 'custom.'])
+    def test_inactive_when_prefix_has_no_db_placeholder(self, fanout_prefix):
+        channel = self._channel(
+            sentinel_fanout_compat=True, fanout_prefix=fanout_prefix)
+
+        assert not channel._fanout_compat_active
+        assert len(channel._get_publish_topics('celery.pidbox', '')) == 1
+
+    def test_put_fanout_publishes_to_both_topics(self):
+        channel = self._channel(sentinel_fanout_compat=True)
+        client = Mock(name='client')
+        channel._create_client = Mock(return_value=client)
+        body = {'hello': 'world'}
+
+        channel._put_fanout('celery.pidbox', body, '')
+
+        channel._create_client.assert_called_once()
+        assert client.publish.call_args_list == [
+            call('/0.celery.pidbox', dumps(body)),
+            call('/{db}.celery.pidbox', dumps(body)),
+        ]
+
+    def test_put_fanout_batch_publishes_to_both_topics(self):
+        channel = self._channel(sentinel_fanout_compat=True)
+        batch = Mock(name='publish_batch')
+        body = {'hello': 'world'}
+
+        channel._put_fanout('celery.pidbox', body, '', _publish_batch=batch)
+
+        assert batch.add.call_args_list == [
+            call('publish', '/0.celery.pidbox', dumps(body)),
+            call('publish', '/{db}.celery.pidbox', dumps(body)),
+        ]
+
+    def test_put_fanout_disabled_publishes_to_current_topic_only(self):
+        channel = self._channel()
+        client = Mock(name='client')
+        channel._create_client = Mock(return_value=client)
+        body = {'hello': 'world'}
+
+        channel._put_fanout('celery.pidbox', body, '')
+
+        client.publish.assert_called_once_with(
+            '/0.celery.pidbox', dumps(body))
+
+    def test_subscribe_to_both_topics(self):
+        channel = self._channel(sentinel_fanout_compat=True)
+        channel.subclient = Mock(name='subclient')
+        channel._fanout_queues = {'q': ('celery.pidbox', '')}
+        channel.active_fanout_queues.add('q')
+
+        channel._subscribe()
+
+        channel.subclient.psubscribe.assert_called_once_with(
+            ['/0.celery.pidbox', '/{db}.celery.pidbox'])
+
+    def test_subscribe_disabled_uses_current_topic_only(self):
+        channel = self._channel()
+        channel.subclient = Mock(name='subclient')
+        channel._fanout_queues = {'q': ('celery.pidbox', '')}
+        channel.active_fanout_queues.add('q')
+
+        channel._subscribe()
+
+        channel.subclient.psubscribe.assert_called_once_with(
+            ['/0.celery.pidbox'])
+
+    def test_unsubscribe_from_both_topics(self):
+        channel = self._channel(sentinel_fanout_compat=True)
+        channel.subclient = Mock(name='subclient')
+        channel._fanout_queues = {'q': ('celery.pidbox', '')}
+
+        channel._unsubscribe_from('q')
+
+        channel.subclient.unsubscribe.assert_called_once_with(
+            ['/0.celery.pidbox', '/{db}.celery.pidbox'])
+
+    def test_message_received_on_both_topics_is_delivered_once(self):
+        channel = self._receiving_channel(sentinel_fanout_compat=True)
+        message = self._message('tag-1')
+
+        assert self._receive(channel, '/0.celery.pidbox', message) is True
+        assert self._receive(channel, '/{db}.celery.pidbox', message) is False
+
+        channel.connection._deliver.assert_called_once_with(message, 'q')
+
+    def test_distinct_messages_are_all_delivered(self):
+        channel = self._receiving_channel(sentinel_fanout_compat=True)
+        first, second = self._message('tag-1'), self._message('tag-2')
+
+        assert self._receive(channel, '/0.celery.pidbox', first) is True
+        assert self._receive(channel, '/{db}.celery.pidbox', second) is True
+
+        assert channel.connection._deliver.call_args_list == [
+            call(first, 'q'), call(second, 'q'),
+        ]
+
+    def test_messages_without_delivery_tag_are_not_deduplicated(self):
+        channel = self._receiving_channel(sentinel_fanout_compat=True)
+        message = {'body': 'ping', 'properties': {}}
+
+        assert self._receive(channel, '/0.celery.pidbox', message) is True
+        assert self._receive(channel, '/{db}.celery.pidbox', message) is True
+
+        assert channel.connection._deliver.call_count == 2
+
+    def test_deduplication_history_is_bounded(self):
+        channel = self._receiving_channel(sentinel_fanout_compat=True)
+        channel._fanout_compat_dedup_size = 2
+
+        for tag in ('tag-1', 'tag-2', 'tag-3'):
+            self._receive(channel, '/0.celery.pidbox', self._message(tag))
+
+        assert list(channel._seen_fanout_tags) == [
+            ('celery.pidbox', 'tag-2'), ('celery.pidbox', 'tag-3'),
+        ]
+        # An evicted tag is no longer recognised as a duplicate.
+        assert self._receive(
+            channel, '/{db}.celery.pidbox', self._message('tag-1')) is True
+
+    def test_disabled_does_not_deduplicate(self):
+        channel = self._receiving_channel()
+        message = self._message('tag-1')
+
+        assert self._receive(channel, '/0.celery.pidbox', message) is True
+        assert self._receive(channel, '/0.celery.pidbox', message) is True
+
+        assert channel.connection._deliver.call_count == 2
+        assert not channel._seen_fanout_tags
+
+
 class test_GlobalKeyPrefixMixin:
 
     from kombu.transport.redis import GlobalKeyPrefixMixin

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -1233,9 +1233,23 @@ class test_Channel:
         self.channel.subclient.connection.connect.assert_called_with()
 
     def test_handle_unsubscribe_message(self):
-        s = self.channel.subclient
-        s.subscribed = True
-        self.channel._handle_message(s, ['unsubscribe', 'a', 0])
+        from redis.client import PubSub
+
+        # a real PubSub, so that redis-py's own bookkeeping is exercised
+        pool = Mock(name='pool')
+        pool.get_encoder.return_value = redis.redis.Redis().get_encoder()
+        s = PubSub(connection_pool=pool)
+        s.psubscribe(['a', 'b'])
+        s.punsubscribe(['a', 'b'])
+        assert s.subscribed
+
+        payload = self.channel._handle_message(s, [b'punsubscribe', b'a', 1])
+        assert payload == {
+            'type': b'punsubscribe', 'pattern': None, 'channel': b'a',
+            'data': 1,
+        }
+        assert s.subscribed
+        assert self.channel._handle_message(s, [b'punsubscribe', b'b', 0])
         assert not s.subscribed
 
     def test_handle_pmessage_message(self):
@@ -1281,6 +1295,29 @@ class test_Channel:
         self.channel.connection._deliver.assert_called_once_with(
             message, 'b',
         )
+
+    def test_unsubscribe_from(self):
+        self.channel.subclient = Mock()
+        self.channel._fanout_queues = {'a': ('a', '')}
+
+        self.channel._unsubscribe_from('a')
+        self.channel.subclient.punsubscribe.assert_called_once_with(
+            ['/{db}.a'])
+        self.channel.subclient.unsubscribe.assert_not_called()
+
+        # nothing to do without a live subscription connection
+        self.channel.subclient.connection._sock = None
+        self.channel._unsubscribe_from('a')
+        self.channel.subclient.punsubscribe.assert_called_once()
+
+    def test_receive_final_unsubscribe_reply_is_ignored(self):
+        s = self.channel.subclient = Mock()
+        self.channel.connection._deliver = Mock(name='_deliver')
+        s.parse_response.return_value = ['punsubscribe', '/{db}.a', 0]
+
+        assert self.channel._receive_one(s) is None
+        s.handle_message.assert_called_once_with(['punsubscribe', '/{db}.a', 0])
+        self.channel.connection._deliver.assert_not_called()
 
     def test_receive_raises_for_connection_error(self):
         self.channel._in_listen = True
@@ -3678,8 +3715,9 @@ class test_SentinelChannel_fanout_compat:
 
         channel._unsubscribe_from('q')
 
-        channel.subclient.unsubscribe.assert_called_once_with(
+        channel.subclient.punsubscribe.assert_called_once_with(
             ['/0.celery.pidbox', '/{db}.celery.pidbox'])
+        channel.subclient.unsubscribe.assert_not_called()
 
     def test_message_received_on_both_topics_is_delivered_once(self):
         channel = self._receiving_channel(sentinel_fanout_compat=True)


### PR DESCRIPTION
## Summary

Since kombu 5.4.0 (#1986, commit 4d281948) `SentinelChannel` substitutes the database number into the fanout key prefix, so a Sentinel worker publishes and listens for fanout messages on `/0.celery.pidbox` instead of the literal `/{db}.celery.pidbox` topic used by kombu < 5.4.0. Fanout exchanges on the Redis transport are implemented with PUB/SUB, and Celery control commands (`ping`, `shutdown`, `rate_limit`, Flower, ...) travel over the `celery.pidbox` fanout exchange, so workers on either side of that release can no longer see each other's broadcasts. During a rolling upgrade new workers disappear from Flower and cannot be controlled from old ones, and vice versa (#2152).

This PR adds an opt-in `sentinel_fanout_compat` transport option (default `False`) to the Sentinel transport. When enabled, `SentinelChannel`:

- publishes every fanout message to both the current topic (`/0.<exchange>`) and the legacy topic (`/{db}.<exchange>`), on a single acquired client, or inside the same `Producer.batch()` pipeline when batching;
- subscribes to both topics;
- delivers a message that arrives on both topics only once, keyed on the unique `delivery_tag` every kombu-published message carries (bounded history of 1000 tags per channel; messages without a tag are never dropped);
- stays inactive when the configured `fanout_prefix` has no `{db}` placeholder, since old and new workers already share the same topic in that case.

Usage during a rolling upgrade:

```python
app = Celery('myapp', broker='sentinel://sentinel:26379/0',
             broker_transport_options={
                 'master_name': 'mymaster',
                 'sentinel_fanout_compat': True,  # remove once every worker runs kombu >= 5.4.0
             })
```

Turning the option off again is also safe during a rolling restart: compat workers keep publishing on the current topic, which is the only topic non-compat workers listen on.

## Implementation notes

Rather than duplicating `_subscribe`, `_unsubscribe_from`, `_put_fanout` and `_receive_one` in `SentinelChannel`, the base `Channel` gets three small behaviour-preserving seams: `_get_publish_topics()` / `_get_subscribe_topics()` return a list of topics (a single one for the plain Redis transport), and `_receive_one()` delivers through a new `_deliver_fanout_message()` hook. `SentinelChannel` overrides `_get_pool()` to remember the unformatted prefix, `_get_publish_topics()` to append the legacy topic, and `_deliver_fanout_message()` to drop duplicates. With the option off, every code path is equivalent to the current behaviour.

 The legacy publish joins the same batch/client as the current one, de-duplication keys on `(exchange, delivery_tag)` instead of a payload hash, and the compat logic only runs when it is actually active.

## Testing

- `t/unit/transport/test_redis.py::test_SentinelChannel_fanout_compat` adds 16 unit tests covering the default, dual publish (direct and batched), dual subscribe/unsubscribe, de-duplication, bounded history, tag-less messages, and the inactive cases.
- Full unit suite, flake8, pydocstyle and isort pass locally.

Closes #2152

