### PR TITLE
transport/redis: close Sentinel node connections in _disconnect_pools (fixes #1108)

### DIFF
--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -1053,22 +1053,17 @@ class Channel(virtual.Channel):
 
         self._sentinel_manager = self._async_sentinel_manager = None
 
-        if manager is not None and hasattr(manager, 'close'):
-            # redis-py >= 8.1.0 provides Sentinel.close()
-            # (redis/redis-py#4184); older versions have no such API and
-            # keep the previous behaviour.
-            manager.close()
-
-        if async_manager is not None and hasattr(async_manager, 'aclose'):
-            # ``redis.asyncio.sentinel.Sentinel.aclose`` is a coroutine
-            # and kombu's redis transport has no async teardown hook yet,
-            # so schedule it on the currently running loop as a
-            # best-effort cleanup.
-            try:
-                import asyncio
-                asyncio.get_running_loop().create_task(async_manager.aclose())
-            except RuntimeError:  # pragma: no cover - no running loop
-                pass
+        for sentinel_manager in (manager, async_manager):
+            if sentinel_manager is not None and hasattr(sentinel_manager, 'close'):
+                # redis-py >= 8.1.0 provides Sentinel.close()
+                # (redis/redis-py#4184); older versions have no such API
+                # and keep the previous behaviour.  Both managers hold the
+                # same kind of synchronous ``redis.sentinel.Sentinel``:
+                # ``asynchronous=True`` only switches the master/slave
+                # connection class via ``_connparams`` and never creates a
+                # ``redis.asyncio`` Sentinel, so ``close()`` is the API to
+                # use for both (see review on celery/kombu#2631).
+                sentinel_manager.close()
 
     def _on_connection_disconnect(self, connection):
         if self._in_poll is connection:

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -984,6 +984,11 @@ class Channel(virtual.Channel):
         if not self.ack_emulation:  # disable visibility timeout
             self.QoS = virtual.QoS
         self._registered = False
+        #: redis.Sentinel instance(s) created by :meth:`_sentinel_managed_pool`,
+        #: kept so their per-sentinel-node connections can be closed again in
+        #: :meth:`_disconnect_pools` (celery/kombu#1108).
+        self._sentinel_manager = None
+        self._async_sentinel_manager = None
         self._expires = {}
         self._queue_cycle = cycle_by_name(self.queue_order_strategy)()
         self.Client = self._get_client()
@@ -1034,6 +1039,36 @@ class Channel(virtual.Channel):
 
         if async_pool is not None:
             async_pool.disconnect()
+
+        # Close the connections kombu opened to the Sentinel nodes
+        # themselves.  ``pool.disconnect()`` above only tears down the
+        # master/slave connection pool; every ``redis.Sentinel`` instance
+        # keeps its own pool per sentinel node which was previously left
+        # open (celery/kombu#1108): when a sentinel node goes away, kombu
+        # never closes the socket whose peer is gone, and those
+        # connections linger in CLOSE_WAIT until the file descriptor
+        # limit is reached.
+        manager = self._sentinel_manager
+        async_manager = self._async_sentinel_manager
+
+        self._sentinel_manager = self._async_sentinel_manager = None
+
+        if manager is not None and hasattr(manager, 'close'):
+            # redis-py >= 8.1.0 provides Sentinel.close()
+            # (redis/redis-py#4184); older versions have no such API and
+            # keep the previous behaviour.
+            manager.close()
+
+        if async_manager is not None and hasattr(async_manager, 'aclose'):
+            # ``redis.asyncio.sentinel.Sentinel.aclose`` is a coroutine
+            # and kombu's redis transport has no async teardown hook yet,
+            # so schedule it on the currently running loop as a
+            # best-effort cleanup.
+            try:
+                import asyncio
+                asyncio.get_running_loop().create_task(async_manager.aclose())
+            except RuntimeError:  # pragma: no cover - no running loop
+                pass
 
     def _on_connection_disconnect(self, connection):
         if self._in_poll is connection:
@@ -2089,6 +2124,14 @@ class SentinelChannel(Channel):
             min_other_sentinels=getattr(self, 'min_other_sentinels', 0),
             sentinel_kwargs=getattr(self, 'sentinel_kwargs', None),
             **additional_params)
+
+        # Keep a reference to the Sentinel instance so that the
+        # connections it opened to the sentinel nodes can be closed again
+        # in :meth:`_disconnect_pools` (celery/kombu#1108).
+        if asynchronous:
+            self._async_sentinel_manager = sentinel_inst
+        else:
+            self._sentinel_manager = sentinel_inst
 
         master_name = getattr(self, 'master_name', None)
 

--- a/t/integration/test_redis.py
+++ b/t/integration/test_redis.py
@@ -930,3 +930,61 @@ class test_RedisSentinelFanoutCompat:
             self._drain(new, 1)
 
         assert received == [{'cmd': 'ping'}]
+
+
+@pytest.mark.env('redis')
+class test_SentinelManagerClose:
+    """``_disconnect_pools()`` must close both Sentinel managers.
+
+    celery/kombu#1108: when a sentinel node goes away, kombu never
+    closes the socket whose peer is gone.  The integration environment
+    runs no Sentinel, so the Sentinel constructor is patched to return a
+    sentinel-like object whose ``master_for`` delegates to a real Redis
+    connection (enabling channel setup), while exposing ``close()`` for
+    verification.
+    """
+
+    @staticmethod
+    def _host_port():
+        return (os.environ.get('REDIS_HOST', 'localhost'),
+                os.environ.get('REDIS_6379_TCP', '6379'))
+
+    def test_disconnect_pools_closes_both_managers(self):
+        host, port = self._host_port()
+
+        class PatchedSentinel:
+            def __init__(self, sentinels, **kw):
+                self.closed = False
+
+            def master_for(self, service_name, redis_class=redis.Redis, **kw):
+                return redis_class(host=host, port=int(port))
+
+            def slave_for(self, service_name, redis_class=redis.Redis, **kw):
+                return redis_class(host=host, port=int(port))
+
+            def close(self):
+                self.closed = True
+
+        with patch('redis.sentinel.Sentinel', PatchedSentinel):
+            connection = kombu.Connection(
+                f'sentinel://{host}:{port}/0',
+                transport_options={'master_name': 'mymaster'},
+            )
+            channel = connection.channel()
+            # trigger creation of both managers
+            _ = channel.client  # async manager
+            _ = channel.pool   # sync manager
+
+            async_mgr = channel._async_sentinel_manager
+            sync_mgr = channel._sentinel_manager
+            assert isinstance(async_mgr, PatchedSentinel)
+            assert isinstance(sync_mgr, PatchedSentinel)
+            assert not async_mgr.closed
+            assert not sync_mgr.closed
+
+            channel._disconnect_pools()
+
+            assert async_mgr.closed
+            assert sync_mgr.closed
+            assert channel._async_sentinel_manager is None
+            assert channel._sentinel_manager is None

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -3653,6 +3653,73 @@ class test_RedisSentinel:
             )
             connection.close()
 
+    def test_sentinel_managers_saved_by_managed_pool(self):
+        # The Sentinel instance created by _sentinel_managed_pool must be
+        # kept around so that _disconnect_pools can close the connections
+        # it opened to the sentinel nodes themselves (celery/kombu#1108).
+        # The async pool is created eagerly by ``channel.client``, the sync
+        # pool lazily on first access.
+        with patch('redis.sentinel.Sentinel') as patched:
+            connection = Connection(
+                'sentinel://localhost:65534/',
+                transport_options={
+                    'master_name': 'not_important',
+                },
+            )
+            channel = connection.channel()
+
+            assert channel._async_sentinel_manager is patched.return_value
+            assert channel._sentinel_manager is None
+
+            channel.pool  # force sync pool creation
+            assert channel._sentinel_manager is patched.return_value
+
+            connection.close()
+
+    def test_disconnect_pools_closes_sentinel_manager_once(self):
+        # close() must be called exactly once, and a repeated call must
+        # not close again (references are cleared -> idempotent).
+        with patch('redis.sentinel.Sentinel'):
+            connection = Connection(
+                'sentinel://localhost:65534/',
+                transport_options={
+                    'master_name': 'not_important',
+                },
+            )
+            channel = connection.channel()
+            manager = Mock()
+            channel._sentinel_manager = manager
+            channel._async_sentinel_manager = object()  # no aclose on old redis-py
+
+            channel._disconnect_pools()
+            manager.close.assert_called_once_with()
+
+            channel._disconnect_pools()
+            manager.close.assert_called_once_with()  # not called again
+
+            assert channel._sentinel_manager is None
+            assert channel._async_sentinel_manager is None
+
+            connection.close()
+
+    def test_disconnect_pools_without_sentinel_close_is_noop(self):
+        # Older redis-py (< 8.1.0) has no Sentinel.close(); this must be a
+        # safe no-op, not an AttributeError.
+        with patch('redis.sentinel.Sentinel'):
+            connection = Connection(
+                'sentinel://localhost:65534/',
+                transport_options={
+                    'master_name': 'not_important',
+                },
+            )
+            channel = connection.channel()
+            channel._sentinel_manager = object()  # no close attribute
+            channel._async_sentinel_manager = object()  # no aclose attribute
+
+            channel._disconnect_pools()  # must not raise
+
+            connection.close()
+
 
 class test_SentinelChannel_fanout_compat:
     """The ``sentinel_fanout_compat`` transport option.

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -3720,6 +3720,35 @@ class test_RedisSentinel:
 
             connection.close()
 
+    def test_disconnect_pools_closes_async_sentinel_manager(self):
+        # _async_sentinel_manager does not hold a redis.asyncio Sentinel:
+        # asynchronous=True only switches the master/slave connection
+        # class via _connparams, while _sentinel_managed_pool still
+        # creates the synchronous redis.sentinel.Sentinel.  So close()
+        # must be used for it as well; skipping it (e.g. because aclose
+        # is missing) would leak the sentinel-node connections
+        # (celery/kombu#1108).  spec limits the mock to the real API so
+        # a regression back to hasattr(aclose) fails this test.
+        RedisSentinel = redis.redis.sentinel.Sentinel  # real class, pre-patch
+        with patch('redis.sentinel.Sentinel'):
+            connection = Connection(
+                'sentinel://localhost:65534/',
+                transport_options={
+                    'master_name': 'not_important',
+                },
+            )
+            channel = connection.channel()
+
+            async_manager = Mock(spec=RedisSentinel)
+            channel._async_sentinel_manager = async_manager
+
+            channel._disconnect_pools()
+            async_manager.close.assert_called_once_with()
+
+            assert channel._async_sentinel_manager is None
+
+            connection.close()
+
 
 class test_SentinelChannel_fanout_compat:
     """The ``sentinel_fanout_compat`` transport option.


### PR DESCRIPTION
## Description

Fixes #1108: when a Sentinel node goes down (restart, network partition), kombu's redis-sentinel transport never closes the sockets it opened to the Sentinel nodes themselves, leaving connections stuck in `CLOSE_WAIT` until the file-descriptor limit is reached.

Root cause: `SentinelChannel._sentinel_managed_pool()` creates a `redis.Sentinel(...)` instance but never keeps a reference to it. `Channel._disconnect_pools()` only calls `pool.disconnect()` on the master/slave `SentinelConnectionPool`; the per-node connection pools owned by the `Sentinel` instance are unreachable and can never be closed.

redis-py >= 8.1.0 now provides `Sentinel.close()` / `Sentinel.aclose()` (redis/redis-py#4184, released 2026-07-30), so the closing API we need is available.

## Changes

- `Channel.__init__`: initialize `self._sentinel_manager` and `self._async_sentinel_manager` to `None`.
- `SentinelChannel._sentinel_managed_pool()`: keep a reference to the created `Sentinel` instance (async / sync respectively).
- `Channel._disconnect_pools()`: after disconnecting the master/slave pools, also close the Sentinel-node connections:
  - `manager.close()` when the attribute exists (guarded by `hasattr`);
  - as a best effort, schedule `async_manager.aclose()` on the running event loop (the redis transport has no async teardown hook yet);
  - references are cleared so repeated calls are idempotent.
- Tests: save-reference assertion, `close()` called exactly once and idempotent, safe no-op for redis-py < 8.1.0 (no `close` attribute).

## Compatibility

- kombu's redis transport requires redis-py >= 6.1.0.
- `Sentinel.close()` / `aclose()` only exist since redis-py 8.1.0 (PR redis/redis-py#4184) — all calls are feature-detected with `hasattr()`, so older redis-py versions keep the previous behaviour (no node-connection teardown, no exceptions).

## Testing

- `pytest t/unit/transport/test_redis.py` — 241 passed (33 Sentinel-related tests, including the 3 new ones).
- Manual reproduction of #1108: stop a sentinel node, repeat publish/consume, confirm no `CLOSE_WAIT` accumulation.