### PR TITLE
Add a consumption guard to the virtual transport QoS

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -8,6 +8,13 @@
 Unreleased
 ==========
 
+- Add a consumption guard to the virtual transport QoS
+  (:attr:`kombu.transport.virtual.QoS.guard`, also settable with the
+  ``qos_guard`` transport option). When set, the guard callable is consulted
+  by ``can_consume()`` in addition to the prefetch count, so applications
+  such as Celery can stop fetching from the broker while they have no
+  capacity to handle more messages, instead of monkeypatching the QoS
+  object (#2353).
 - Add PGMQ transport for PostgreSQL message queues (#2559)
 
 - Add a transport-aware :meth:`kombu.Producer.batch` API. The Redis transport

--- a/docs/userguide/consumers.rst
+++ b/docs/userguide/consumers.rst
@@ -227,6 +227,50 @@ this:
 Read more about consumer priorities here:
 https://www.rabbitmq.com/consumer-priority.html
 
+Virtual Transports
+------------------
+
+Consumption Guard
+~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 5.7.0
+
+Virtual transports (Redis, SQS, PGMQ, and so on) emulate ``prefetch_count``
+in :class:`kombu.transport.virtual.QoS`: the transport only fetches a new
+message from the broker while :meth:`~kombu.transport.virtual.QoS.can_consume`
+returns true, that is while the number of unacknowledged messages is below
+the prefetch count.
+
+Sometimes the prefetch count alone is not enough to express when an
+application can take on more work.  A worker may, for instance, want to
+fetch a message only when a process is free to handle it, so that a
+long-running message doesn't hold other, already fetched messages hostage,
+and so that messages are spread fairly across workers.  For that a
+*consumption guard* can be installed with the ``qos_guard`` transport option:
+
+.. code-block:: python
+
+    def has_free_slot(qos):
+        return len(active_jobs) < number_of_processes
+
+    connection = Connection(
+        'redis://localhost',
+        transport_options={'qos_guard': has_free_slot},
+    )
+
+The guard is a callable receiving the channel's
+:class:`~kombu.transport.virtual.QoS` instance.  As long as it returns a
+falsy value :meth:`~kombu.transport.virtual.QoS.can_consume` returns false and
+:meth:`~kombu.transport.virtual.QoS.can_consume_max_estimate` returns ``0``,
+so no new messages are fetched from the broker.  The prefetch count is still
+honored when the guard allows consumption.  The guard is called on every
+poll, so it should be cheap and must not block.
+
+The guard can also be set, or replaced at runtime, directly on an existing
+channel: ``channel.qos.guard = has_free_slot``.  It's disabled (:const:`None`)
+by default.  Native AMQP transports implement prefetching in the broker
+and ignore this option.
+
 
 Reference
 =========

--- a/kombu/transport/confluentkafka.py
+++ b/kombu/transport/confluentkafka.py
@@ -112,10 +112,14 @@ class QoS(virtual.QoS):
         :returns: True, if this QoS object can accept a message.
         :rtype: bool
         """
+        if not self.guard_allows():
+            return False
         return not self.prefetch_count or len(self._not_yet_acked) < self \
             .prefetch_count
 
     def can_consume_max_estimate(self):
+        if not self.guard_allows():
+            return 0
         if self.prefetch_count:
             return self.prefetch_count - len(self._not_yet_acked)
         else:

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -76,6 +76,13 @@ Transport Options
   Defaults to ``False``.
 
   .. versionadded:: 5.7.0
+* ``qos_guard``: (callable) Optional consumption guard applied on top of
+  the prefetch count.  Called with the channel's
+  :class:`~kombu.transport.virtual.QoS` instance before fetching from the
+  broker; while it returns a falsy value no new messages are fetched.
+  See :attr:`kombu.transport.virtual.QoS.guard`.  Defaults to ``None``.
+
+  .. versionadded:: 5.7.0
 
 Queue Arguments
 ===============

--- a/kombu/transport/virtual/base.py
+++ b/kombu/transport/virtual/base.py
@@ -161,10 +161,30 @@ class QoS:
     ---------
         channel (ChannelT): Connection channel.
         prefetch_count (int): Initial prefetch count (defaults to 0).
+        guard (Callable): Optional consumption guard (see :attr:`guard`).
     """
 
     #: current prefetch count value
     prefetch_count = 0
+
+    #: Optional consumption guard consulted by :meth:`can_consume`
+    #: in addition to the prefetch limit.
+    #:
+    #: When set, this must be a callable accepting the :class:`QoS`
+    #: instance and returning a boolean.  If it returns a falsy value,
+    #: :meth:`can_consume` returns :const:`False` (and
+    #: :meth:`can_consume_max_estimate` returns ``0``), so the transport
+    #: fetches no new messages from the broker until the guard allows it
+    #: again.  This lets applications apply their own back-pressure on
+    #: top of ``prefetch_count``, for example only fetching a message
+    #: when a worker process is free to handle it (Celery's
+    #: ``worker_disable_prefetch``).
+    #:
+    #: Disabled (:const:`None`) by default.  Can also be set with
+    #: ``transport_options['qos_guard']``.
+    #:
+    #: .. versionadded:: 5.7.0
+    guard = None
 
     #: :class:`~collections.OrderedDict` of active messages.
     #: *NOTE*: Can only be modified by the consuming thread.
@@ -179,9 +199,11 @@ class QoS:
     #: If disabled, unacked messages won't be restored at shutdown.
     restore_at_shutdown = True
 
-    def __init__(self, channel, prefetch_count=0):
+    def __init__(self, channel, prefetch_count=0, guard=None):
         self.channel = channel
         self.prefetch_count = prefetch_count or 0
+        if guard is not None:
+            self.guard = guard
 
         # Standard Python dictionaries do not support setting attributes
         # on the object, hence the use of OrderedDict
@@ -194,12 +216,19 @@ class QoS:
             self, self.restore_unacked_once, exitpriority=1,
         )
 
+    def guard_allows(self):
+        """Return true if the :attr:`guard` allows consuming (or is unset)."""
+        guard = self.guard
+        return guard is None or bool(guard(self))
+
     def can_consume(self):
         """Return true if the channel can be consumed from.
 
         Used to ensure the client adhers to currently active
-        prefetch limits.
+        prefetch limits, and to the optional :attr:`guard`.
         """
+        if not self.guard_allows():
+            return False
         pcount = self.prefetch_count
         return not pcount or len(self._delivered) - len(self._dirty) < pcount
 
@@ -213,8 +242,12 @@ class QoS:
 
         Returns
         -------
-            int: greater than zero.
+            int: zero or greater, or :const:`None` if there's no
+            prefetch limit.  Always ``0`` while the :attr:`guard`
+            disallows consuming.
         """
+        if not self.guard_allows():
+            return 0
         pcount = self.prefetch_count
         if pcount:
             return max(pcount - (len(self._delivered) - len(self._dirty)), 0)
@@ -464,8 +497,16 @@ class Channel(AbstractChannel, base.StdChannel):
     #: Set by ``transport_options['deadletter_queue']``.
     deadletter_queue = None
 
+    #: Optional callable guarding consumption in addition to the
+    #: prefetch limit, installed as :attr:`QoS.guard` on this channel's
+    #: :attr:`qos` when it's first created.
+    #: Set by ``transport_options['qos_guard']``.
+    qos_guard = None
+
     # List of options to transfer from :attr:`transport_options`.
-    from_transport_options = ('body_encoding', 'deadletter_queue')
+    from_transport_options = (
+        'body_encoding', 'deadletter_queue', 'qos_guard',
+    )
 
     # Priority defaults
     default_priority = 0
@@ -843,6 +884,8 @@ class Channel(AbstractChannel, base.StdChannel):
         """:class:`QoS` manager for this channel."""
         if self._qos is None:
             self._qos = self.QoS(self)
+            if self.qos_guard is not None:
+                self._qos.guard = self.qos_guard
         return self._qos
 
     @property

--- a/requirements/extras/pgmq.txt
+++ b/requirements/extras/pgmq.txt
@@ -1,1 +1,1 @@
-pgmq>=1.1.0
+pgmq>=1.1.0; platform_python_implementation == "CPython"

--- a/t/integration/common.py
+++ b/t/integration/common.py
@@ -543,3 +543,119 @@ class BaseFailover(BasicFunctionality):
         super().test_simple_buffer_publish_consume(
             failover_connection
         )
+
+
+class BaseQoSGuard:
+    """Tests for the virtual transport consumption guard (``QoS.guard``)."""
+
+    @staticmethod
+    def _publish(channel, queue, body):
+        kombu.Producer(channel).publish(
+            body,
+            retry=True,
+            exchange=queue.exchange,
+            routing_key=queue.routing_key,
+            declare=[queue],
+            serializer='pickle',
+        )
+
+    @staticmethod
+    def _consumer(channel, queue, callback):
+        consumer = kombu.Consumer(channel, [queue], accept=['pickle'])
+        consumer.register_callback(callback)
+        return consumer
+
+    def test_guard_blocks_fetch_until_allowed(self, connection):
+        name = 'test_qos_guard'
+        queue = kombu.Queue(name, routing_key=name)
+        state = {'allow': False}
+        received = []
+
+        def callback(body, message):
+            received.append(body)
+            message.ack()
+
+        with connection as conn:
+            with conn.channel() as channel:
+                assert channel.qos.guard is None
+                channel.qos.guard = lambda qos: state['allow']
+                self._publish(channel, queue, {'hello': 'guard'})
+
+                with self._consumer(channel, queue, callback):
+                    # The message is waiting on the broker, but the guard
+                    # forbids consuming so nothing must be fetched.
+                    with pytest.raises(socket.timeout):
+                        conn.drain_events(timeout=1)
+                    assert received == []
+
+                    state['allow'] = True
+                    conn.drain_events(timeout=1)
+                    assert received == [{'hello': 'guard'}]
+
+    def test_guard_from_transport_options(self, connection):
+        name = 'test_qos_guard_option'
+        queue = kombu.Queue(name, routing_key=name)
+        state = {'allow': False}
+        seen = []
+        received = []
+
+        def guard(qos):
+            seen.append(qos)
+            return state['allow']
+
+        def callback(body, message):
+            received.append(body)
+            message.ack()
+
+        # Copy: the fixture may share its transport options between tests.
+        connection.transport_options = {
+            **connection.transport_options, 'qos_guard': guard,
+        }
+        with connection as conn:
+            with conn.channel() as channel:
+                assert channel.qos.guard is guard
+                self._publish(channel, queue, {'hello': 'option'})
+
+                with self._consumer(channel, queue, callback):
+                    with pytest.raises(socket.timeout):
+                        conn.drain_events(timeout=1)
+                    assert received == []
+                    assert seen and all(qos is channel.qos for qos in seen)
+
+                    state['allow'] = True
+                    conn.drain_events(timeout=1)
+                    assert received == [{'hello': 'option'}]
+
+    def test_guard_applies_back_pressure_from_unacked(self, connection):
+        # Mirrors Celery's ``worker_disable_prefetch``: only fetch a new
+        # message while nothing is being processed, regardless of the
+        # (unlimited) prefetch count.
+        name = 'test_qos_guard_back_pressure'
+        queue = kombu.Queue(name, routing_key=name)
+        in_progress = []
+
+        def callback(body, message):
+            in_progress.append(message)
+
+        with connection as conn:
+            with conn.channel() as channel:
+                channel.qos.guard = lambda qos: not in_progress
+                assert channel.qos.prefetch_count == 0
+
+                with self._consumer(channel, queue, callback):
+                    self._publish(channel, queue, 1)
+                    conn.drain_events(timeout=1)
+                    assert [m.payload for m in in_progress] == [1]
+
+                    # A second message is not fetched while the first one
+                    # is still being handled...
+                    self._publish(channel, queue, 2)
+                    with pytest.raises(socket.timeout):
+                        conn.drain_events(timeout=1)
+                    assert [m.payload for m in in_progress] == [1]
+
+                    # ...but is as soon as the application has capacity.
+                    in_progress.pop().ack()
+                    conn.drain_events(timeout=1)
+                    assert [m.payload for m in in_progress] == [2]
+                    in_progress.pop().ack()

--- a/t/integration/test_kafka.py
+++ b/t/integration/test_kafka.py
@@ -5,7 +5,7 @@ import pytest
 import kombu
 
 from .common import (BaseExchangeTypes, BaseFailover, BaseMessage,
-                     BasicFunctionality)
+                     BaseQoSGuard, BasicFunctionality)
 
 
 def get_connection(hostname, port):
@@ -66,4 +66,10 @@ class test_KafkaFailover(BaseFailover):
 @pytest.mark.env('kafka')
 @pytest.mark.flaky(reruns=5, reruns_delay=2)
 class test_KafkaMessage(BaseMessage):
+    pass
+
+
+@pytest.mark.env('kafka')
+@pytest.mark.flaky(reruns=5, reruns_delay=2)
+class test_KafkaQoSGuard(BaseQoSGuard):
     pass

--- a/t/integration/test_mongodb.py
+++ b/t/integration/test_mongodb.py
@@ -7,7 +7,7 @@ import pytest
 import kombu
 
 from .common import (BaseExchangeTypes, BaseMessage, BasePriority,
-                     BasicFunctionality)
+                     BaseQoSGuard, BasicFunctionality)
 
 
 def get_connection(hostname, port, vhost):
@@ -182,4 +182,10 @@ class test_MongoDBPriority(BasePriority):
 @pytest.mark.env('mongodb')
 @pytest.mark.flaky(reruns=5, reruns_delay=2)
 class test_MongoDBMessage(BaseMessage):
+    pass
+
+
+@pytest.mark.env('mongodb')
+@pytest.mark.flaky(reruns=5, reruns_delay=2)
+class test_MongoDBQoSGuard(BaseQoSGuard):
     pass

--- a/t/integration/test_pgmq.py
+++ b/t/integration/test_pgmq.py
@@ -5,13 +5,14 @@ import socket
 from contextlib import closing
 from time import sleep, time
 
-import psycopg
 import pytest
 
 import kombu
 from kombu.exceptions import OperationalError
 
 from .common import BaseExchangeTypes, BaseMessage, BasicFunctionality
+
+psycopg = pytest.importorskip('psycopg')
 
 # connect() does not wrap the transport error as kombu OperationalError.
 _CONN_FAIL = (OperationalError, psycopg.OperationalError, psycopg.InterfaceError)

--- a/t/integration/test_pgmq.py
+++ b/t/integration/test_pgmq.py
@@ -10,7 +10,8 @@ import pytest
 import kombu
 from kombu.exceptions import OperationalError
 
-from .common import BaseExchangeTypes, BaseMessage, BasicFunctionality
+from .common import (BaseExchangeTypes, BaseMessage, BaseQoSGuard,
+                     BasicFunctionality)
 
 psycopg = pytest.importorskip('psycopg')
 
@@ -88,6 +89,12 @@ class test_PGMQBaseExchangeTypes(BaseExchangeTypes):
 @pytest.mark.env('pgmq')
 @pytest.mark.flaky(reruns=3, reruns_delay=2)
 class test_PGMQBaseMessage(BaseMessage):
+    pass
+
+
+@pytest.mark.env('pgmq')
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
+class test_PGMQQoSGuard(BaseQoSGuard):
     pass
 
 

--- a/t/integration/test_redis.py
+++ b/t/integration/test_redis.py
@@ -16,7 +16,7 @@ from kombu.transport.redis import (SUBCLIENT_MAX_MISSED_HEALTH_CHECKS, Channel,
 from kombu.utils.json import loads
 
 from .common import (BaseExchangeTypes, BaseMessage, BasePriority,
-                     BasicFunctionality)
+                     BaseQoSGuard, BasicFunctionality)
 
 
 def get_connection(
@@ -450,6 +450,62 @@ class test_RedisPublishBatch:
 @pytest.mark.flaky(reruns=5, reruns_delay=2)
 class test_RedisMessage(BaseMessage):
     pass
+
+
+@pytest.mark.env('redis')
+@pytest.mark.flaky(reruns=5, reruns_delay=2)
+class test_RedisQoSGuard(BaseQoSGuard):
+
+    def test_guard_defers_brpop_in_event_loop(self, connection, redis_client):
+        # The guard must also gate the asynchronous (hub) path, where the
+        # transport registers a BRPOP on every poll tick while it may
+        # consume.  While the guard says no, no BRPOP must be sent, so the
+        # message stays on the broker for other consumers.
+        name = f'qos-guard-{uuid4().hex}'
+        queue = kombu.Queue(name, routing_key=name)
+        key = connection.transport_options.get('global_keyprefix', '') + name
+        state = {'allow': False}
+        received = []
+
+        def on_message(body, message):
+            received.append(body)
+            message.ack()
+
+        def poll(hub, deadline):
+            while monotonic() < deadline:
+                for tick in hub.on_tick:
+                    tick()
+                for fd, _ in hub.poller.poll(0.1):
+                    callback, args = hub.readers[fd]
+                    callback(*args)
+
+        hub = Hub()
+        with connection:
+            with kombu.Consumer(
+                connection, queues=[queue], callbacks=[on_message]
+            ) as consumer:
+                channel = consumer.channel
+                channel.qos.guard = lambda qos: state['allow']
+                connection.register_with_event_loop(hub)
+                try:
+                    with connection.clone() as publisher:
+                        kombu.Producer(publisher).publish(
+                            'hello', routing_key=name, declare=[queue])
+
+                    poll(hub, monotonic() + 1)
+                    assert received == []
+                    assert not channel._in_poll
+                    # The message is still on the broker.
+                    assert redis_client.llen(key) == 1
+
+                    state['allow'] = True
+                    deadline = monotonic() + 5
+                    while not received and monotonic() < deadline:
+                        poll(hub, monotonic() + 0.2)
+                    assert received == ['hello']
+                    assert redis_client.llen(key) == 0
+                finally:
+                    queue(channel).delete()
 
 
 @pytest.mark.env('redis')

--- a/t/integration/test_sqs.py
+++ b/t/integration/test_sqs.py
@@ -9,7 +9,8 @@ import pytest
 import kombu
 import kombu.asynchronous
 
-from .common import BaseExchangeTypes, BaseMessage, BasicFunctionality
+from .common import (BaseExchangeTypes, BaseMessage, BaseQoSGuard,
+                     BasicFunctionality)
 
 
 def get_connection(hostname: str = "localhost", port: int = 4100, queue_prefix: str = "") -> kombu.Connection:
@@ -109,4 +110,10 @@ class test_SQSBaseExchangeTypes(BaseExchangeTypes):
 @pytest.mark.env('sqs')
 @pytest.mark.flaky(reruns=5, reruns_delay=2)
 class test_SQSMessage(BaseMessage):
+    pass
+
+
+@pytest.mark.env('sqs')
+@pytest.mark.flaky(reruns=5, reruns_delay=2)
+class test_SQSQoSGuard(BaseQoSGuard):
     pass

--- a/t/unit/transport/test_confluentkafka.py
+++ b/t/unit/transport/test_confluentkafka.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+pytest.importorskip('confluent_kafka')
+
+from kombu.transport import confluentkafka  # noqa: E402
+
+
+class test_QoS:
+
+    def setup_method(self):
+        self.channel = Mock(name='channel')
+        self.qos = confluentkafka.QoS(self.channel, prefetch_count=2)
+        # ``_not_yet_acked`` is a class attribute; give each test its own.
+        self.qos._not_yet_acked = {}
+
+    def teardown_method(self):
+        self.qos._on_collect.cancel()
+
+    def test_can_consume__prefetch_limit(self):
+        assert self.qos.can_consume()
+        assert self.qos.can_consume_max_estimate() == 2
+        self.qos.append(Mock(name='m1'), 1)
+        assert self.qos.can_consume()
+        assert self.qos.can_consume_max_estimate() == 1
+        self.qos.append(Mock(name='m2'), 2)
+        assert not self.qos.can_consume()
+        assert self.qos.can_consume_max_estimate() == 0
+
+    def test_can_consume__no_prefetch_limit(self):
+        self.qos.prefetch_count = 0
+        self.qos.append(Mock(name='m1'), 1)
+        assert self.qos.can_consume()
+        assert self.qos.can_consume_max_estimate() == 1
+
+    def test_can_consume__guard(self):
+        allow = [False]
+        calls = []
+
+        def guard(qos):
+            calls.append(qos)
+            return allow[0]
+
+        self.qos.guard = guard
+        assert not self.qos.can_consume()
+        assert self.qos.can_consume_max_estimate() == 0
+
+        allow[0] = True
+        assert self.qos.can_consume()
+        assert self.qos.can_consume_max_estimate() == 2
+        assert calls == [self.qos] * 4
+
+    def test_can_consume__guard_and_prefetch_limit(self):
+        self.qos.guard = lambda qos: True
+        self.qos.append(Mock(name='m1'), 1)
+        self.qos.append(Mock(name='m2'), 2)
+        assert not self.qos.can_consume()
+        assert self.qos.can_consume_max_estimate() == 0
+
+    def test_guard__from_constructor(self):
+        qos = confluentkafka.QoS(self.channel, guard=lambda q: False)
+        try:
+            assert not qos.can_consume()
+            assert qos.can_consume_max_estimate() == 0
+        finally:
+            qos._on_collect.cancel()

--- a/t/unit/transport/test_redis.py
+++ b/t/unit/transport/test_redis.py
@@ -3196,6 +3196,16 @@ class test_MultiChannelPoller:
         qos.reject(1234, True)
         qos.restore_by_tag.assert_called_with(1234, leftmost=True)
 
+    def test_qos_guard(self):
+        p, channel = self.create_get()
+        allow = [False]
+        qos = redis.QoS(channel, guard=lambda q: allow[0])
+        assert not qos.can_consume()
+        assert qos.can_consume_max_estimate() == 0
+        allow[0] = True
+        assert qos.can_consume()
+        assert qos.can_consume_max_estimate() is None
+
     def test_get_brpop_qos_allow(self):
         p, channel = self.create_get(queues=['a_queue'])
         channel.qos.can_consume.return_value = True

--- a/t/unit/transport/virtual/test_base.py
+++ b/t/unit/transport/virtual/test_base.py
@@ -54,6 +54,82 @@ class test_QoS:
         qos = virtual.QoS(client().channel())
         qos.restore_visible()
 
+    def test_guard__default_is_unset(self):
+        assert self.q.guard is None
+        assert self.q.guard_allows()
+        assert self.q.can_consume()
+        assert self.q.can_consume_max_estimate() == 10
+
+    def test_guard__gates_can_consume(self):
+        allow = [True]
+        calls = []
+
+        def guard(qos):
+            calls.append(qos)
+            return allow[0]
+
+        self.q.guard = guard
+        assert self.q.guard_allows()
+        assert self.q.can_consume()
+        assert self.q.can_consume_max_estimate() == 10
+
+        allow[0] = False
+        assert not self.q.guard_allows()
+        assert not self.q.can_consume()
+        assert self.q.can_consume_max_estimate() == 0
+
+        allow[0] = True
+        assert self.q.can_consume()
+        # guard_allows, can_consume and can_consume_max_estimate each
+        # consult the guard exactly once per call.
+        assert calls == [self.q] * 7
+
+    def test_guard__prefetch_limit_still_applies(self):
+        self.q.guard = lambda qos: True
+        for i in range(self.q.prefetch_count):
+            assert self.q.can_consume()
+            self.q.append(i, uuid())
+        assert not self.q.can_consume()
+        assert self.q.can_consume_max_estimate() == 0
+
+    def test_guard__no_prefetch_limit(self):
+        qos = virtual.QoS(client().channel(), guard=lambda q: False)
+        try:
+            assert qos.guard is not None
+            assert not qos.can_consume()
+            assert qos.can_consume_max_estimate() == 0
+            qos.guard = None
+            assert qos.can_consume()
+            assert qos.can_consume_max_estimate() is None
+        finally:
+            qos._on_collect.cancel()
+
+    def test_guard__result_is_coerced_to_bool(self):
+        self.q.guard = lambda qos: 0
+        assert self.q.can_consume() is False
+        self.q.guard = lambda qos: 'yes'
+        assert self.q.can_consume() is True
+
+    def test_guard__from_transport_options(self):
+        guard = Mock(name='qos_guard', return_value=False)
+        channel = client(transport_options={'qos_guard': guard}).channel()
+        try:
+            assert channel.qos_guard is guard
+            assert channel.qos.guard is guard
+            assert not channel.qos.can_consume()
+            guard.assert_called_once_with(channel.qos)
+        finally:
+            channel.qos._on_collect.cancel()
+
+    def test_guard__channel_default(self):
+        channel = client().channel()
+        try:
+            assert channel.qos_guard is None
+            assert channel.qos.guard is None
+            assert channel.qos.can_consume()
+        finally:
+            channel.qos._on_collect.cancel()
+
     def test_can_consume(self, stdouts):
         stderr = io.StringIO()
         _restored = []


### PR DESCRIPTION
Fixes #2353

## Summary

Celery's `worker_disable_prefetch` (celery/celery#9863) currently monkeypatches `can_consume()` on kombu's QoS object so that a worker only fetches a message from the broker when a process is free to run it. As noted in that PR, the guard logically belongs in kombu, where every virtual transport (Redis, SQS, PGMQ, ...) already gates broker fetches on `QoS.can_consume()`.

This PR adds an optional consumption guard to `kombu.transport.virtual.QoS`:

- `QoS.guard`: a callable receiving the QoS instance. While it returns a falsy value, `can_consume()` returns `False` and `can_consume_max_estimate()` returns `0`, so no new messages are fetched until the application has capacity again. The prefetch count is still honored when the guard allows consumption.
- The guard can be passed to the `QoS` constructor, assigned to `channel.qos.guard` at runtime, or configured with the new `qos_guard` transport option, which the channel installs on its QoS when it's first created.
- The `confluentkafka` QoS overrides `can_consume()` and now honors the guard as well.

The guard is disabled (`None`) by default, so existing behavior is unchanged. Native AMQP transports implement prefetching in the broker and are unaffected.

Celery can then replace its `MethodType` patch with:

```python
transport_options={'qos_guard': lambda qos: len(state.reserved_requests) < limit}
