### PR TITLE
fix(filesystem): match queue name exactly, not as a substring

### DIFF
--- a/kombu/transport/filesystem.py
+++ b/kombu/transport/filesystem.py
@@ -224,14 +224,14 @@ class Channel(virtual.Channel):
 
     def _get(self, queue):
         """Get next message from `queue`."""
-        queue_find = '.' + queue + '.msg'
+        queue_find = f'{queue}.msg'
         folder = os.listdir(self.data_folder_in)
         folder = sorted(folder)
         while len(folder) > 0:
             filename = folder.pop(0)
 
             # only handle message for the requested queue
-            if filename.find(queue_find) < 0:
+            if filename.partition('.')[2] != queue_find:
                 continue
 
             if self.store_processed:
@@ -296,14 +296,14 @@ class Channel(virtual.Channel):
     def _purge(self, queue):
         """Remove all messages from `queue`."""
         count = 0
-        queue_find = '.' + queue + '.msg'
+        queue_find = f'{queue}.msg'
 
         folder = os.listdir(self.data_folder_in)
         while len(folder) > 0:
             filename = folder.pop()
             try:
                 # only purge messages for the requested queue
-                if filename.find(queue_find) < 0:
+                if filename.partition('.')[2] != queue_find:
                     continue
 
                 filename = os.path.join(self.data_folder_in, filename)
@@ -322,13 +322,13 @@ class Channel(virtual.Channel):
         """Return the number of messages in `queue` as an :class:`int`."""
         count = 0
 
-        queue_find = f'.{queue}.msg'
+        queue_find = f'{queue}.msg'
         folder = os.listdir(self.data_folder_in)
         while len(folder) > 0:
             filename = folder.pop()
 
             # only handle message for the requested queue
-            if filename.find(queue_find) < 0:
+            if filename.partition('.')[2] != queue_find:
                 continue
 
             count += 1

--- a/t/unit/transport/test_filesystem.py
+++ b/t/unit/transport/test_filesystem.py
@@ -195,6 +195,30 @@ class test_FilesystemTransport(WithJanitorMixin):
             self.q2(consumer_channel).purge()
             assert self.q2(consumer_channel).get() is None
 
+    def test_dotted_queue_name_not_matched_by_suffix(self):
+        producer_channel = self._add_channel(self.p.channel())
+        consumer_channel = self._add_channel(self.c.channel())
+        producer = Producer(producer_channel, self.e)
+        # 'b' is a dotted suffix of 'a.b', the two must not share messages
+        dotted = Queue('a.b', exchange=self.e, routing_key='a.b')
+        suffix = Queue('b', exchange=self.e, routing_key='b')
+        with (
+            managed_consumer(consumer_channel, dotted),
+            managed_consumer(consumer_channel, suffix),
+        ):
+            dotted(consumer_channel).declare()
+            suffix(consumer_channel).declare()
+
+            producer.publish({'foo': 1}, routing_key='a.b')
+
+            assert suffix(consumer_channel).queue_declare(
+                passive=True).message_count == 0
+            assert suffix(consumer_channel).get() is None
+
+            # purging 'b' must leave the message routed to 'a.b' in place
+            suffix(consumer_channel).purge()
+            assert dotted(consumer_channel).get()
+
 
 @t.skip.if_win32
 class test_FilesystemFanout(WithJanitorMixin):


### PR DESCRIPTION
Fixes #2646

## Problem

`_get`, `_purge` and `_size` in the filesystem transport select spool files with a
substring test rather than by comparing the queue field:

```python
queue_find = '.' + queue + '.msg'
...
if filename.find(queue_find) < 0:
    continue
```

`_put` writes `<ts>_<uuid4>.<queue>.msg`, so a file belonging to queue `a.b` is
`…_<uuid>.a.b.msg` — which contains `.b.msg`. A consumer of `b` therefore accepts it.
Where two queues share a spool and one name is a dotted suffix of the other, the shorter
queue silently consumes, counts and purges the longer queue's messages. `_purge` on one
queue deletes the other's backlog.

## Fix

The prefix `_put` writes (an `int` timestamp and a `uuid4`) contains no `.`, so the queue
field is exactly `filename.partition('.')[2]` minus the extension. Comparing that for
equality anchors the match at the start of the queue field, at all three sites:

```python
queue_find = f'{queue}.msg'
...
if filename.partition('.')[2] != queue_find:
    continue
```

A suffix test (`filename.endswith('.' + queue + '.msg')`) is **not** sufficient —
`…uuid.a.b.msg` ends with `.b.msg`, leaving the reported case unfixed.

No filename format change, so existing spools stay readable.

## Verification

Behaviour corpus of 10 `(queue consumed, queue written to)` pairs driven through
`Channel._put` / `Channel._size` on a real spool:

| Build | Wrong results / 10 |
|---|---|
| unpatched | 5 |
| `endswith` | 3 |
| this patch | 0 |

`('b','b')`, `('a.b','a.b')` and `('b.msg','b.msg')` still match, so the change does not
over-restrict.

The added regression test fails on unpatched `main` (`assert 1 == 0`) and passes with the fix.

Unit suite `python -bb -m pytest t/unit -q`: no regressions, +1 passing test.
