### PR TITLE
fix(asynchronous): close pending HTTP client requests on hub shutdown

### DIFF
--- a/kombu/asynchronous/http/base.py
+++ b/kombu/asynchronous/http/base.py
@@ -245,6 +245,12 @@ class BaseClient:
     def __init__(self, hub, **kwargs):
         self.hub = hub
         self._header_parser = header_parser()
+        # Without this, a client left with a pending request when the hub
+        # closes (e.g. during worker shutdown) keeps that request running
+        # in the background: it can complete and deliver its result well
+        # after the rest of the consumer has already torn down, with
+        # nothing left to act on it (see SQS long-polling in curl.py).
+        self.hub.on_close.add(self.close)
 
     def perform(self, request, **kwargs):
         for req in maybe_list(request) or []:
@@ -255,7 +261,7 @@ class BaseClient:
     def add_request(self, request):
         raise NotImplementedError('must implement add_request')
 
-    def close(self):
+    def close(self, *args):
         pass
 
     def on_header(self, headers, line):

--- a/kombu/asynchronous/http/curl.py
+++ b/kombu/asynchronous/http/curl.py
@@ -63,7 +63,7 @@ class CurlClient(BaseClient):
         self._multi.add_handle(dummy_curl_handle)
         self._multi.remove_handle(dummy_curl_handle)
 
-    def close(self):
+    def close(self, *args):
         self._timeout_check_tref.cancel()
         for _curl in self._curls:
             _curl.close()

--- a/t/unit/asynchronous/http/test_curl.py
+++ b/t/unit/asynchronous/http/test_curl.py
@@ -53,6 +53,25 @@ class test_CurlClient:
                 _curl.close.assert_called_with()
             x._multi.close.assert_called_with()
 
+    def test_registers_close_with_hub_on_close(self, hub):
+        # A pending request left on the client when the hub closes (e.g.
+        # during worker shutdown) otherwise keeps running in the
+        # background and can deliver its result after the rest of the
+        # consumer has already torn down.
+        with patch('kombu.asynchronous.http.curl.pycurl'):
+            x = self.Client(hub)
+            assert x.close in hub.on_close
+
+    def test_hub_close_closes_client(self, hub):
+        with patch('kombu.asynchronous.http.curl.pycurl'):
+            x = self.Client(hub)
+            x._timeout_check_tref = Mock(name='timeout_check_tref')
+            hub.close()
+            x._timeout_check_tref.cancel.assert_called_with()
+            for _curl in x._curls:
+                _curl.close.assert_called_with()
+            x._multi.close.assert_called_with()
+
     def test_add_request(self):
         with patch('kombu.asynchronous.http.curl.pycurl'):
             x = self.Client()


### PR DESCRIPTION
Fixes celery/celery#10172. Related to celery/kombu#1819.

## What this fixes

A worker in warm shutdown can lose an in-flight SQS message: a long poll started just before shutdown keeps running in the background after the consumer has already torn down, and when it eventually completes, its callback still fires and hands the message to a pipeline that no longer exists to process it. SQS has already marked the message non-visible the moment `ReceiveMessage` returned it, so it sits stuck until the visibility timeout expires.

I checked whether `worker_soft_shutdown_timeout` (celery/celery#9213) covers this. It does not: `wait_for_soft_shutdown` only waits when `state.active_requests` is non-empty, and its own docstring says the worker will not wait at all when there are no tasks in progress, which is exactly the case in the linked report.

## Root cause

`kombu/transport/SQS/__init__.py` still has this in `Transport.close()`:

```python
def close(self):
    super().close()
    # if self._asynsqs:
    #     try:
    #         self.asynsqs().close()
    #     except AttributeError as exc:  # FIXME ???
    #         if "can't set attribute" not in str(exc):
    #             raise
```

That call was added in the boto3-based async rewrite (#1759) and left commented out when #1759 was reverted in #1799, for an unrelated reason (a botocore wire-protocol regression, nothing to do with connection safety). It is not something to re-enable as written: `AsyncSQSConnection` has no `close()` method today, so calling it would just raise `AttributeError`.

The actual live resource is one level down. `AsyncHTTPSConnection.__init__` calls `get_client()`, which caches a single `CurlClient` on the hub (`hub._current_http_client`), shared by every async AWS request on that event loop. `CurlClient.close()` genuinely tears down its curl handles, its multi-handle, and its recurring timeout check, so it is the right thing to call. But nothing ever calls it: `Hub.close()` runs every callback registered in `hub.on_close`, and neither `CurlClient` nor its base class ever registers into it.

## The fix

Register the client's `close()` with `hub.on_close` in `BaseClient.__init__`, so any current or future HTTP client backend gets wired into the hub's own shutdown sequence without needing to remember to do it itself. `Hub.close()` invokes each callback as `callback(self)`, passing the hub, so `close()` needs to accept that argument; it did not before.

## Testing

Added two tests against a real `Hub` instance, not a mock, since the whole point is proving the hub's actual shutdown path reaches the client:

```
test_registers_close_with_hub_on_close   confirms the registration happens on construction
test_hub_close_closes_client             confirms hub.close() alone triggers the client's teardown
```

Reverted the fix locally and confirmed both new tests fail exactly where expected (`cancel()` never called, because `hub.close()` never reaches the client), then restored it and confirmed all pass. Ran the full `t/unit/asynchronous/` and `t/unit/transport/SQS/` suites: 427 passed, 1 pre-existing failure (`test_generate_sts_session_token`, a missing `freeze_time` plugin in my environment, unrelated to this change, reproduces identically on unmodified `main`).

## Scope

This closes the specific gap in celery/celery#10172 (an outstanding request survives hub shutdown and delivers into nothing). It does not address the broader class of problems tracked in celery/kombu#1819 around SQS message handling during shutdown more generally; happy to follow up separately if that's useful.
