### PR TITLE
Install the pgmq extra only in the envs that exercise it (fixes PyPy integration CI)

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -117,8 +117,6 @@ jobs:
                   allow-prereleases: true
                   cache: 'pip'
                   cache-dependency-path: '**/setup.py'
-          -   name: Install Rust toolchain
-              uses: dtolnay/rust-toolchain@stable
           -   name: Install tox
               run: python -m pip install --upgrade pip wheel tox tox-docker
           -   name: >

--- a/requirements/test-ci.txt
+++ b/requirements/test-ci.txt
@@ -17,4 +17,3 @@ urllib3>=1.26.16; sys_platform != 'win32'
 -r extras/sqlalchemy.txt
 -r extras/etcd.txt
 -r extras/gcpubsub.txt
--r extras/pgmq.txt

--- a/t/integration/test_pgmq.py
+++ b/t/integration/test_pgmq.py
@@ -5,13 +5,14 @@ import socket
 from contextlib import closing
 from time import sleep, time
 
-import psycopg
 import pytest
 
 import kombu
 from kombu.exceptions import OperationalError
 
 from .common import BaseExchangeTypes, BaseMessage, BasicFunctionality
+
+psycopg = pytest.importorskip('psycopg')
 
 # connect() does not wrap the transport error as kombu OperationalError.
 _CONN_FAIL = (OperationalError, psycopg.OperationalError, psycopg.InterfaceError)

--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,8 @@ deps=
     apicheck,pypy3.11,3.10,3.11,3.12,3.13,3.14: -r{toxinidir}/requirements/test.txt
     apicheck,pypy3.11,3.10,3.11,3.12,3.13,3.14: -r{toxinidir}/requirements/test-ci.txt
     apicheck,3.10-linux,3.11-linux,3.12-linux,3.13-linux,3.14-linux: -r{toxinidir}/requirements/extras/confluentkafka.txt
+    apicheck,3.10-unit,3.11-unit,3.12-unit,3.13-unit,3.14-unit: -r{toxinidir}/requirements/extras/pgmq.txt
+    3.10-linux-integration-pgmq,3.11-linux-integration-pgmq,3.12-linux-integration-pgmq,3.13-linux-integration-pgmq,3.14-linux-integration-pgmq: -r{toxinidir}/requirements/extras/pgmq.txt
     apicheck,linkcheck: -r{toxinidir}/requirements/docs.txt
     flake8,pydocstyle,mypy: -r{toxinidir}/requirements/pkgutils.txt
     integration: -r{toxinidir}/requirements/test-integration.txt


### PR DESCRIPTION
## Problem

Since #2559 (PGMQ transport) the three PyPy integration jobs (`pypy3.11` × `py-amqp`, `py-redis`, `py-mongodb`) fail at the pip install step.

#2559 added `-r extras/pgmq.txt` to `requirements/test-ci.txt`, which every tox env installs. `pgmq` hard-depends on `orjson`, and orjson refuses to build on PyPy in its own build script, so a Rust toolchain (#2634) cannot help:

